### PR TITLE
Configure ArchUnit to test ADR compliance

### DIFF
--- a/doc/adr/0008-use-archunit-to-enforce-architecture.md
+++ b/doc/adr/0008-use-archunit-to-enforce-architecture.md
@@ -1,0 +1,27 @@
+# 8. Use ArchUnit to Enforce Architecture
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+Architecture Decision Records document intended constraints, but nothing prevents developers from inadvertently violating them. Manual code review catches some violations, but automated enforcement is more reliable and provides faster feedback. The project already uses JUnit 5 and Maven Surefire, so an architecture testing library that integrates with these tools would fit naturally into the existing build pipeline.
+
+## Decision
+
+We will use ArchUnit (`com.tngtech.archunit:archunit-junit5`) to write executable architecture tests that verify compliance with our ADRs.
+
+- Architecture tests live under `src/test/java/com/embervault/architecture/` and run as part of the standard test suite.
+- Each rule references the ADR it enforces (e.g., ADR-0005 for SLF4J logging).
+- New ADRs that introduce enforceable constraints should be accompanied by corresponding ArchUnit rules where practical.
+
+## Consequences
+
+- Architectural violations are caught automatically during `mvn test`, preventing them from reaching the main branch.
+- Developers get immediate feedback when a change breaks an architectural constraint, with a clear message explaining the rule and the ADR behind it.
+- Adding new architecture rules requires only writing declarative ArchUnit test methods; no build plugin configuration is needed.
+- The test suite execution time increases slightly, but ArchUnit analysis is fast and the overhead is negligible.
+- Because the project uses Java modules (JPMS), the architecture tests use `ClassFileImporter.importPath()` to scan the compiled classes directory directly rather than `@AnalyzeClasses`, which cannot see into named modules via package-based class loading.

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <checkstyle.version>10.21.4</checkstyle.version>
 
         <!-- Dependency versions -->
+        <archunit-junit5.version>1.4.1</archunit-junit5.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.16</logback.version>
@@ -76,6 +77,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>${archunit-junit5.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/embervault/architecture/ArchitectureTest.java
+++ b/src/test/java/com/embervault/architecture/ArchitectureTest.java
@@ -1,0 +1,68 @@
+package com.embervault.architecture;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architecture fitness tests enforcing ADR compliance via ArchUnit.
+ *
+ * <p>These rules run as part of the normal test suite and fail the build
+ * when architectural constraints are violated.</p>
+ *
+ * <p>Uses {@link ClassFileImporter#importPath(Path)} to scan the compiled
+ * classes directory directly, which works reliably with Java modules (JPMS)
+ * where package-based scanning cannot see into named modules.</p>
+ */
+class ArchitectureTest {
+
+    private static JavaClasses classes;
+
+    @BeforeAll
+    static void importClasses() {
+        Path classesDir = Paths.get("target", "classes");
+        classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPath(classesDir);
+    }
+
+    @Test
+    @DisplayName("ADR-0005: SLF4J must be used for logging, not java.util.logging")
+    void shouldUseSl4jForLogging() {
+        noClasses()
+                .should().dependOnClassesThat()
+                .resideInAPackage("java.util.logging")
+                .because("ADR-0005 mandates SLF4J for logging, not java.util.logging")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("All production classes reside under com.embervault")
+    void classesShouldResideInEmbervaultPackage() {
+        classes()
+                .should().resideInAPackage("com.embervault..")
+                .because("all production code must live under the com.embervault package hierarchy")
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("No field injection via javax.inject or com.google.inject")
+    void noFieldInjection() {
+        noClasses()
+                .should().dependOnClassesThat()
+                .haveNameMatching(".*javax\\.inject\\.Inject|.*com\\.google\\.inject\\.Inject")
+                .because("field injection is discouraged; use constructor injection instead")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `com.tngtech.archunit:archunit-junit5` (1.4.1) as a test-scoped dependency
- Create `ArchitectureTest.java` with three rules: SLF4J-only logging (ADR-0005), correct package structure, and no field injection
- Use `ClassFileImporter.importPath()` instead of `@AnalyzeClasses` to work correctly with Java modules (JPMS)
- Add ADR-0008 documenting the decision to use ArchUnit for architecture enforcement

## Test plan
- [x] `mvn test` passes with all 4 tests (1 smoke + 3 architecture)
- [x] ArchUnit correctly scans compiled classes despite JPMS module-info.java
- [x] No warnings or errors in test output

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)