### PR TITLE
Add Map and Outline tab views with SplitPane layout

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -2,16 +2,20 @@ package com.embervault;
 
 import java.io.IOException;
 
-import com.embervault.adapter.in.ui.view.NoteViewController;
-import com.embervault.adapter.in.ui.viewmodel.NoteViewModel;
-import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
-import com.embervault.application.NoteServiceImpl;
-import com.embervault.application.port.in.NoteService;
-import com.embervault.application.port.out.NoteRepository;
+import com.embervault.adapter.in.ui.view.MapViewController;
+import com.embervault.adapter.in.ui.view.OutlineViewController;
+import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
+import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import com.embervault.application.ProjectServiceImpl;
+import com.embervault.application.port.in.ProjectService;
+import com.embervault.domain.Project;
 import javafx.application.Application;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.SplitPane;
 import javafx.stage.Stage;
 
 /**
@@ -21,20 +25,38 @@ public class App extends Application {
 
     @Override
     public void start(Stage stage) throws IOException {
-        // Manual dependency injection
-        NoteRepository repository = new InMemoryNoteRepository();
-        NoteService noteService = new NoteServiceImpl(repository);
-        NoteViewModel viewModel = new NoteViewModel(noteService);
+        // Create an empty project on startup
+        ProjectService projectService = new ProjectServiceImpl();
+        Project project = projectService.createEmptyProject();
 
-        FXMLLoader loader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/NoteView.fxml"));
-        Parent root = loader.load();
+        // Observable note title for binding to ViewModels
+        StringProperty rootNoteTitle = new SimpleStringProperty(
+                project.getRootNote().getTitle());
 
-        NoteViewController controller = loader.getController();
-        controller.initViewModel(viewModel);
+        // Create ViewModels
+        MapViewModel mapViewModel = new MapViewModel(rootNoteTitle);
+        OutlineViewModel outlineViewModel = new OutlineViewModel(rootNoteTitle);
 
-        Scene scene = new Scene(root, 800, 600);
-        stage.setTitle("EmberVault");
+        // Load MapView
+        FXMLLoader mapLoader = new FXMLLoader(getClass().getResource(
+                "/com/embervault/adapter/in/ui/view/MapView.fxml"));
+        Parent mapView = mapLoader.load();
+        MapViewController mapController = mapLoader.getController();
+        mapController.initViewModel(mapViewModel);
+
+        // Load OutlineView
+        FXMLLoader outlineLoader = new FXMLLoader(getClass().getResource(
+                "/com/embervault/adapter/in/ui/view/OutlineView.fxml"));
+        Parent outlineView = outlineLoader.load();
+        OutlineViewController outlineController = outlineLoader.getController();
+        outlineController.initViewModel(outlineViewModel);
+
+        // SplitPane with Map on left, Outline on right
+        SplitPane splitPane = new SplitPane(mapView, outlineView);
+        splitPane.setDividerPositions(0.5);
+
+        Scene scene = new Scene(splitPane, 1024, 768);
+        stage.setTitle("EmberVault - " + project.getName());
         stage.setScene(scene);
         stage.show();
     }

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -1,0 +1,29 @@
+package com.embervault.adapter.in.ui.view;
+
+import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+
+/**
+ * FXML controller for the Map view.
+ *
+ * <p>Contains no business logic; all state is managed by the {@link MapViewModel}.</p>
+ */
+public class MapViewController {
+
+    @FXML private Label mapLabel;
+
+    private MapViewModel viewModel;
+
+    /**
+     * Injects the ViewModel and binds UI controls to its properties.
+     */
+    public void initViewModel(MapViewModel viewModel) {
+        this.viewModel = viewModel;
+    }
+
+    /** Returns the associated ViewModel. */
+    public MapViewModel getViewModel() {
+        return viewModel;
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -1,0 +1,29 @@
+package com.embervault.adapter.in.ui.view;
+
+import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+
+/**
+ * FXML controller for the Outline view.
+ *
+ * <p>Contains no business logic; all state is managed by the {@link OutlineViewModel}.</p>
+ */
+public class OutlineViewController {
+
+    @FXML private Label outlineLabel;
+
+    private OutlineViewModel viewModel;
+
+    /**
+     * Injects the ViewModel and binds UI controls to its properties.
+     */
+    public void initViewModel(OutlineViewModel viewModel) {
+        this.viewModel = viewModel;
+    }
+
+    /** Returns the associated ViewModel. */
+    public OutlineViewModel getViewModel() {
+        return viewModel;
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -1,0 +1,32 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.Objects;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.StringProperty;
+
+/**
+ * ViewModel for the Map view tab.
+ *
+ * <p>Computes a tab title of the form "Map: &lt;note title&gt;" that updates
+ * reactively when the underlying note title changes.</p>
+ */
+public final class MapViewModel {
+
+    private final ReadOnlyStringWrapper tabTitle = new ReadOnlyStringWrapper();
+
+    /**
+     * Constructs a MapViewModel that derives its tab title from the given note title property.
+     */
+    public MapViewModel(StringProperty noteTitle) {
+        Objects.requireNonNull(noteTitle, "noteTitle must not be null");
+        tabTitle.bind(Bindings.concat("Map: ", noteTitle));
+    }
+
+    /** Returns the tab title property. */
+    public ReadOnlyStringProperty tabTitleProperty() {
+        return tabTitle.getReadOnlyProperty();
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -1,0 +1,32 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.Objects;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.StringProperty;
+
+/**
+ * ViewModel for the Outline view tab.
+ *
+ * <p>Computes a tab title of the form "Outline: &lt;note title&gt;" that updates
+ * reactively when the underlying note title changes.</p>
+ */
+public final class OutlineViewModel {
+
+    private final ReadOnlyStringWrapper tabTitle = new ReadOnlyStringWrapper();
+
+    /**
+     * Constructs an OutlineViewModel that derives its tab title from the given note title property.
+     */
+    public OutlineViewModel(StringProperty noteTitle) {
+        Objects.requireNonNull(noteTitle, "noteTitle must not be null");
+        tabTitle.bind(Bindings.concat("Outline: ", noteTitle));
+    }
+
+    /** Returns the tab title property. */
+    public ReadOnlyStringProperty tabTitleProperty() {
+        return tabTitle.getReadOnlyProperty();
+    }
+}

--- a/src/main/java/com/embervault/application/ProjectServiceImpl.java
+++ b/src/main/java/com/embervault/application/ProjectServiceImpl.java
@@ -1,0 +1,15 @@
+package com.embervault.application;
+
+import com.embervault.application.port.in.ProjectService;
+import com.embervault.domain.Project;
+
+/**
+ * Application service implementing project use cases.
+ */
+public final class ProjectServiceImpl implements ProjectService {
+
+    @Override
+    public Project createEmptyProject() {
+        return Project.createEmpty();
+    }
+}

--- a/src/main/java/com/embervault/application/port/in/ProjectService.java
+++ b/src/main/java/com/embervault/application/port/in/ProjectService.java
@@ -1,0 +1,14 @@
+package com.embervault.application.port.in;
+
+import com.embervault.domain.Project;
+
+/**
+ * Inbound port defining the project management use cases.
+ */
+public interface ProjectService {
+
+    /**
+     * Creates a new empty project with a default root note.
+     */
+    Project createEmptyProject();
+}

--- a/src/main/java/com/embervault/domain/Project.java
+++ b/src/main/java/com/embervault/domain/Project.java
@@ -1,0 +1,75 @@
+package com.embervault.domain;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A project entity representing a collection of notes with a root note.
+ */
+public final class Project {
+
+    private final UUID id;
+    private final String name;
+    private final Note rootNote;
+
+    /**
+     * Creates a new Project with the given id, name, and root note.
+     */
+    public Project(UUID id, String name, Note rootNote) {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(rootNote, "rootNote must not be null");
+
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+
+        this.id = id;
+        this.name = name;
+        this.rootNote = rootNote;
+    }
+
+    /**
+     * Creates an empty project with a root Note titled "Untitled".
+     */
+    public static Project createEmpty() {
+        Note rootNote = Note.create("Untitled", "");
+        return new Project(UUID.randomUUID(), "Untitled", rootNote);
+    }
+
+    /** Returns the unique identifier. */
+    public UUID getId() {
+        return id;
+    }
+
+    /** Returns the project name. */
+    public String getName() {
+        return name;
+    }
+
+    /** Returns the root note. */
+    public Note getRootNote() {
+        return rootNote;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Project other)) {
+            return false;
+        }
+        return id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Project{id=" + id + ", name='" + name + "'}";
+    }
+}

--- a/src/main/resources/com/embervault/adapter/in/ui/view/MapView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/MapView.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.StackPane?>
+
+<StackPane xmlns:fx="http://javafx.com/fxml"
+           fx:controller="com.embervault.adapter.in.ui.view.MapViewController">
+    <padding>
+        <Insets top="10" right="10" bottom="10" left="10"/>
+    </padding>
+
+    <Label fx:id="mapLabel" text="Map View" style="-fx-font-size: 18;"/>
+</StackPane>

--- a/src/main/resources/com/embervault/adapter/in/ui/view/OutlineView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/OutlineView.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox alignment="CENTER" xmlns:fx="http://javafx.com/fxml"
+      fx:controller="com.embervault.adapter.in.ui.view.OutlineViewController">
+    <padding>
+        <Insets top="10" right="10" bottom="10" left="10"/>
+    </padding>
+
+    <Label fx:id="outlineLabel" text="Outline View" style="-fx-font-size: 18;"/>
+</VBox>

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
@@ -1,0 +1,39 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MapViewModelTest {
+
+    @Test
+    @DisplayName("tabTitle reflects the note title with Map prefix")
+    void tabTitle_shouldReflectNoteTitleWithMapPrefix() {
+        StringProperty noteTitle = new SimpleStringProperty("My Note");
+        MapViewModel viewModel = new MapViewModel(noteTitle);
+
+        assertEquals("Map: My Note", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("tabTitle updates when note title changes")
+    void tabTitle_shouldUpdateWhenNoteTitleChanges() {
+        StringProperty noteTitle = new SimpleStringProperty("Original");
+        MapViewModel viewModel = new MapViewModel(noteTitle);
+
+        noteTitle.set("Updated");
+
+        assertEquals("Map: Updated", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null noteTitle")
+    void constructor_shouldRejectNullNoteTitle() {
+        assertThrows(NullPointerException.class,
+                () -> new MapViewModel(null));
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -1,0 +1,39 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OutlineViewModelTest {
+
+    @Test
+    @DisplayName("tabTitle reflects the note title with Outline prefix")
+    void tabTitle_shouldReflectNoteTitleWithOutlinePrefix() {
+        StringProperty noteTitle = new SimpleStringProperty("My Note");
+        OutlineViewModel viewModel = new OutlineViewModel(noteTitle);
+
+        assertEquals("Outline: My Note", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("tabTitle updates when note title changes")
+    void tabTitle_shouldUpdateWhenNoteTitleChanges() {
+        StringProperty noteTitle = new SimpleStringProperty("Original");
+        OutlineViewModel viewModel = new OutlineViewModel(noteTitle);
+
+        noteTitle.set("Updated");
+
+        assertEquals("Outline: Updated", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null noteTitle")
+    void constructor_shouldRejectNullNoteTitle() {
+        assertThrows(NullPointerException.class,
+                () -> new OutlineViewModel(null));
+    }
+}

--- a/src/test/java/com/embervault/application/ProjectServiceImplTest.java
+++ b/src/test/java/com/embervault/application/ProjectServiceImplTest.java
@@ -1,0 +1,46 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.embervault.application.port.in.ProjectService;
+import com.embervault.domain.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProjectServiceImplTest {
+
+    private ProjectService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProjectServiceImpl();
+    }
+
+    @Test
+    @DisplayName("createEmptyProject() returns a project with Untitled name")
+    void createEmptyProject_shouldReturnUntitledProject() {
+        Project project = service.createEmptyProject();
+
+        assertNotNull(project);
+        assertEquals("Untitled", project.getName());
+    }
+
+    @Test
+    @DisplayName("createEmptyProject() returns a project with a root note")
+    void createEmptyProject_shouldHaveRootNote() {
+        Project project = service.createEmptyProject();
+
+        assertNotNull(project.getRootNote());
+        assertEquals("Untitled", project.getRootNote().getTitle());
+    }
+
+    @Test
+    @DisplayName("createEmptyProject() returns a project with a valid id")
+    void createEmptyProject_shouldHaveValidId() {
+        Project project = service.createEmptyProject();
+
+        assertNotNull(project.getId());
+    }
+}

--- a/src/test/java/com/embervault/domain/ProjectTest.java
+++ b/src/test/java/com/embervault/domain/ProjectTest.java
@@ -1,0 +1,97 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProjectTest {
+
+    @Test
+    @DisplayName("createEmpty() produces a project with non-null id and name")
+    void createEmpty_shouldPopulateIdAndName() {
+        Project project = Project.createEmpty();
+
+        assertNotNull(project.getId());
+        assertEquals("Untitled", project.getName());
+    }
+
+    @Test
+    @DisplayName("createEmpty() produces a project with a root note titled Untitled")
+    void createEmpty_shouldHaveRootNoteTitledUntitled() {
+        Project project = Project.createEmpty();
+
+        assertNotNull(project.getRootNote());
+        assertEquals("Untitled", project.getRootNote().getTitle());
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null id")
+    void constructor_shouldRejectNullId() {
+        Note rootNote = Note.create("Title", "");
+        assertThrows(NullPointerException.class,
+                () -> new Project(null, "Name", rootNote));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null name")
+    void constructor_shouldRejectNullName() {
+        Note rootNote = Note.create("Title", "");
+        assertThrows(NullPointerException.class,
+                () -> new Project(UUID.randomUUID(), null, rootNote));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects blank name")
+    void constructor_shouldRejectBlankName() {
+        Note rootNote = Note.create("Title", "");
+        assertThrows(IllegalArgumentException.class,
+                () -> new Project(UUID.randomUUID(), "   ", rootNote));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null rootNote")
+    void constructor_shouldRejectNullRootNote() {
+        assertThrows(NullPointerException.class,
+                () -> new Project(UUID.randomUUID(), "Name", null));
+    }
+
+    @Test
+    @DisplayName("equals() is based on id")
+    void equals_shouldBeBasedOnId() {
+        UUID id = UUID.randomUUID();
+        Note noteA = Note.create("A", "a");
+        Note noteB = Note.create("B", "b");
+        Project projectA = new Project(id, "A", noteA);
+        Project projectB = new Project(id, "B", noteB);
+
+        assertEquals(projectA, projectB);
+    }
+
+    @Test
+    @DisplayName("hashCode() is consistent with equals()")
+    void hashCode_shouldBeConsistentWithEquals() {
+        UUID id = UUID.randomUUID();
+        Note noteA = Note.create("A", "a");
+        Note noteB = Note.create("B", "b");
+        Project projectA = new Project(id, "A", noteA);
+        Project projectB = new Project(id, "B", noteB);
+
+        assertEquals(projectA.hashCode(), projectB.hashCode());
+    }
+
+    @Test
+    @DisplayName("toString() includes id and name")
+    void toString_shouldIncludeIdAndName() {
+        Project project = Project.createEmpty();
+        String str = project.toString();
+
+        assertNotNull(str);
+        assertEquals(true, str.contains(project.getId().toString()));
+        assertEquals(true, str.contains("Untitled"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Project` domain entity with `createEmpty()` factory method and `ProjectService` application port
- Add `MapViewModel` and `OutlineViewModel` with reactive tab title bindings ("Map: <title>" / "Outline: <title>")
- Add `MapView.fxml`/`OutlineView.fxml` with corresponding view controllers as placeholder views
- Update `App.java` to create an empty project on startup and display Map and Outline views in a 50/50 `SplitPane`
- TDD: tests written first for domain (`ProjectTest`), application (`ProjectServiceImplTest`), and viewmodel layers (`MapViewModelTest`, `OutlineViewModelTest`)

## Test plan
- [x] All 116 tests pass (`mvnw verify`)
- [x] Checkstyle passes with 0 violations
- [x] JaCoCo coverage thresholds met (view controllers excluded per existing config)
- [x] ArchUnit architecture rules pass (domain isolation, viewmodel no scene deps, views no domain deps)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)