### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Run Maven verify
+        run: ./mvnw verify --batch-mode --no-transfer-progress
+
+      - name: Upload JaCoCo coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: target/site/jacoco/
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with a `build` job that runs on push and PR to `main`
- Uses Java 25 (Temurin) with Maven caching via `setup-java`
- Runs `./mvnw verify` which executes compile, tests, Checkstyle, and JaCoCo coverage checks
- Uploads JaCoCo coverage report as a build artifact (14-day retention)

Closes #10

## Test plan
- [ ] Verify the `build` job appears in the PR checks and passes
- [ ] Confirm JaCoCo coverage report artifact is uploaded after the run
- [ ] Confirm branch protection can reference the `build` job as a required status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)