### PR TITLE
Revert CI distribution from oracle back to temurin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Java 25
         uses: actions/setup-java@v4
         with:
-          distribution: oracle
+          distribution: temurin
           java-version: '25'
           cache: maven
 


### PR DESCRIPTION
## Summary
- Reverts the oracle distribution change from PR #27, keeping temurin

🤖 Generated with [Claude Code](https://claude.com/claude-code)