### PR TITLE
Scaffold initial MVVM example with Note entity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
                             </rules>
                             <excludes>
                                 <exclude>com/embervault/App.class</exclude>
+                                <exclude>com/embervault/adapter/in/ui/view/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -1,9 +1,17 @@
 package com.embervault;
 
+import java.io.IOException;
+
+import com.embervault.adapter.in.ui.view.NoteViewController;
+import com.embervault.adapter.in.ui.viewmodel.NoteViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.application.port.out.NoteRepository;
 import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.Label;
-import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 /**
@@ -12,11 +20,20 @@ import javafx.stage.Stage;
 public class App extends Application {
 
     @Override
-    public void start(Stage stage) {
-        Label label = new Label("Welcome to EmberVault");
-        StackPane root = new StackPane(label);
-        Scene scene = new Scene(root, 800, 600);
+    public void start(Stage stage) throws IOException {
+        // Manual dependency injection
+        NoteRepository repository = new InMemoryNoteRepository();
+        NoteService noteService = new NoteServiceImpl(repository);
+        NoteViewModel viewModel = new NoteViewModel(noteService);
 
+        FXMLLoader loader = new FXMLLoader(getClass().getResource(
+                "/com/embervault/adapter/in/ui/view/NoteView.fxml"));
+        Parent root = loader.load();
+
+        NoteViewController controller = loader.getController();
+        controller.initViewModel(viewModel);
+
+        Scene scene = new Scene(root, 800, 600);
         stage.setTitle("EmberVault");
         stage.setScene(scene);
         stage.show();

--- a/src/main/java/com/embervault/adapter/in/ui/view/NoteViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/NoteViewController.java
@@ -1,0 +1,59 @@
+package com.embervault.adapter.in.ui.view;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.NoteViewModel;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+
+/**
+ * FXML controller that binds UI controls to the {@link NoteViewModel}.
+ *
+ * <p>Contains no business logic; all actions delegate to the ViewModel.
+ * Uses {@link NoteDisplayItem} (from the viewmodel package) rather than
+ * domain entities, satisfying ADR-0013.</p>
+ */
+public class NoteViewController {
+
+    @FXML private ListView<NoteDisplayItem> noteListView;
+    @FXML private TextField titleField;
+    @FXML private TextArea contentArea;
+    @FXML private Button addButton;
+    @FXML private Button saveButton;
+    @FXML private Button deleteButton;
+
+    private NoteViewModel viewModel;
+
+    /**
+     * Injects the ViewModel and binds UI controls to its properties.
+     */
+    public void initViewModel(NoteViewModel viewModel) {
+        this.viewModel = viewModel;
+
+        noteListView.setItems(viewModel.getNotes());
+        titleField.textProperty().bindBidirectional(viewModel.titleProperty());
+        contentArea.textProperty().bindBidirectional(viewModel.contentProperty());
+
+        noteListView.getSelectionModel().selectedItemProperty()
+                .addListener((obs, oldVal, newVal) -> viewModel.selectNote(newVal));
+
+        viewModel.loadNotes();
+    }
+
+    @FXML
+    void onAdd() {
+        viewModel.addNote();
+    }
+
+    @FXML
+    void onSave() {
+        viewModel.saveNote();
+    }
+
+    @FXML
+    void onDelete() {
+        viewModel.deleteNote();
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItem.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItem.java
@@ -1,0 +1,62 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Presentation-layer representation of a note for display in the View.
+ *
+ * <p>Decouples the View from the domain {@code Note} entity, satisfying
+ * the ADR-0013 constraint that Views must not reference domain packages.</p>
+ */
+public final class NoteDisplayItem {
+
+    private final UUID id;
+    private final String title;
+    private final String content;
+
+    /**
+     * Constructs a display item with the given id, title, and content.
+     */
+    public NoteDisplayItem(UUID id, String title, String content) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.title = Objects.requireNonNull(title, "title must not be null");
+        this.content = Objects.requireNonNull(content, "content must not be null");
+    }
+
+    /** Returns the note id. */
+    public UUID getId() {
+        return id;
+    }
+
+    /** Returns the title. */
+    public String getTitle() {
+        return title;
+    }
+
+    /** Returns the content. */
+    public String getContent() {
+        return content;
+    }
+
+    @Override
+    public String toString() {
+        return title;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NoteDisplayItem other)) {
+            return false;
+        }
+        return id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteViewModel.java
@@ -1,0 +1,136 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * ViewModel for the note management screen.
+ *
+ * <p>Exposes observable properties that the View binds to. Depends on the
+ * {@link NoteService} inbound port, not on infrastructure directly.
+ * Exposes {@link NoteDisplayItem} to the View so that the View never
+ * references domain classes.</p>
+ */
+public final class NoteViewModel {
+
+    private final NoteService noteService;
+
+    private final ObservableList<NoteDisplayItem> notes =
+            FXCollections.observableArrayList();
+    private final ObjectProperty<NoteDisplayItem> selectedNote =
+            new SimpleObjectProperty<>();
+    private final StringProperty title = new SimpleStringProperty("");
+    private final StringProperty content = new SimpleStringProperty("");
+
+    /**
+     * Constructs a NoteViewModel backed by the given use-case port.
+     */
+    public NoteViewModel(NoteService noteService) {
+        this.noteService = Objects.requireNonNull(noteService,
+                "noteService must not be null");
+    }
+
+    /** Returns the observable list of note display items. */
+    public ObservableList<NoteDisplayItem> getNotes() {
+        return notes;
+    }
+
+    /** Returns the selected-note property. */
+    public ObjectProperty<NoteDisplayItem> selectedNoteProperty() {
+        return selectedNote;
+    }
+
+    /** Returns the title property for the editor field. */
+    public StringProperty titleProperty() {
+        return title;
+    }
+
+    /** Returns the content property for the editor field. */
+    public StringProperty contentProperty() {
+        return content;
+    }
+
+    /** Loads all notes from the service into the observable list. */
+    public void loadNotes() {
+        notes.setAll(noteService.getAllNotes().stream()
+                .map(NoteViewModel::toDisplayItem)
+                .toList());
+    }
+
+    /** Creates a new note from the current title and content properties. */
+    public void addNote() {
+        Note created = noteService.createNote(title.get(), content.get());
+        notes.add(toDisplayItem(created));
+        clearEditor();
+    }
+
+    /** Saves changes to the currently selected note. */
+    public void saveNote() {
+        NoteDisplayItem selected = selectedNote.get();
+        if (selected == null) {
+            return;
+        }
+        Note updated = noteService.updateNote(
+                selected.getId(), title.get(), content.get());
+        NoteDisplayItem updatedItem = toDisplayItem(updated);
+        int index = findNoteIndex(updated.getId());
+        if (index >= 0) {
+            notes.set(index, updatedItem);
+        }
+        selectedNote.set(updatedItem);
+    }
+
+    /** Deletes the currently selected note. */
+    public void deleteNote() {
+        NoteDisplayItem selected = selectedNote.get();
+        if (selected == null) {
+            return;
+        }
+        noteService.deleteNote(selected.getId());
+        notes.remove(selected);
+        clearEditor();
+        selectedNote.set(null);
+    }
+
+    /**
+     * Called when the user selects a note in the list.
+     * Populates the editor fields from the selected display item.
+     */
+    public void selectNote(NoteDisplayItem item) {
+        selectedNote.set(item);
+        if (item != null) {
+            title.set(item.getTitle());
+            content.set(item.getContent());
+        } else {
+            clearEditor();
+        }
+    }
+
+    private void clearEditor() {
+        title.set("");
+        content.set("");
+    }
+
+    private int findNoteIndex(UUID id) {
+        for (int i = 0; i < notes.size(); i++) {
+            if (notes.get(i).getId().equals(id)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static NoteDisplayItem toDisplayItem(Note note) {
+        return new NoteDisplayItem(
+                note.getId(), note.getTitle(), note.getContent());
+    }
+}

--- a/src/main/java/com/embervault/adapter/out/persistence/InMemoryNoteRepository.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/InMemoryNoteRepository.java
@@ -1,0 +1,40 @@
+package com.embervault.adapter.out.persistence;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.Note;
+
+/**
+ * In-memory implementation of {@link NoteRepository} backed by a {@link LinkedHashMap}.
+ */
+public final class InMemoryNoteRepository implements NoteRepository {
+
+    private final Map<UUID, Note> store = new LinkedHashMap<>();
+
+    @Override
+    public Note save(Note note) {
+        store.put(note.getId(), note);
+        return note;
+    }
+
+    @Override
+    public Optional<Note> findById(UUID id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public List<Note> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public void delete(UUID id) {
+        store.remove(id);
+    }
+}

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -1,0 +1,59 @@
+package com.embervault.application;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.application.port.in.NoteService;
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.Note;
+
+/**
+ * Application service implementing note use cases.
+ *
+ * <p>Delegates persistence to the {@link NoteRepository} outbound port.</p>
+ */
+public final class NoteServiceImpl implements NoteService {
+
+    private final NoteRepository repository;
+
+    /**
+     * Constructs a NoteServiceImpl backed by the given repository.
+     */
+    public NoteServiceImpl(NoteRepository repository) {
+        this.repository = Objects.requireNonNull(repository,
+                "repository must not be null");
+    }
+
+    @Override
+    public Note createNote(String title, String content) {
+        Note note = Note.create(title, content);
+        return repository.save(note);
+    }
+
+    @Override
+    public Optional<Note> getNote(UUID id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<Note> getAllNotes() {
+        return repository.findAll();
+    }
+
+    @Override
+    public Note updateNote(UUID id, String title, String content) {
+        Note note = repository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Note not found: " + id));
+        note.update(title, content);
+        return repository.save(note);
+    }
+
+    @Override
+    public void deleteNote(UUID id) {
+        repository.delete(id);
+    }
+}

--- a/src/main/java/com/embervault/application/package-info.java
+++ b/src/main/java/com/embervault/application/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Application services implementing inbound use-case ports.
+ *
+ * <p>See ADR-0009 (Hexagonal Architecture).</p>
+ */
+package com.embervault.application;

--- a/src/main/java/com/embervault/application/port/in/NoteService.java
+++ b/src/main/java/com/embervault/application/port/in/NoteService.java
@@ -1,0 +1,38 @@
+package com.embervault.application.port.in;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Inbound port defining the note management use cases.
+ */
+public interface NoteService {
+
+    /**
+     * Creates a new note with the given title and content.
+     */
+    Note createNote(String title, String content);
+
+    /**
+     * Retrieves a note by its id.
+     */
+    Optional<Note> getNote(UUID id);
+
+    /**
+     * Retrieves all notes.
+     */
+    List<Note> getAllNotes();
+
+    /**
+     * Updates an existing note's title and content.
+     */
+    Note updateNote(UUID id, String title, String content);
+
+    /**
+     * Deletes the note with the given id.
+     */
+    void deleteNote(UUID id);
+}

--- a/src/main/java/com/embervault/application/port/out/NoteRepository.java
+++ b/src/main/java/com/embervault/application/port/out/NoteRepository.java
@@ -1,0 +1,33 @@
+package com.embervault.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Outbound port for persisting and retrieving notes.
+ */
+public interface NoteRepository {
+
+    /**
+     * Saves the given note, creating or replacing it by id.
+     */
+    Note save(Note note);
+
+    /**
+     * Finds a note by its unique identifier.
+     */
+    Optional<Note> findById(UUID id);
+
+    /**
+     * Returns all notes.
+     */
+    List<Note> findAll();
+
+    /**
+     * Deletes the note with the given id.
+     */
+    void delete(UUID id);
+}

--- a/src/main/java/com/embervault/domain/Note.java
+++ b/src/main/java/com/embervault/domain/Note.java
@@ -1,0 +1,109 @@
+package com.embervault.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A note entity representing a titled piece of content.
+ */
+public final class Note {
+
+    private final UUID id;
+    private String title;
+    private String content;
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    /**
+     * Creates a new Note with the given id, title, content, and timestamps.
+     */
+    public Note(UUID id, String title, String content,
+            Instant createdAt, Instant updatedAt) {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(title, "title must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+        Objects.requireNonNull(createdAt, "createdAt must not be null");
+        Objects.requireNonNull(updatedAt, "updatedAt must not be null");
+
+        if (title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    /**
+     * Creates a new Note with auto-generated id and current timestamps.
+     */
+    public static Note create(String title, String content) {
+        Instant now = Instant.now();
+        return new Note(UUID.randomUUID(), title, content, now, now);
+    }
+
+    /** Returns the unique identifier. */
+    public UUID getId() {
+        return id;
+    }
+
+    /** Returns the title. */
+    public String getTitle() {
+        return title;
+    }
+
+    /** Returns the content. */
+    public String getContent() {
+        return content;
+    }
+
+    /** Returns the creation timestamp. */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /** Returns the last-updated timestamp. */
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /**
+     * Updates the title and content, setting updatedAt to now.
+     */
+    public void update(String newTitle, String newContent) {
+        Objects.requireNonNull(newTitle, "title must not be null");
+        Objects.requireNonNull(newContent, "content must not be null");
+
+        if (newTitle.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+
+        this.title = newTitle;
+        this.content = newContent;
+        this.updatedAt = Instant.now();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Note other)) {
+            return false;
+        }
+        return id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Note{id=" + id + ", title='" + title + "'}";
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -6,16 +6,16 @@ module com.embervault {
     exports com.embervault;
 
     // Hexagonal architecture packages (ADR-0009).
-    // Exports will be added as classes are introduced in each package.
-    // Package structure:
-    //   com.embervault.domain                    - core domain model
-    //   com.embervault.application.port.in       - inbound ports (use cases)
-    //   com.embervault.application.port.out      - outbound ports (repositories)
-    //   com.embervault.adapter.in.ui             - inbound adapters (JavaFX)
-    //   com.embervault.adapter.out.persistence   - outbound adapters (storage)
+    exports com.embervault.domain;
+    exports com.embervault.application.port.in;
+    exports com.embervault.application.port.out;
+    exports com.embervault.application;
+    exports com.embervault.adapter.out.persistence;
+    exports com.embervault.adapter.in.ui.viewmodel;
+    exports com.embervault.adapter.in.ui.view;
 
     // MVVM sub-packages within the UI adapter (ADR-0013).
-    //   com.embervault.adapter.in.ui.view        - FXML views and controllers
-    //   com.embervault.adapter.in.ui.viewmodel   - ViewModels with observable properties
+    // Open to javafx.fxml so FXMLLoader can reflectively instantiate controllers.
     opens com.embervault.adapter.in.ui.view to javafx.fxml;
+    opens com.embervault.domain to javafx.base;
 }

--- a/src/main/resources/com/embervault/adapter/in/ui/view/NoteView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/NoteView.fxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox spacing="10" xmlns:fx="http://javafx.com/fxml"
+      fx:controller="com.embervault.adapter.in.ui.view.NoteViewController">
+    <padding>
+        <Insets top="10" right="10" bottom="10" left="10"/>
+    </padding>
+
+    <!-- Left: note list -->
+    <ListView fx:id="noteListView" prefWidth="250" HBox.hgrow="NEVER"/>
+
+    <!-- Right: editor -->
+    <VBox spacing="8" HBox.hgrow="ALWAYS">
+        <TextField fx:id="titleField" promptText="Title"/>
+        <TextArea fx:id="contentArea" promptText="Content" VBox.vgrow="ALWAYS"/>
+        <HBox spacing="8">
+            <Button fx:id="addButton" text="Add" onAction="#onAdd"/>
+            <Button fx:id="saveButton" text="Save" onAction="#onSave"/>
+            <Button fx:id="deleteButton" text="Delete" onAction="#onDelete"/>
+        </HBox>
+    </VBox>
+</HBox>

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItemTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItemTest.java
@@ -1,0 +1,113 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NoteDisplayItemTest {
+
+    @Test
+    @DisplayName("constructor stores id, title, and content")
+    void constructor_shouldStoreFields() {
+        UUID id = UUID.randomUUID();
+        NoteDisplayItem item = new NoteDisplayItem(id, "Title", "Content");
+
+        assertEquals(id, item.getId());
+        assertEquals("Title", item.getTitle());
+        assertEquals("Content", item.getContent());
+    }
+
+    @Test
+    @DisplayName("constructor rejects null id")
+    void constructor_shouldRejectNullId() {
+        assertThrows(NullPointerException.class,
+                () -> new NoteDisplayItem(null, "Title", "Content"));
+    }
+
+    @Test
+    @DisplayName("constructor rejects null title")
+    void constructor_shouldRejectNullTitle() {
+        assertThrows(NullPointerException.class,
+                () -> new NoteDisplayItem(UUID.randomUUID(), null, "Content"));
+    }
+
+    @Test
+    @DisplayName("constructor rejects null content")
+    void constructor_shouldRejectNullContent() {
+        assertThrows(NullPointerException.class,
+                () -> new NoteDisplayItem(UUID.randomUUID(), "Title", null));
+    }
+
+    @Test
+    @DisplayName("toString() returns the title")
+    void toString_shouldReturnTitle() {
+        NoteDisplayItem item = new NoteDisplayItem(
+                UUID.randomUUID(), "My Note", "Body");
+
+        assertEquals("My Note", item.toString());
+    }
+
+    @Test
+    @DisplayName("equals() returns true for same id")
+    void equals_shouldReturnTrueForSameId() {
+        UUID id = UUID.randomUUID();
+        NoteDisplayItem a = new NoteDisplayItem(id, "A", "a");
+        NoteDisplayItem b = new NoteDisplayItem(id, "B", "b");
+
+        assertEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("equals() returns false for different ids")
+    void equals_shouldReturnFalseForDifferentIds() {
+        NoteDisplayItem a = new NoteDisplayItem(
+                UUID.randomUUID(), "A", "a");
+        NoteDisplayItem b = new NoteDisplayItem(
+                UUID.randomUUID(), "A", "a");
+
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("equals() returns true for same instance")
+    void equals_shouldReturnTrueForSameInstance() {
+        NoteDisplayItem item = new NoteDisplayItem(
+                UUID.randomUUID(), "A", "a");
+
+        assertEquals(item, item);
+    }
+
+    @Test
+    @DisplayName("equals() returns false for null")
+    void equals_shouldReturnFalseForNull() {
+        NoteDisplayItem item = new NoteDisplayItem(
+                UUID.randomUUID(), "A", "a");
+
+        assertNotEquals(item, null);
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    @DisplayName("equals() returns false for different type")
+    void equals_shouldReturnFalseForDifferentType() {
+        NoteDisplayItem item = new NoteDisplayItem(
+                UUID.randomUUID(), "A", "a");
+
+        assertNotEquals(item, "not a display item");
+    }
+
+    @Test
+    @DisplayName("hashCode() is consistent with equals()")
+    void hashCode_shouldBeConsistentWithEquals() {
+        UUID id = UUID.randomUUID();
+        NoteDisplayItem a = new NoteDisplayItem(id, "A", "a");
+        NoteDisplayItem b = new NoteDisplayItem(id, "B", "b");
+
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/NoteViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/NoteViewModelTest.java
@@ -1,0 +1,161 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NoteViewModelTest {
+
+    private NoteViewModel viewModel;
+    private NoteService noteService;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        viewModel = new NoteViewModel(noteService);
+    }
+
+    @Test
+    @DisplayName("loadNotes() populates the observable list from the service")
+    void loadNotes_shouldPopulateList() {
+        noteService.createNote("A", "a");
+        noteService.createNote("B", "b");
+
+        viewModel.loadNotes();
+
+        assertEquals(2, viewModel.getNotes().size());
+    }
+
+    @Test
+    @DisplayName("addNote() creates a note and adds it to the list")
+    void addNote_shouldCreateAndAppend() {
+        viewModel.titleProperty().set("New Title");
+        viewModel.contentProperty().set("New Content");
+
+        viewModel.addNote();
+
+        assertEquals(1, viewModel.getNotes().size());
+        assertEquals("New Title", viewModel.getNotes().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("addNote() clears editor fields after creation")
+    void addNote_shouldClearEditor() {
+        viewModel.titleProperty().set("Title");
+        viewModel.contentProperty().set("Content");
+
+        viewModel.addNote();
+
+        assertEquals("", viewModel.titleProperty().get());
+        assertEquals("", viewModel.contentProperty().get());
+    }
+
+    @Test
+    @DisplayName("selectNote() populates editor fields")
+    void selectNote_shouldPopulateEditor() {
+        viewModel.titleProperty().set("Title");
+        viewModel.contentProperty().set("Content");
+        viewModel.addNote();
+        NoteDisplayItem item = viewModel.getNotes().get(0);
+
+        viewModel.selectNote(item);
+
+        assertEquals("Title", viewModel.titleProperty().get());
+        assertEquals("Content", viewModel.contentProperty().get());
+        assertEquals(item, viewModel.selectedNoteProperty().get());
+    }
+
+    @Test
+    @DisplayName("selectNote(null) clears editor fields")
+    void selectNote_null_shouldClearEditor() {
+        viewModel.titleProperty().set("Residual");
+        viewModel.contentProperty().set("Residual");
+
+        viewModel.selectNote(null);
+
+        assertEquals("", viewModel.titleProperty().get());
+        assertEquals("", viewModel.contentProperty().get());
+        assertNull(viewModel.selectedNoteProperty().get());
+    }
+
+    @Test
+    @DisplayName("saveNote() updates the selected note in the list")
+    void saveNote_shouldUpdateSelectedNote() {
+        viewModel.titleProperty().set("Original");
+        viewModel.contentProperty().set("Original");
+        viewModel.addNote();
+
+        NoteDisplayItem created = viewModel.getNotes().get(0);
+        viewModel.selectNote(created);
+        viewModel.titleProperty().set("Updated");
+        viewModel.contentProperty().set("Updated");
+
+        viewModel.saveNote();
+
+        assertEquals("Updated", viewModel.getNotes().get(0).getTitle());
+        assertEquals("Updated", viewModel.getNotes().get(0).getContent());
+    }
+
+    @Test
+    @DisplayName("saveNote() does nothing when no note is selected")
+    void saveNote_shouldDoNothingWhenNothingSelected() {
+        viewModel.saveNote();
+        // no exception
+        assertTrue(viewModel.getNotes().isEmpty());
+    }
+
+    @Test
+    @DisplayName("deleteNote() removes the selected note from the list")
+    void deleteNote_shouldRemoveSelectedNote() {
+        viewModel.titleProperty().set("ToDelete");
+        viewModel.contentProperty().set("ToDelete");
+        viewModel.addNote();
+
+        NoteDisplayItem created = viewModel.getNotes().get(0);
+        viewModel.selectNote(created);
+
+        viewModel.deleteNote();
+
+        assertTrue(viewModel.getNotes().isEmpty());
+        assertNull(viewModel.selectedNoteProperty().get());
+        assertEquals("", viewModel.titleProperty().get());
+    }
+
+    @Test
+    @DisplayName("deleteNote() does nothing when no note is selected")
+    void deleteNote_shouldDoNothingWhenNothingSelected() {
+        viewModel.deleteNote();
+        // no exception
+        assertTrue(viewModel.getNotes().isEmpty());
+    }
+
+    @Test
+    @DisplayName("saveNote() handles case where note is not in observable list")
+    void saveNote_shouldHandleMissingNoteInList() {
+        // Create a note via ViewModel
+        viewModel.titleProperty().set("Title");
+        viewModel.contentProperty().set("Content");
+        viewModel.addNote();
+
+        NoteDisplayItem created = viewModel.getNotes().get(0);
+        viewModel.selectNote(created);
+
+        // Clear the observable list directly, simulating an out-of-sync state
+        viewModel.getNotes().clear();
+
+        viewModel.titleProperty().set("Updated");
+        viewModel.contentProperty().set("Updated");
+
+        // Should not throw, even though the note is not in the list
+        viewModel.saveNote();
+        assertTrue(viewModel.getNotes().isEmpty());
+    }
+}

--- a/src/test/java/com/embervault/adapter/out/persistence/InMemoryNoteRepositoryTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/InMemoryNoteRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.embervault.adapter.out.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InMemoryNoteRepositoryTest {
+
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+    }
+
+    @Test
+    @DisplayName("save() stores a note that can be retrieved by id")
+    void save_shouldStoreNote() {
+        Note note = Note.create("Title", "Content");
+
+        repository.save(note);
+
+        Optional<Note> found = repository.findById(note.getId());
+        assertTrue(found.isPresent());
+        assertEquals(note, found.get());
+    }
+
+    @Test
+    @DisplayName("findById() returns empty for unknown id")
+    void findById_shouldReturnEmptyForUnknownId() {
+        Optional<Note> found = repository.findById(UUID.randomUUID());
+
+        assertFalse(found.isPresent());
+    }
+
+    @Test
+    @DisplayName("findAll() returns all saved notes")
+    void findAll_shouldReturnAllNotes() {
+        Note noteA = Note.create("A", "a");
+        Note noteB = Note.create("B", "b");
+        repository.save(noteA);
+        repository.save(noteB);
+
+        List<Note> all = repository.findAll();
+
+        assertEquals(2, all.size());
+        assertTrue(all.contains(noteA));
+        assertTrue(all.contains(noteB));
+    }
+
+    @Test
+    @DisplayName("findAll() returns empty list when no notes exist")
+    void findAll_shouldReturnEmptyListWhenEmpty() {
+        List<Note> all = repository.findAll();
+
+        assertTrue(all.isEmpty());
+    }
+
+    @Test
+    @DisplayName("delete() removes a note by id")
+    void delete_shouldRemoveNote() {
+        Note note = Note.create("Title", "Content");
+        repository.save(note);
+
+        repository.delete(note.getId());
+
+        assertFalse(repository.findById(note.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("delete() is safe for unknown ids")
+    void delete_shouldBeSafeForUnknownId() {
+        repository.delete(UUID.randomUUID());
+        // no exception expected
+    }
+
+    @Test
+    @DisplayName("save() replaces an existing note with the same id")
+    void save_shouldReplaceExistingNote() {
+        Note note = Note.create("Old", "Old content");
+        repository.save(note);
+
+        note.update("New", "New content");
+        repository.save(note);
+
+        Note found = repository.findById(note.getId()).orElseThrow();
+        assertEquals("New", found.getTitle());
+        assertEquals("New content", found.getContent());
+    }
+}

--- a/src/test/java/com/embervault/application/NoteServiceImplTest.java
+++ b/src/test/java/com/embervault/application/NoteServiceImplTest.java
@@ -1,0 +1,99 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NoteServiceImplTest {
+
+    private NoteService service;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        service = new NoteServiceImpl(repository);
+    }
+
+    @Test
+    @DisplayName("createNote() returns a persisted note")
+    void createNote_shouldPersistAndReturn() {
+        Note note = service.createNote("Title", "Content");
+
+        assertNotNull(note);
+        assertNotNull(note.getId());
+        assertEquals("Title", note.getTitle());
+        assertTrue(repository.findById(note.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("getNote() returns the note when it exists")
+    void getNote_shouldReturnExistingNote() {
+        Note created = service.createNote("Title", "Content");
+
+        Optional<Note> found = service.getNote(created.getId());
+
+        assertTrue(found.isPresent());
+        assertEquals(created, found.get());
+    }
+
+    @Test
+    @DisplayName("getNote() returns empty when note does not exist")
+    void getNote_shouldReturnEmptyForMissing() {
+        Optional<Note> found = service.getNote(UUID.randomUUID());
+
+        assertTrue(found.isEmpty());
+    }
+
+    @Test
+    @DisplayName("getAllNotes() returns all created notes")
+    void getAllNotes_shouldReturnAll() {
+        service.createNote("A", "a");
+        service.createNote("B", "b");
+
+        List<Note> all = service.getAllNotes();
+
+        assertEquals(2, all.size());
+    }
+
+    @Test
+    @DisplayName("updateNote() updates title and content")
+    void updateNote_shouldModifyNote() {
+        Note created = service.createNote("Old", "Old");
+
+        Note updated = service.updateNote(created.getId(), "New", "New");
+
+        assertEquals("New", updated.getTitle());
+        assertEquals("New", updated.getContent());
+    }
+
+    @Test
+    @DisplayName("updateNote() throws when note does not exist")
+    void updateNote_shouldThrowForMissing() {
+        assertThrows(NoSuchElementException.class,
+                () -> service.updateNote(UUID.randomUUID(), "T", "C"));
+    }
+
+    @Test
+    @DisplayName("deleteNote() removes the note")
+    void deleteNote_shouldRemoveNote() {
+        Note created = service.createNote("Title", "Content");
+
+        service.deleteNote(created.getId());
+
+        assertTrue(service.getNote(created.getId()).isEmpty());
+    }
+}

--- a/src/test/java/com/embervault/domain/NoteTest.java
+++ b/src/test/java/com/embervault/domain/NoteTest.java
@@ -1,0 +1,191 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NoteTest {
+
+    @Test
+    @DisplayName("create() produces a Note with non-null id and timestamps")
+    void create_shouldPopulateIdAndTimestamps() {
+        Note note = Note.create("My Title", "Some content");
+
+        assertNotNull(note.getId());
+        assertEquals("My Title", note.getTitle());
+        assertEquals("Some content", note.getContent());
+        assertNotNull(note.getCreatedAt());
+        assertNotNull(note.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("create() sets createdAt equal to updatedAt initially")
+    void create_shouldSetEqualTimestamps() {
+        Note note = Note.create("Title", "Content");
+
+        assertEquals(note.getCreatedAt(), note.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null id")
+    void constructor_shouldRejectNullId() {
+        Instant now = Instant.now();
+        assertThrows(NullPointerException.class,
+                () -> new Note(null, "Title", "Content", now, now));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null title")
+    void constructor_shouldRejectNullTitle() {
+        Instant now = Instant.now();
+        assertThrows(NullPointerException.class,
+                () -> new Note(UUID.randomUUID(), null, "Content", now, now));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects blank title")
+    void constructor_shouldRejectBlankTitle() {
+        Instant now = Instant.now();
+        assertThrows(IllegalArgumentException.class,
+                () -> new Note(UUID.randomUUID(), "   ", "Content", now, now));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null content")
+    void constructor_shouldRejectNullContent() {
+        Instant now = Instant.now();
+        assertThrows(NullPointerException.class,
+                () -> new Note(UUID.randomUUID(), "Title", null, now, now));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null createdAt")
+    void constructor_shouldRejectNullCreatedAt() {
+        Instant now = Instant.now();
+        assertThrows(NullPointerException.class,
+                () -> new Note(UUID.randomUUID(), "Title", "Content", null, now));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null updatedAt")
+    void constructor_shouldRejectNullUpdatedAt() {
+        Instant now = Instant.now();
+        assertThrows(NullPointerException.class,
+                () -> new Note(UUID.randomUUID(), "Title", "Content", now, null));
+    }
+
+    @Test
+    @DisplayName("update() rejects null content")
+    void update_shouldRejectNullContent() {
+        Note note = Note.create("Title", "Content");
+
+        assertThrows(NullPointerException.class,
+                () -> note.update("Title", null));
+    }
+
+    @Test
+    @DisplayName("update() changes title, content, and updatedAt")
+    void update_shouldChangeFieldsAndTimestamp() {
+        Note note = Note.create("Old", "Old content");
+        Instant before = note.getUpdatedAt();
+
+        note.update("New", "New content");
+
+        assertEquals("New", note.getTitle());
+        assertEquals("New content", note.getContent());
+        assertTrue(note.getUpdatedAt().compareTo(before) >= 0);
+    }
+
+    @Test
+    @DisplayName("update() rejects blank title")
+    void update_shouldRejectBlankTitle() {
+        Note note = Note.create("Title", "Content");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> note.update("  ", "Content"));
+    }
+
+    @Test
+    @DisplayName("update() rejects null title")
+    void update_shouldRejectNullTitle() {
+        Note note = Note.create("Title", "Content");
+
+        assertThrows(NullPointerException.class,
+                () -> note.update(null, "Content"));
+    }
+
+    @Test
+    @DisplayName("equals() returns true for same instance")
+    void equals_shouldReturnTrueForSameInstance() {
+        Note note = Note.create("Title", "Content");
+
+        assertEquals(note, note);
+    }
+
+    @Test
+    @DisplayName("equals() is based on id")
+    void equals_shouldBeBasedOnId() {
+        UUID id = UUID.randomUUID();
+        Instant now = Instant.now();
+        Note noteA = new Note(id, "A", "a", now, now);
+        Note noteB = new Note(id, "B", "b", now, now);
+
+        assertEquals(noteA, noteB);
+    }
+
+    @Test
+    @DisplayName("equals() returns false for different ids")
+    void equals_shouldReturnFalseForDifferentIds() {
+        Note noteA = Note.create("Same", "Same");
+        Note noteB = Note.create("Same", "Same");
+
+        assertNotEquals(noteA, noteB);
+    }
+
+    @SuppressWarnings("EqualsWithItself")
+    @Test
+    @DisplayName("equals() returns false for null")
+    void equals_shouldReturnFalseForNull() {
+        Note note = Note.create("Title", "Content");
+
+        assertNotEquals(note, null);
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    @DisplayName("equals() returns false for different type")
+    void equals_shouldReturnFalseForDifferentType() {
+        Note note = Note.create("Title", "Content");
+
+        assertNotEquals(note, "not a note");
+    }
+
+    @Test
+    @DisplayName("hashCode() is consistent with equals()")
+    void hashCode_shouldBeConsistentWithEquals() {
+        UUID id = UUID.randomUUID();
+        Instant now = Instant.now();
+        Note noteA = new Note(id, "A", "a", now, now);
+        Note noteB = new Note(id, "B", "b", now, now);
+
+        assertEquals(noteA.hashCode(), noteB.hashCode());
+    }
+
+    @Test
+    @DisplayName("toString() includes id and title")
+    void toString_shouldIncludeIdAndTitle() {
+        Note note = Note.create("Test", "Content");
+        String str = note.toString();
+
+        assertTrue(str.contains(note.getId().toString()));
+        assertTrue(str.contains("Test"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implements full MVVM scaffold across all hexagonal architecture layers per ADR-0009 and ADR-0013
- Domain `Note` entity with UUID id, title/content fields, timestamps, and validation
- Inbound (`NoteService`) and outbound (`NoteRepository`) port interfaces, `NoteServiceImpl` application service, `InMemoryNoteRepository` adapter
- `NoteViewModel` with JavaFX observable properties, `NoteDisplayItem` presentation DTO to decouple View from domain, `NoteViewController` binding FXML to ViewModel
- `NoteView.fxml` layout: ListView on left, title+content editor on right, Add/Save/Delete buttons
- App.java wired with manual DI to load the FXML view
- 66 tests (entity, repository, service, ViewModel, display item, architecture fitness) all passing
- Checkstyle clean, JaCoCo coverage above 80% thresholds (UI view classes excluded)

## Test plan
- [x] `mvnw verify` passes: all 66 tests green, checkstyle clean, JaCoCo met
- [x] ArchUnit rules validate ADR-0009 (domain isolation) and ADR-0013 (View does not reference domain)
- [ ] Manual smoke test: `mvnw javafx:run` launches the note editor UI

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)