### PR TITLE
Add TestFX for JavaFX UI testing

### DIFF
--- a/doc/adr/0014-use-testfx-for-ui-testing.md
+++ b/doc/adr/0014-use-testfx-for-ui-testing.md
@@ -1,0 +1,31 @@
+# 14. Use TestFX for UI Testing
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+The project uses JavaFX for its user interface (ADR-0006) and JUnit 5 as the testing framework (ADR-0003). Unit tests cover domain logic and architecture rules, but there is no mechanism to test JavaFX UI components in an automated fashion. Manual UI testing is slow, error-prone, and does not scale as the application grows.
+
+TestFX is the de facto standard library for automated JavaFX UI testing. It integrates with JUnit 5, can drive a live JavaFX stage, simulate user interactions (clicks, typing, drag-and-drop), and assert on the state of UI nodes.
+
+Headless testing via Monocle is desirable for CI environments but is not available for Java 25 at this time. Until a compatible headless toolkit is released, UI tests require a display (or software rendering via `-Dprism.order=sw`).
+
+## Decision
+
+We will use TestFX (`org.testfx:testfx-core` and `org.testfx:testfx-junit5`) for automated JavaFX UI testing.
+
+- UI tests live under `src/test/java/com/embervault/ui/` and use the `@ExtendWith(ApplicationExtension.class)` JUnit 5 integration.
+- All UI tests are tagged with `@Tag("ui")` so they can be excluded in headless CI environments using the `skip-ui-tests` Maven profile (`mvn test -Pskip-ui-tests`).
+- Monocle (`org.testfx:openjfx-monocle`) is not included because no release is compatible with Java 25. This decision should be revisited when a compatible Monocle version becomes available.
+- The Surefire plugin is configured with `--add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED` to allow TestFX reflective access to internal JavaFX APIs.
+
+## Consequences
+
+- Developers can write automated tests that launch real JavaFX stages, interact with UI controls, and assert on observable state.
+- UI regressions are caught earlier in the development cycle rather than relying solely on manual testing.
+- UI tests require a graphical display (or software rendering) to run, so CI pipelines that lack a display must either use Xvfb/virtual framebuffer or activate the `skip-ui-tests` profile.
+- When Monocle adds Java 25 support, it can be added as a test dependency to enable true headless UI testing without a display server.

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.16</logback.version>
         <javafx.version>24</javafx.version>
+        <testfx.version>4.0.18</testfx.version>
 
         <!-- Plugin versions (JavaFX) -->
         <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
@@ -86,6 +87,18 @@
             <version>${archunit-junit5.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testfx</groupId>
+            <artifactId>testfx-core</artifactId>
+            <version>${testfx.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testfx</groupId>
+            <artifactId>testfx-junit5</artifactId>
+            <version>${testfx.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -105,6 +118,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <argLine>
+                            ${argLine}
+                            --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
+                        </argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -247,4 +266,21 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>skip-ui-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups>ui</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/test/java/com/embervault/ui/JavaFxSmokeTest.java
+++ b/src/test/java/com/embervault/ui/JavaFxSmokeTest.java
@@ -1,0 +1,38 @@
+package com.embervault.ui;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Smoke test verifying that TestFX can launch a JavaFX stage and interact with it.
+ *
+ * <p>Tagged with "ui" so headless CI environments can exclude these tests
+ * via {@code mvn test -Pskip-ui-tests}.
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class JavaFxSmokeTest {
+
+    private Stage stage;
+
+    @Start
+    private void start(Stage stage) {
+        this.stage = stage;
+        stage.setTitle("EmberVault TestFX Smoke Test");
+        stage.show();
+    }
+
+    @Test
+    void stageShouldBeShowing(FxRobot robot) {
+        assertNotNull(stage, "Stage should have been initialized by @Start");
+        assertTrue(stage.isShowing(), "Stage should be visible after show()");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `testfx-core` and `testfx-junit5` 4.0.18 as test-scoped dependencies for automated JavaFX UI testing
- Create `JavaFxSmokeTest` that launches a minimal stage and asserts it is showing, tagged with `@Tag("ui")`
- Add `skip-ui-tests` Maven profile (`mvn test -Pskip-ui-tests`) to exclude UI tests in headless CI environments
- Configure Surefire with `--add-exports` for TestFX reflective access to internal JavaFX APIs
- Monocle (`openjfx-monocle`) is omitted because no release supports Java 25; documented in ADR-0014
- Write ADR-0014 documenting the TestFX decision and headless testing strategy

## Test plan
- [x] `mvn test` passes with all 13 tests (including new UI smoke test)
- [x] `mvn test -Pskip-ui-tests` passes with 12 tests (UI test excluded)
- [ ] Verify CI passes (may need display or `skip-ui-tests` profile)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)