### PR TITLE
Configure Maven profiles for dev and prod

### DIFF
--- a/doc/adr/0015-use-maven-profiles.md
+++ b/doc/adr/0015-use-maven-profiles.md
@@ -1,0 +1,48 @@
+# 15. Use Maven profiles for dev and prod
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+The project needs different configurations for development and production
+environments. During development, verbose DEBUG-level logging aids
+troubleshooting, while production requires quieter INFO/WARN-level logging
+with a cleaner output format. Without a profile mechanism, developers must
+manually swap configuration files or remember to change settings before
+building a release artifact.
+
+## Decision
+
+We will use Maven profiles (`dev` and `prod`) combined with resource filtering
+to select the appropriate Logback configuration at build time.
+
+- The `dev` profile is active by default and sets `logback.profile` to
+  `logback-dev.xml` (DEBUG level, verbose console output with thread names and
+  full timestamps).
+- The `prod` profile sets `logback.profile` to `logback-prod.xml` (WARN root
+  level, INFO for `com.embervault`, compact console output).
+- The main `logback.xml` uses a filtered `<include resource="${logback.profile}"/>`
+  directive so the Maven-selected profile configuration is loaded at runtime.
+- Resource filtering is scoped to `logback.xml` only, avoiding unintended
+  token replacement in other resource files (e.g., FXML).
+
+Usage:
+
+    ./mvnw verify              # builds with dev profile (default)
+    ./mvnw verify -Pprod       # builds with prod profile
+
+## Consequences
+
+- Developers get verbose logging out of the box without any extra flags.
+- Production builds are created with a single `-Pprod` flag, reducing the
+  chance of shipping a DEBUG-level artifact.
+- Adding new profile-specific properties (e.g., database URLs, feature flags)
+  follows the same pattern: declare a property in each `<profile>` block and
+  reference it in a filtered resource.
+- Logback configuration is now split across three files (`logback.xml`,
+  `logback-dev.xml`, `logback-prod.xml`), which adds a small amount of
+  indirection compared to a single file.

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,27 @@
 
         <!-- Plugin versions (JavaFX) -->
         <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
+        <!-- Profile-specific defaults (overridden by active profile) -->
+        <logback.profile>logback-dev.xml</logback.profile>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <logback.profile>logback-dev.xml</logback.profile>
+            </properties>
+        </profile>
+        <profile>
+            <id>prod</id>
+            <properties>
+                <logback.profile>logback-prod.xml</logback.profile>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencyManagement>
         <dependencies>
@@ -89,6 +109,22 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>logback.xml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>logback.xml</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.embervault" level="DEBUG" />
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/src/main/resources/logback-prod.xml
+++ b/src/main/resources/logback-prod.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{20} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.embervault" level="INFO" />
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Delegates to the profile-specific logback configuration.
+  The property 'logback.profile' is set via Maven resource filtering
+  based on the active Maven profile (dev or prod).
+-->
 <configuration>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="CONSOLE" />
-    </root>
+    <include resource="${logback.profile}" />
 
 </configuration>


### PR DESCRIPTION
## Summary
- Add `dev` and `prod` Maven profiles to `pom.xml` with `dev` active by default
- Create `logback-dev.xml` (DEBUG level, verbose console) and `logback-prod.xml` (WARN root / INFO app, compact console)
- Use Maven resource filtering on `logback.xml` to include the profile-specific config via `<include resource="${logback.profile}" />`
- Add ADR-0015 documenting the decision

## Usage
```
./mvnw verify            # dev profile (default) - DEBUG logging
./mvnw verify -Pprod     # prod profile - INFO/WARN logging
```

## Test plan
- [x] `./mvnw verify` succeeds with dev profile (default)
- [x] `./mvnw verify -Pprod` succeeds with prod profile
- [x] Filtered `target/classes/logback.xml` includes `logback-dev.xml` for dev
- [x] Filtered `target/classes/logback.xml` includes `logback-prod.xml` for prod
- [x] Checkstyle passes
- [x] All tests pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)