### PR TITLE
Add ADR directory and initial architecture decision records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # embervault
 Tinderbox inspired in JavaFX
+
+## Architecture Decision Records
+
+This project uses [Architecture Decision Records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) (ADRs) to document significant architectural choices. All ADRs are stored in [`doc/adr/`](doc/adr/).
+
+To create a new ADR, install [adr-tools](https://github.com/npryce/adr-tools) and run:
+
+```sh
+adr new "Title of Decision"
+```

--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,38 @@
+# 1. Record Architecture Decisions
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project. These
+decisions affect the structure and direction of the codebase, and future
+contributors (including our future selves) need to understand why certain
+choices were made.
+
+Without a clear record, knowledge about past decisions is lost when team
+members move on or memories fade. This leads to repeated discussions,
+accidental reversals of decisions, and difficulty onboarding new contributors.
+
+## Decision
+
+We will use Architecture Decision Records (ADRs), as described by Michael
+Nygard in his article "Documenting Architecture Decisions."
+
+Each ADR will be a short Markdown file in the `doc/adr/` directory. Each record
+will contain a title, date, status, context, decision, and consequences. ADRs
+will be numbered sequentially and will not be removed; if a decision is
+reversed, a new ADR will supersede the old one.
+
+## Consequences
+
+- All significant architectural decisions will be documented in one place.
+- New contributors can read through past ADRs to understand the reasoning
+  behind the current state of the project.
+- The cost of writing an ADR is low, but the discipline must be maintained
+  by the team.
+- ADRs are immutable once accepted; changes require a new ADR that supersedes
+  the previous one.

--- a/doc/adr/0002-use-adr-tools-to-manage-adrs.md
+++ b/doc/adr/0002-use-adr-tools-to-manage-adrs.md
@@ -1,0 +1,36 @@
+# 2. Use adr-tools to Manage ADRs
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+Now that we have decided to use ADRs (see ADR-0001), we need a consistent way
+to create and manage them. Manually creating ADR files is error-prone: numbering
+can drift, formatting can vary, and the process adds friction that discourages
+documentation.
+
+adr-tools is a lightweight command-line package that automates the creation and
+management of ADR files. It provides commands to create new ADRs from a
+template, link related decisions, and generate a table of contents.
+
+## Decision
+
+We will use adr-tools (https://github.com/npryce/adr-tools) to manage our
+Architecture Decision Records. The ADR directory is configured as `doc/adr/`.
+A template file is provided at `doc/adr/template.md` for consistent formatting.
+
+Team members should install adr-tools locally and use `adr new "Title"` to
+create new records rather than copying files by hand.
+
+## Consequences
+
+- ADR creation is standardized and automated, reducing formatting inconsistencies.
+- New ADRs are automatically numbered, preventing numbering conflicts.
+- Team members need to install adr-tools, adding a lightweight developer
+  dependency.
+- The template can be customized to fit the project's needs over time.
+- Superseding and linking ADRs is handled by the tooling rather than manual edits.

--- a/doc/adr/template.md
+++ b/doc/adr/template.md
@@ -1,0 +1,19 @@
+# NUMBER. TITLE
+
+Date: DATE
+
+## Status
+
+STATUS
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION
## Summary

- Create `doc/adr/` directory structure for Architecture Decision Records
- Add ADR-0001: Record Architecture Decisions (the standard meta-ADR)
- Add ADR-0002: Use adr-tools to Manage ADRs
- Add ADR template at `doc/adr/template.md` for consistent formatting
- Update README.md with a section pointing to the ADRs

Closes #2

## Test plan

- [ ] Verify `doc/adr/` directory contains both ADRs and the template
- [ ] Confirm ADR format is consistent across all files (Title, Date, Status, Context, Decision, Consequences)
- [ ] Confirm README links to the ADR directory
- [ ] Verify adr-tools can use the directory (`adr list` from repo root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)