### PR TITLE
Configure JavaFX for UI toolkit

### DIFF
--- a/doc/adr/0006-use-javafx-for-ui.md
+++ b/doc/adr/0006-use-javafx-for-ui.md
@@ -1,0 +1,27 @@
+# 6. Use JavaFX for the User Interface
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+EmberVault is a desktop application inspired by Tinderbox that requires a rich, interactive user interface. We need a UI framework that supports Java, provides modern controls, and enables custom layouts and visualizations.
+
+Options considered:
+- **JavaFX** — Modern Java UI toolkit with CSS styling, FXML, and rich control library
+- **Swing** — Legacy Java UI toolkit, still maintained but showing its age
+- **Web-based (Electron/Tauri)** — Would require leaving the Java ecosystem
+
+## Decision
+
+We will use JavaFX as the UI framework for EmberVault.
+
+## Consequences
+
+- **Positive:** Native Java integration, modern controls, CSS-based styling, FXML for declarative layouts, active community and ongoing development
+- **Positive:** Scene graph architecture suits the spatial/visual nature of a Tinderbox-inspired application
+- **Negative:** JavaFX is not bundled with the JDK since Java 11; must be managed as a separate dependency
+- **Negative:** Platform-specific native libraries required for distribution

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.16</logback.version>
+        <javafx.version>24</javafx.version>
+
+        <!-- Plugin versions (JavaFX) -->
+        <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -58,6 +62,16 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -105,6 +119,14 @@
                     <version>${maven-clean-plugin.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-maven-plugin</artifactId>
+                    <version>${javafx-maven-plugin.version}</version>
+                    <configuration>
+                        <mainClass>com.embervault/com.embervault.App</mainClass>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${maven-checkstyle-plugin.version}</version>
@@ -137,6 +159,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -1,0 +1,28 @@
+package com.embervault;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+/**
+ * Main application entry point for EmberVault.
+ */
+public class App extends Application {
+
+    @Override
+    public void start(Stage stage) {
+        Label label = new Label("Welcome to EmberVault");
+        StackPane root = new StackPane(label);
+        Scene scene = new Scene(root, 800, 600);
+
+        stage.setTitle("EmberVault");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module com.embervault {
+    requires javafx.controls;
+    requires javafx.fxml;
+
+    opens com.embervault to javafx.fxml;
+    exports com.embervault;
+}


### PR DESCRIPTION
## Summary
- Add `javafx-controls` and `javafx-fxml` dependencies (OpenJFX 24) to pom.xml with version property and `javafx-maven-plugin`
- Create minimal `App.java` JavaFX Application entry point with "EmberVault" window title
- Add `module-info.java` for JavaFX module system access
- Add ADR 0006 documenting the decision to use JavaFX

## Test plan
- [x] `mvn compile` succeeds with Java 25
- [ ] Verify `mvn javafx:run` launches the EmberVault window on a machine with a display

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)