### PR TITLE
Configure JUnit 5 for testing

### DIFF
--- a/doc/adr/0003-use-junit5-as-testing-framework.md
+++ b/doc/adr/0003-use-junit5-as-testing-framework.md
@@ -1,0 +1,23 @@
+# 3. Use JUnit 5 as testing framework
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+EmberVault needs a testing framework to support the TDD workflow established in ADR-0001. The project targets Java 25 and uses Maven as its build tool. We need a modern, extensible testing framework that integrates well with this stack and supports current best practices such as display names, parameterized tests, and nested test classes.
+
+## Decision
+
+We will use JUnit 5 (Jupiter) as the project's testing framework. The JUnit BOM is imported in dependency management to ensure consistent versioning across all JUnit modules. The `junit-jupiter` aggregate artifact is declared with test scope, and Maven Surefire plugin 3.5.2 is configured to discover and run Jupiter tests.
+
+## Consequences
+
+- Test classes use JUnit 5 annotations (`@Test`, `@DisplayName`, `@Nested`, `@ParameterizedTest`, etc.) and the `org.junit.jupiter.api.Assertions` API.
+- The JUnit 5 extension model is available for custom lifecycle hooks and dependency injection in tests.
+- Adding additional JUnit 5 modules (e.g., `junit-jupiter-params`) requires only a dependency declaration; the BOM controls the version.
+- Legacy JUnit 4 tests are not supported unless the `junit-vintage-engine` is explicitly added.
+- Maven Surefire automatically discovers test classes following the `*Test` / `Test*` / `*Tests` naming conventions.

--- a/src/test/java/com/embervault/SmokeTest.java
+++ b/src/test/java/com/embervault/SmokeTest.java
@@ -1,0 +1,19 @@
+package com.embervault;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Smoke test to verify JUnit 5 is correctly configured and tests are discovered
+ * by the Maven Surefire plugin.
+ */
+class SmokeTest {
+
+    @Test
+    @DisplayName("JUnit 5 is configured and test discovery works")
+    void junitFiveIsConfigured() {
+        assertTrue(true, "JUnit 5 test was discovered and executed");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a smoke test (`SmokeTest.java`) that verifies JUnit 5 is discovered and executed by Maven Surefire
- Adds ADR-0003 documenting the decision to use JUnit 5 as the testing framework
- JUnit 5 BOM, `junit-jupiter` dependency, and Surefire plugin were already configured in #1

## Test plan
- [x] `mvn test` discovers and runs `SmokeTest` via `JUnitPlatformProvider`
- [x] 1 test run, 0 failures, 0 errors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)