### PR TITLE
Configure SLF4J for logging

### DIFF
--- a/doc/adr/0005-use-slf4j-for-logging.md
+++ b/doc/adr/0005-use-slf4j-for-logging.md
@@ -1,0 +1,28 @@
+# 5. Use SLF4J for Logging
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+The application needs a logging framework to provide structured, configurable logging output. Java's built-in `java.util.logging` is limited in flexibility and configuration. The project needs a logging facade that decouples application code from the underlying logging implementation, allowing the backend to be swapped without code changes.
+
+## Decision
+
+We will use SLF4J (Simple Logging Facade for Java) as the logging API and Logback as the logging backend.
+
+- `slf4j-api` provides the facade that application code programs against.
+- `logback-classic` provides the native SLF4J implementation with rich configuration options.
+- A `logback.xml` configuration for production use (INFO level, console appender).
+- A `logback-test.xml` configuration for test use (DEBUG level, console appender).
+
+## Consequences
+
+- All application logging will use the SLF4J API (`LoggerFactory.getLogger()`), keeping code decoupled from the backend.
+- Logback provides powerful configuration including log levels per package, multiple appenders, and pattern layouts without code changes.
+- The logging backend can be replaced in the future (e.g., Log4j2) by swapping the dependency, with no changes to application code.
+- Test output uses DEBUG level for more detailed diagnostic information during development and CI.
+- Third-party libraries that use SLF4J will automatically route through the same logging configuration.

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 
         <!-- Dependency versions -->
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <logback.version>1.5.16</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -45,6 +47,16 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary
- Add SLF4J API (2.0.16) and Logback Classic (1.5.16) dependencies to `pom.xml` with version properties
- Add `logback.xml` (INFO level, console appender) and `logback-test.xml` (DEBUG level) configurations
- Add ADR 0005 documenting the decision to use SLF4J with Logback

Closes #6

## Test plan
- [x] `mvn compile` succeeds with new dependencies resolved
- [ ] Verify logging works when a Logger is used in application code

🤖 Generated with [Claude Code](https://claude.com/claude-code)