### PR TITLE
Fix CI workflow and add .claude to .gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Java 25
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: oracle
           java-version: '25'
           cache: maven
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ target/
 
 # Swap files
 *.swp
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary
- Switch CI Java distribution from `temurin` to `oracle` since Temurin does not provide Java 25 builds via setup-java
- Add `.claude/` to `.gitignore` to exclude Claude Code workspace files from version control

## Test plan
- [ ] Verify CI workflow runs successfully on GitHub Actions with Oracle JDK 25
- [ ] Confirm `.claude/` directory is no longer tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)