### PR TITLE
Add ADR-0016: error handling strategy

### DIFF
--- a/doc/adr/0016-error-handling-strategy.md
+++ b/doc/adr/0016-error-handling-strategy.md
@@ -1,0 +1,58 @@
+# 16. Error Handling Strategy
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+EmberVault needs a consistent, layered error handling strategy that aligns with the hexagonal architecture (ADR-0009) and the MVVM pattern (ADR-0013). Without a deliberate approach, error handling tends to become ad-hoc: domain validation failures may surface as raw exceptions in the UI, error messages may leak implementation details to users, and catch blocks may silently swallow important failures. A well-defined strategy ensures that each layer handles errors at the appropriate level of abstraction and that users receive clear, actionable feedback.
+
+Java's checked exception mechanism, while well-intentioned, introduces tight coupling between layers and clutters method signatures with exception declarations that must be propagated through every intermediate caller. Unchecked exceptions provide the same signalling capability without forcing every method in the call chain to declare or catch them, which better suits a layered architecture where exceptions naturally bubble up to a designated handling boundary.
+
+## Decision
+
+We will adopt a layered error handling strategy using exclusively unchecked exceptions. All custom exceptions extend `RuntimeException` (directly or through a base class), and no checked exceptions are introduced by application code.
+
+### Domain Layer
+
+The domain layer defines a base `DomainException` class (extending `RuntimeException`) and domain-specific subclasses that communicate business rule violations:
+
+- `DomainException` — Abstract base class for all domain-originated errors. Resides in `com.embervault.domain`.
+- `EntityNotFoundException` — Thrown when a requested entity does not exist. Extends `DomainException`.
+- `ValidationException` — Thrown when a domain invariant or input validation rule is violated. Extends `DomainException`.
+
+Additional domain exception subclasses may be introduced as the domain model grows; all must extend `DomainException`. This constraint is enforced by an ArchUnit rule in the build.
+
+### Application Layer
+
+The application layer (use cases / inbound ports) catches domain exceptions when translation or enrichment is needed. If a use case must signal a failure that is not purely domain-related (e.g., a coordination failure across multiple domain operations), it may throw an `ApplicationException` (extending `RuntimeException`). In most cases, domain exceptions pass through the application layer unmodified.
+
+### UI Layer — ViewModel
+
+ViewModels (ADR-0013) are the designated error handling boundary for the UI. A ViewModel catches application and domain exceptions arising from use case calls and translates them into observable error state — typically a `StringProperty` for an error message and a `BooleanProperty` indicating whether an error is active. ViewModels never let exceptions propagate to the View or to the JavaFX runtime.
+
+### UI Layer — View
+
+Views bind to the ViewModel's error properties and display user-friendly messages using standard JavaFX controls (labels, alerts, banners). Views contain no try-catch blocks and no exception handling logic of their own; they rely entirely on the ViewModel to manage error state.
+
+### Summary of Error Flow
+
+```
+Domain (throws DomainException subclasses)
+  --> Application (catches/translates if needed, may throw ApplicationException)
+    --> ViewModel (catches all exceptions, exposes error state via observable properties)
+      --> View (binds to error properties, displays messages)
+```
+
+## Consequences
+
+- Every layer handles errors at its own level of abstraction, preventing leaky abstractions.
+- Using only unchecked exceptions keeps method signatures clean and avoids forced propagation through intermediate layers.
+- The `DomainException` base class provides a single type to catch when a layer needs to handle all domain errors generically.
+- ArchUnit enforces that domain exceptions extend `DomainException`, preventing accidental introduction of ad-hoc exception classes in the domain layer.
+- ViewModels serve as the error boundary for the UI, ensuring that unhandled exceptions never crash the JavaFX application thread.
+- Views remain thin and declarative, consistent with ADR-0013.
+- Developers must decide the appropriate exception granularity for new domain rules, which adds a small amount of design overhead.

--- a/src/main/java/com/embervault/domain/DomainException.java
+++ b/src/main/java/com/embervault/domain/DomainException.java
@@ -1,0 +1,34 @@
+package com.embervault.domain;
+
+/**
+ * Base class for all domain-originated exceptions.
+ *
+ * <p>All custom exceptions within the domain layer must extend this class.
+ * This constraint is enforced by an ArchUnit rule (see ADR-0016).
+ *
+ * <p>{@code DomainException} is an unchecked exception (extends
+ * {@link RuntimeException}) so that it can propagate through intermediate
+ * layers without polluting method signatures with checked-exception
+ * declarations.</p>
+ */
+public abstract class DomainException extends RuntimeException {
+
+    /**
+     * Creates a domain exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    protected DomainException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a domain exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the underlying cause
+     */
+    protected DomainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/embervault/domain/EntityNotFoundException.java
+++ b/src/main/java/com/embervault/domain/EntityNotFoundException.java
@@ -1,0 +1,31 @@
+package com.embervault.domain;
+
+/**
+ * Thrown when a requested entity cannot be found.
+ *
+ * <p>This exception signals that a lookup by identifier yielded no result,
+ * which is a domain-level concern (the entity simply does not exist).
+ * See ADR-0016 for the error handling strategy.</p>
+ */
+public class EntityNotFoundException extends DomainException {
+
+    /**
+     * Creates an exception indicating that an entity was not found.
+     *
+     * @param message the detail message describing which entity was missing
+     */
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates an exception indicating that an entity was not found, with an
+     * underlying cause.
+     *
+     * @param message the detail message describing which entity was missing
+     * @param cause   the underlying cause
+     */
+    public EntityNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/embervault/domain/ValidationException.java
+++ b/src/main/java/com/embervault/domain/ValidationException.java
@@ -1,0 +1,30 @@
+package com.embervault.domain;
+
+/**
+ * Thrown when a domain invariant or input validation rule is violated.
+ *
+ * <p>This exception indicates that the caller supplied data that does not
+ * satisfy the domain's validation constraints. See ADR-0016 for the error
+ * handling strategy.</p>
+ */
+public class ValidationException extends DomainException {
+
+    /**
+     * Creates a validation exception with the specified detail message.
+     *
+     * @param message the detail message describing the validation failure
+     */
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a validation exception with the specified detail message and cause.
+     *
+     * @param message the detail message describing the validation failure
+     * @param cause   the underlying cause
+     */
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,6 +5,9 @@ module com.embervault {
     opens com.embervault to javafx.fxml;
     exports com.embervault;
 
+    // Domain exception hierarchy (ADR-0016).
+    exports com.embervault.domain;
+
     // Hexagonal architecture packages (ADR-0009).
     // Exports will be added as classes are introduced in each package.
     // Package structure:

--- a/src/test/java/com/embervault/architecture/ArchitectureTest.java
+++ b/src/test/java/com/embervault/architecture/ArchitectureTest.java
@@ -6,6 +6,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.embervault.domain.DomainException;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -164,6 +165,18 @@ class ArchitectureTest {
                 .resideInAPackage("com.embervault.adapter.out..")
                 .because("ADR-0013 mandates that Views do not reference infrastructure "
                         + "(outbound adapter) packages")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0016: Domain exceptions must extend DomainException")
+    void domainExceptionsShouldExtendDomainException() {
+        classes()
+                .that().resideInAPackage("com.embervault.domain..")
+                .and().areAssignableTo(Exception.class)
+                .should().beAssignableTo(DomainException.class)
+                .because("ADR-0016 mandates that all domain exceptions extend DomainException")
                 .allowEmptyShould(true)
                 .check(classes);
     }

--- a/src/test/java/com/embervault/domain/DomainExceptionTest.java
+++ b/src/test/java/com/embervault/domain/DomainExceptionTest.java
@@ -1,0 +1,105 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the domain exception hierarchy (ADR-0016).
+ *
+ * <p>Verifies that every domain exception carries messages and causes
+ * correctly and extends the expected base types.</p>
+ */
+class DomainExceptionTest {
+
+    @Nested
+    @DisplayName("EntityNotFoundException")
+    class EntityNotFoundExceptionTests {
+
+        @Test
+        @DisplayName("carries the detail message")
+        void shouldCarryMessage() {
+            var exception = new EntityNotFoundException("Vault not found");
+            assertEquals("Vault not found", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("carries the detail message and cause")
+        void shouldCarryMessageAndCause() {
+            var cause = new RuntimeException("underlying error");
+            var exception = new EntityNotFoundException("Vault not found", cause);
+
+            assertEquals("Vault not found", exception.getMessage());
+            assertSame(cause, exception.getCause());
+        }
+
+        @Test
+        @DisplayName("has null cause when constructed with message only")
+        void shouldHaveNullCauseWhenNotProvided() {
+            var exception = new EntityNotFoundException("Vault not found");
+            assertNull(exception.getCause());
+        }
+
+        @Test
+        @DisplayName("extends DomainException")
+        void shouldExtendDomainException() {
+            var exception = new EntityNotFoundException("not found");
+            assertInstanceOf(DomainException.class, exception);
+        }
+
+        @Test
+        @DisplayName("extends RuntimeException (unchecked)")
+        void shouldExtendRuntimeException() {
+            var exception = new EntityNotFoundException("not found");
+            assertInstanceOf(RuntimeException.class, exception);
+        }
+    }
+
+    @Nested
+    @DisplayName("ValidationException")
+    class ValidationExceptionTests {
+
+        @Test
+        @DisplayName("carries the detail message")
+        void shouldCarryMessage() {
+            var exception = new ValidationException("Name must not be blank");
+            assertEquals("Name must not be blank", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("carries the detail message and cause")
+        void shouldCarryMessageAndCause() {
+            var cause = new IllegalArgumentException("bad input");
+            var exception = new ValidationException("Name must not be blank", cause);
+
+            assertEquals("Name must not be blank", exception.getMessage());
+            assertSame(cause, exception.getCause());
+        }
+
+        @Test
+        @DisplayName("has null cause when constructed with message only")
+        void shouldHaveNullCauseWhenNotProvided() {
+            var exception = new ValidationException("Name must not be blank");
+            assertNull(exception.getCause());
+        }
+
+        @Test
+        @DisplayName("extends DomainException")
+        void shouldExtendDomainException() {
+            var exception = new ValidationException("invalid");
+            assertInstanceOf(DomainException.class, exception);
+        }
+
+        @Test
+        @DisplayName("extends RuntimeException (unchecked)")
+        void shouldExtendRuntimeException() {
+            var exception = new ValidationException("invalid");
+            assertInstanceOf(RuntimeException.class, exception);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add ADR-0016 documenting a layered error handling strategy using unchecked exceptions, aligned with hexagonal architecture (ADR-0009) and MVVM (ADR-0013)
- Introduce domain exception hierarchy: `DomainException` (abstract base), `EntityNotFoundException`, and `ValidationException` in `com.embervault.domain`
- Add ArchUnit rule enforcing that all domain exceptions extend `DomainException`
- Add unit tests for exception classes verifying message/cause propagation and type hierarchy

## Test plan
- [x] `DomainExceptionTest` verifies message and cause propagation for `EntityNotFoundException` and `ValidationException`
- [x] `DomainExceptionTest` verifies both exception types extend `DomainException` and `RuntimeException`
- [x] ArchUnit test enforces domain exceptions must extend `DomainException`
- [x] `./mvnw verify` passes (23 tests, 0 failures, checkstyle clean, coverage met)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)