### PR TITLE
Fix CI TestFX display error with xvfb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,11 @@ jobs:
           java-version: '25'
           cache: maven
 
+      - name: Install xvfb
+        run: sudo apt-get install -y xvfb
+
       - name: Run Maven verify
-        run: ./mvnw verify --batch-mode --no-transfer-progress
+        run: xvfb-run ./mvnw verify --batch-mode --no-transfer-progress
 
       - name: Upload JaCoCo coverage report
         if: always()


### PR DESCRIPTION
## Summary
- Install `xvfb` in CI and wrap the Maven verify command with `xvfb-run` to provide a virtual framebuffer on ubuntu-latest, which has no display server
- This fixes `java.lang.UnsupportedOperationException: Unable to open DISPLAY` errors from TestFX UI tests tagged `@Tag("ui")` (related to PR #34)
- Java 25 Temurin setup is left as-is since setup-java resolves GA releases

## Test plan
- [ ] Verify CI passes on this PR (xvfb-run provides the virtual display for TestFX)
- [ ] Confirm no regressions in non-UI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)