### PR TITLE
Add ADRs for hexagonal architecture, DDD, SOLID, and DRY

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,6 +8,9 @@
     Add suppressions here for intentional style exceptions.
 -->
 <suppressions>
+    <!-- module-info.java cannot be parsed by Checkstyle with Java 25 -->
+    <suppress checks=".*" files="module-info\.java$"/>
+
     <!-- Allow longer test files -->
     <suppress checks="FileLength" files=".*Test\.java$"/>
 

--- a/doc/adr/0009-use-hexagonal-architecture.md
+++ b/doc/adr/0009-use-hexagonal-architecture.md
@@ -1,0 +1,33 @@
+# 9. Use Hexagonal Architecture
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+EmberVault needs a clear separation between domain logic and external concerns such as the UI (JavaFX), persistence, and any future integrations. Without an explicit architectural boundary, domain logic tends to leak into framework-specific code, making the system difficult to test, refactor, and evolve. The Hexagonal Architecture (Ports & Adapters) pattern addresses this by placing the domain at the center and defining explicit interfaces (ports) through which all external interaction flows.
+
+## Decision
+
+We will structure EmberVault following the Hexagonal Architecture (Ports & Adapters) pattern. Domain logic is isolated from all external concerns via ports (interfaces defined by the domain) and adapters (implementations that bridge the domain to infrastructure such as UI, persistence, and external services).
+
+The package structure is:
+
+- `com.embervault.domain` — Core domain model: entities, value objects, aggregates, domain services, and domain events. This package has zero dependencies on frameworks or infrastructure.
+- `com.embervault.application.port.in` — Inbound ports (use case interfaces) that define how the outside world drives the application.
+- `com.embervault.application.port.out` — Outbound ports (repository and gateway interfaces) that define what the domain needs from infrastructure.
+- `com.embervault.adapter.in.ui` — Inbound adapters: JavaFX controllers and views that translate user actions into use case calls.
+- `com.embervault.adapter.out.persistence` — Outbound adapters: implementations of outbound ports for data storage.
+
+Dependency flow is strictly inward: adapters depend on ports, ports depend on the domain, and the domain depends on nothing outside itself.
+
+## Consequences
+
+- Domain logic can be tested in isolation without starting JavaFX or connecting to a database.
+- Swapping an adapter (e.g., replacing file-based persistence with a database) requires only a new adapter implementation; no domain changes are needed.
+- The explicit port interfaces serve as a contract between layers, making the system easier to reason about.
+- Developers must place new code in the correct package and follow the dependency direction, which adds a small learning curve.
+- ArchUnit tests enforce the dependency rules automatically as part of the build (see ADR-0008).

--- a/doc/adr/0010-use-domain-driven-design.md
+++ b/doc/adr/0010-use-domain-driven-design.md
@@ -1,0 +1,32 @@
+# 10. Use Domain-Driven Design
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+EmberVault manages interconnected notes, links, and metadata — a domain with meaningful business rules and relationships. A naive approach of scattering logic across controllers and utility classes leads to an anemic domain model that is hard to understand and maintain. Domain-Driven Design (DDD) provides tactical patterns that give structure to the domain layer, making the codebase a direct expression of the problem space.
+
+## Decision
+
+We will apply DDD tactical patterns within the `com.embervault.domain` package:
+
+- **Entities** — Objects with a distinct identity that persists over time (e.g., a Note). Identity is based on a unique identifier, not attribute equality.
+- **Value Objects** — Immutable objects defined entirely by their attributes with no conceptual identity (e.g., a NoteTitle, a Tag). They are compared by value, not reference.
+- **Aggregates** — Clusters of entities and value objects that form a consistency boundary. External code references an aggregate only through its root entity.
+- **Repositories** — Interfaces (outbound ports) that provide collection-like access to aggregates. Implementations live in the adapter layer, not in the domain.
+- **Domain Services** — Stateless operations that express domain logic which does not naturally belong to a single entity or value object.
+
+All domain types reside in `com.embervault.domain` and its sub-packages. They must not depend on infrastructure frameworks.
+
+## Consequences
+
+- The domain model directly reflects the problem space, making the code easier to understand and discuss with non-technical stakeholders.
+- Aggregates enforce consistency boundaries, reducing the risk of invalid state.
+- Value objects eliminate a broad class of bugs related to mutable shared state.
+- Repository interfaces decouple the domain from persistence details, supporting the Hexagonal Architecture (ADR-0009).
+- Developers must understand DDD tactical patterns, which requires an initial learning investment.
+- Over-engineering is a risk; we will apply these patterns pragmatically, introducing aggregates and domain services only when the complexity warrants them.

--- a/doc/adr/0011-follow-solid-principles.md
+++ b/doc/adr/0011-follow-solid-principles.md
@@ -1,0 +1,30 @@
+# 11. Follow SOLID Principles
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+As EmberVault grows, maintaining a codebase that is easy to understand, extend, and refactor becomes increasingly important. The SOLID principles are a well-established set of object-oriented design guidelines that promote flexible, maintainable software. Adopting them early establishes a shared design vocabulary and prevents the accumulation of tightly coupled, rigid code.
+
+## Decision
+
+We will follow the SOLID principles across the codebase:
+
+- **Single Responsibility Principle (SRP)** — Each class has one reason to change. Domain entities model domain concepts, adapters handle infrastructure translation, and use cases orchestrate application workflows.
+- **Open/Closed Principle (OCP)** — Classes are open for extension but closed for modification. New behavior is added through new implementations of existing interfaces rather than modifying existing classes.
+- **Liskov Substitution Principle (LSP)** — Subtypes are substitutable for their base types without altering the correctness of the program. Implementations of ports and domain interfaces honor the contracts defined by their supertypes.
+- **Interface Segregation Principle (ISP)** — Clients are not forced to depend on interfaces they do not use. Inbound and outbound ports are fine-grained, each representing a specific use case or capability.
+- **Dependency Inversion Principle (DIP)** — High-level modules do not depend on low-level modules; both depend on abstractions. The domain defines port interfaces, and adapters provide implementations, following the dependency direction mandated by the Hexagonal Architecture (ADR-0009).
+
+These principles are enforced via code review. Automated enforcement through static analysis or ArchUnit is not practical for most SOLID principles, which require human judgment about design intent.
+
+## Consequences
+
+- The codebase favors small, focused classes and interfaces, which are easier to test and reason about.
+- New features can often be added by implementing new classes rather than modifying existing ones, reducing regression risk.
+- Code reviews have a shared vocabulary for discussing design quality.
+- Strict adherence can lead to over-abstraction; the team will apply these principles pragmatically, guided by actual complexity rather than speculative future needs.

--- a/doc/adr/0012-follow-dry-principle.md
+++ b/doc/adr/0012-follow-dry-principle.md
@@ -1,0 +1,30 @@
+# 12. Follow DRY Principle
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+Duplicated logic is a recurring source of bugs: when a rule or calculation is expressed in multiple places, changes must be applied everywhere, and missed updates lead to inconsistent behavior. The Don't Repeat Yourself (DRY) principle addresses this by ensuring that every piece of knowledge has a single, authoritative representation in the codebase.
+
+## Decision
+
+We will follow the DRY principle: every distinct piece of domain knowledge, business logic, or structural pattern should be expressed in exactly one place. When duplication is detected, it should be extracted into a shared abstraction — a method, class, or module — that can be reused.
+
+DRY applies to:
+
+- **Domain logic** — Business rules are expressed once in the domain layer, not duplicated across adapters or use cases.
+- **Configuration** — Shared constants and settings are defined in a single location.
+- **Test utilities** — Common test setup and assertion logic is extracted into helper classes or methods rather than copied between test files.
+
+This principle is enforced via code review. Automated detection of duplication (e.g., CPD) may be introduced in the future but is not part of this decision.
+
+## Consequences
+
+- Changes to business rules require modification in only one place, reducing the risk of inconsistency.
+- The codebase is smaller and easier to navigate.
+- Code reviewers actively look for duplication and suggest extraction during review.
+- Over-application of DRY can lead to premature abstraction; the team will tolerate minor duplication when the duplicated pieces are likely to diverge in the future (the "Rule of Three" heuristic).

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
                         <failsOnError>true</failsOnError>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                         <violationSeverity>error</violationSeverity>
+                        <excludes>**/module-info.java</excludes>
                     </configuration>
                 </plugin>
             </plugins>

--- a/src/main/java/com/embervault/adapter/in/ui/package-info.java
+++ b/src/main/java/com/embervault/adapter/in/ui/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Inbound adapters: JavaFX controllers and views that translate user actions into use case calls.
+ *
+ * <p>See ADR-0009 (Hexagonal Architecture).</p>
+ */
+package com.embervault.adapter.in.ui;

--- a/src/main/java/com/embervault/adapter/out/persistence/package-info.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Outbound adapters: implementations of outbound ports for data storage.
+ *
+ * <p>See ADR-0009 (Hexagonal Architecture).</p>
+ */
+package com.embervault.adapter.out.persistence;

--- a/src/main/java/com/embervault/application/port/in/package-info.java
+++ b/src/main/java/com/embervault/application/port/in/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Inbound ports: use case interfaces that define how the outside world drives the application.
+ *
+ * <p>See ADR-0009 (Hexagonal Architecture).</p>
+ */
+package com.embervault.application.port.in;

--- a/src/main/java/com/embervault/application/port/out/package-info.java
+++ b/src/main/java/com/embervault/application/port/out/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Outbound ports: repository and gateway interfaces that define what the domain needs
+ * from infrastructure.
+ *
+ * <p>See ADR-0009 (Hexagonal Architecture).</p>
+ */
+package com.embervault.application.port.out;

--- a/src/main/java/com/embervault/domain/package-info.java
+++ b/src/main/java/com/embervault/domain/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Core domain model: entities, value objects, aggregates, domain services.
+ *
+ * <p>This package has zero dependencies on frameworks or infrastructure.
+ * See ADR-0009 (Hexagonal Architecture) and ADR-0010 (Domain-Driven Design).</p>
+ */
+package com.embervault.domain;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,4 +4,13 @@ module com.embervault {
 
     opens com.embervault to javafx.fxml;
     exports com.embervault;
+
+    // Hexagonal architecture packages (ADR-0009).
+    // Exports will be added as classes are introduced in each package.
+    // Package structure:
+    //   com.embervault.domain                    - core domain model
+    //   com.embervault.application.port.in       - inbound ports (use cases)
+    //   com.embervault.application.port.out      - outbound ports (repositories)
+    //   com.embervault.adapter.in.ui             - inbound adapters (JavaFX)
+    //   com.embervault.adapter.out.persistence   - outbound adapters (storage)
 }

--- a/src/test/java/com/embervault/SmokeTest.java
+++ b/src/test/java/com/embervault/SmokeTest.java
@@ -1,9 +1,9 @@
 package com.embervault;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Smoke test to verify JUnit 5 is correctly configured and tests are discovered

--- a/src/test/java/com/embervault/architecture/ArchitectureTest.java
+++ b/src/test/java/com/embervault/architecture/ArchitectureTest.java
@@ -1,5 +1,8 @@
 package com.embervault.architecture;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -9,9 +12,6 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 /**
  * Architecture fitness tests enforcing ADR compliance via ArchUnit.
@@ -62,6 +62,69 @@ class ArchitectureTest {
                 .should().dependOnClassesThat()
                 .haveNameMatching(".*javax\\.inject\\.Inject|.*com\\.google\\.inject\\.Inject")
                 .because("field injection is discouraged; use constructor injection instead")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0009: Domain must not depend on adapter packages")
+    void domainShouldNotDependOnAdapters() {
+        noClasses()
+                .that().resideInAPackage("com.embervault.domain..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("com.embervault.adapter..")
+                .because("ADR-0009 mandates that domain logic is isolated from adapters "
+                        + "(dependency flows inward only)")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0009: Domain must not depend on application packages")
+    void domainShouldNotDependOnApplication() {
+        noClasses()
+                .that().resideInAPackage("com.embervault.domain..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("com.embervault.application..")
+                .because("ADR-0009 mandates that domain logic does not depend on the "
+                        + "application layer (dependency flows inward only)")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0009: Domain must not depend on JavaFX")
+    void domainShouldNotDependOnJavaFx() {
+        noClasses()
+                .that().resideInAPackage("com.embervault.domain..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("javafx..")
+                .because("ADR-0009 mandates that domain logic is free of UI framework dependencies")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0009: Domain must not depend on Spring Framework")
+    void domainShouldNotDependOnSpring() {
+        noClasses()
+                .that().resideInAPackage("com.embervault.domain..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("org.springframework..")
+                .because("ADR-0009 mandates that domain logic is free of infrastructure "
+                        + "framework dependencies")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0009: Adapter classes should not be accessed by domain")
+    void adaptersShouldNotBeAccessedByDomain() {
+        noClasses()
+                .that().resideInAPackage("com.embervault.adapter..")
+                .should().onlyBeAccessed().byClassesThat()
+                .resideInAPackage("com.embervault.domain..")
+                .because("ADR-0009 mandates that adapters are not accessed directly by domain code")
                 .allowEmptyShould(true)
                 .check(classes);
     }


### PR DESCRIPTION
## Summary
- Add ADRs 0009-0012: hexagonal architecture (ports & adapters), domain-driven design, SOLID principles, and DRY principle
- Create hexagonal package structure (`domain`, `application.port.in/out`, `adapter.in.ui`, `adapter.out.persistence`) with `package-info.java` files
- Add 5 ArchUnit tests enforcing domain isolation: no domain dependencies on adapters, application layer, JavaFX, or Spring
- Fix pre-existing checkstyle issues: exclude `module-info.java` from parsing (incompatible with Checkstyle + Java 25) and correct static import ordering

## Test plan
- [x] `mvn verify` passes (9 tests, 0 failures, checkstyle clean, JaCoCo clean)
- [ ] Review ADR content for accuracy and completeness
- [ ] Verify ArchUnit tests will catch violations when real domain/adapter classes are added

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)