### PR TITLE
Configure JaCoCo for code coverage

### DIFF
--- a/doc/adr/0007-use-jacoco-for-code-coverage.md
+++ b/doc/adr/0007-use-jacoco-for-code-coverage.md
@@ -1,0 +1,39 @@
+# 7. Use JaCoCo for code coverage
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+As we adopt a TDD development process (ADR-0001), we need visibility into how much of the
+codebase is exercised by our test suite. Without a code coverage tool, it is difficult to identify
+untested code paths, and coverage can silently regress over time. We need an automated mechanism
+integrated into the Maven build that measures coverage, generates reports, and enforces minimum
+thresholds to prevent regressions.
+
+## Decision
+
+We will use [JaCoCo](https://www.jacoco.org/) integrated via the `jacoco-maven-plugin` to measure
+and enforce code coverage. The plugin is configured with three executions:
+
+- **prepare-agent**: Instruments the bytecode before tests run so that coverage data is collected.
+- **report**: Generates both HTML and XML coverage reports during the `verify` phase. HTML reports
+  provide a human-readable view; XML reports enable integration with CI tools and coverage services.
+- **check**: Enforces minimum coverage thresholds during the `verify` phase. The build fails if
+  line coverage or branch coverage falls below 80% at the bundle level.
+
+The `App` class (JavaFX `Application` subclass) is excluded from coverage checks because it
+requires a running JavaFX runtime and cannot be meaningfully unit tested.
+
+## Consequences
+
+- Developers get immediate feedback on test coverage via HTML reports in `target/site/jacoco/`.
+- The build fails if coverage drops below the configured thresholds, preventing silent regressions.
+- CI pipelines can consume the XML report for coverage badges and trend tracking.
+- The JavaFX `App` class exclusion means that UI launch code is not subject to coverage enforcement;
+  this is acceptable since it will be verified through integration or manual testing.
+- Thresholds may need to be adjusted as the codebase grows and more complex untestable code
+  (e.g., UI controllers) is introduced.

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <checkstyle.version>10.21.4</checkstyle.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
 
         <!-- Dependency versions -->
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
@@ -127,6 +128,11 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${maven-checkstyle-plugin.version}</version>
@@ -163,6 +169,60 @@
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <formats>
+                                <format>HTML</format>
+                                <format>XML</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                            <excludes>
+                                <exclude>com/embervault/App.class</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- Add `jacoco-maven-plugin` 0.8.14 to the Maven build with `prepare-agent`, `report`, and `check` goals
- Generate both HTML and XML coverage reports during the `verify` phase
- Enforce 80% minimum line and branch coverage at the bundle level, excluding the JavaFX `App` class
- Add ADR 0007 documenting the decision to use JaCoCo for code coverage

## Test plan
- [x] `mvn verify` runs successfully with JaCoCo instrumentation, report generation, and coverage checks passing
- [x] HTML report generated at `target/site/jacoco/index.html`
- [x] XML report generated at `target/site/jacoco/jacoco.xml`
- [x] Coverage check passes with `App` class excluded

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)