### PR TITLE
Add --enable-native-access=javafx.graphics to JVM options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,20 @@
                 <logback.profile>logback-prod.xml</logback.profile>
             </properties>
         </profile>
+        <profile>
+            <id>skip-ui-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups>ui</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -156,8 +170,9 @@
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                         <argLine>
-                            ${argLine}
+                            @{argLine}
                             --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
+                            --enable-native-access=javafx.graphics
                         </argLine>
                     </configuration>
                 </plugin>
@@ -187,6 +202,9 @@
                     <version>${javafx-maven-plugin.version}</version>
                     <configuration>
                         <mainClass>com.embervault/com.embervault.App</mainClass>
+                        <options>
+                            <option>--enable-native-access=javafx.graphics</option>
+                        </options>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -303,21 +321,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>skip-ui-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludedGroups>ui</excludedGroups>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,10 +5,7 @@ module com.embervault {
     opens com.embervault to javafx.fxml;
     exports com.embervault;
 
-    // Domain exception hierarchy (ADR-0016).
-    exports com.embervault.domain;
-
-    // Hexagonal architecture packages (ADR-0009).
+    // Domain exception hierarchy (ADR-0016) and hexagonal architecture packages (ADR-0009).
     exports com.embervault.domain;
     exports com.embervault.application.port.in;
     exports com.embervault.application.port.out;


### PR DESCRIPTION
## Summary
- Added `--enable-native-access=javafx.graphics` to the `javafx-maven-plugin` `<options>` so `mvn javafx:run` passes the flag to the JVM
- Added the same flag to `maven-surefire-plugin` `<argLine>` so TestFX UI tests also receive it
- Fixed JaCoCo late property replacement (`${argLine}` -> `@{argLine}`) to ensure the JaCoCo agent is properly injected
- Merged duplicate `<profiles>` blocks in pom.xml (pre-existing XML error)
- Removed duplicate `exports com.embervault.domain` in module-info.java (pre-existing compilation error)

Closes #39

## Test plan
- [x] `mvn verify` passes locally with Java 25 (78 tests, 0 failures)
- [x] JaCoCo coverage checks pass (all thresholds met)
- [x] Checkstyle passes (0 violations)
- [ ] CI pipeline passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)