### PR TITLE
Implement type-safe attribute system (Tinderbox model)

### DIFF
--- a/doc/adr/0018-use-type-safe-attribute-map.md
+++ b/doc/adr/0018-use-type-safe-attribute-map.md
@@ -1,0 +1,51 @@
+# 18. Use Type-Safe Attribute Map for Note Model
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+EmberVault models notes inspired by Tinderbox, where every note is fundamentally a bag of typed attributes rather than a fixed set of fields. Tinderbox defines 11 attribute types (String, Number, Boolean, Color, Date, Interval, File, URL, List, Set, Action), hundreds of built-in system attributes, and supports user-defined attributes at runtime. Attributes inherit through a prototype chain: note -> prototype -> prototype's prototype -> document default.
+
+We needed to decide how to represent note data internally. Two alternatives were considered:
+
+**Alternative A: Type-Safe Attribute Map** -- A sealed `AttributeValue` interface with record variants for each type, stored in a sparse `AttributeMap`. Attributes are resolved through a prototype inheritance chain.
+
+**Alternative B: Fixed Field Entity** -- Keep the original `Note` class with hardcoded fields (title, content, createdAt, updatedAt) and add new fields as needed.
+
+## Decision
+
+We chose **Alternative A: Type-Safe Attribute Map**.
+
+The core design consists of:
+
+- **AttributeType** enum with 11 variants mapping to Java types
+- **AttributeValue** sealed interface with 11 record variants enabling exhaustive pattern matching
+- **TbxColor** value object supporting named, hex, RGB, and HSV color formats
+- **AttributeDefinition** record defining schema (name, type, default, intrinsic/read-only/system flags)
+- **AttributeMap** sparse map holding only locally-set values
+- **AttributeSchemaRegistry** pre-populated with essential system attributes using the "$" naming convention
+- **AttributeResolver** domain service implementing the inheritance chain (local -> prototype chain -> document default), with intrinsic attributes skipping the prototype chain
+
+The `Note` entity was refactored to use `AttributeMap` internally while maintaining backward-compatible convenience methods (`getTitle()`, `getContent()`, `getCreatedAt()`, `getUpdatedAt()`).
+
+The `AttributeResolver` accepts a `Function<UUID, Optional<Note>>` for prototype lookups rather than depending on `NoteRepository` directly, preserving the hexagonal architecture constraint that domain code must not depend on the application layer.
+
+## Consequences
+
+### Positive
+
+- Compile-time type safety via Java sealed types and pattern matching in switch expressions
+- Extensible: new attributes (system or user-defined) can be added without modifying the Note class
+- Prototype inheritance enables reusable note templates, matching Tinderbox's powerful prototype system
+- Sparse storage is memory-efficient since notes only store locally-overridden values
+- Backward-compatible: existing code using `getTitle()`/`getContent()` continues to work
+
+### Negative
+
+- More indirection when accessing common attributes compared to direct field access
+- The attribute resolution chain adds complexity compared to a simple field lookup
+- Cast-based convenience methods (e.g., extracting a String from AttributeValue) are not statically type-checked at the accessor level

--- a/src/main/java/com/embervault/domain/AttributeDefinition.java
+++ b/src/main/java/com/embervault/domain/AttributeDefinition.java
@@ -1,0 +1,122 @@
+package com.embervault.domain;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Defines the schema for a single attribute in the Tinderbox model.
+ *
+ * <p>An attribute definition specifies the name, type, default value, and
+ * metadata flags such as whether the attribute is intrinsic, read-only, or
+ * system-defined.</p>
+ *
+ * @param name            the attribute name, case-sensitive (e.g., "$Name")
+ * @param type            the attribute type
+ * @param defaultValue    the document-level default value
+ * @param description     a human-readable description
+ * @param suggestedValues optional suggested values for UI dropdowns
+ * @param readOnly        whether the attribute is computed/read-only
+ * @param intrinsic       whether the attribute is intrinsic (never inherited from prototypes)
+ * @param system          whether this is a built-in system attribute
+ */
+public record AttributeDefinition(
+        String name,
+        AttributeType type,
+        AttributeValue defaultValue,
+        String description,
+        List<String> suggestedValues,
+        boolean readOnly,
+        boolean intrinsic,
+        boolean system
+) {
+
+    /**
+     * Canonical constructor with validation.
+     */
+    public AttributeDefinition {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(defaultValue, "defaultValue must not be null");
+        Objects.requireNonNull(description, "description must not be null");
+        suggestedValues = List.copyOf(suggestedValues);
+    }
+
+    /**
+     * Creates a new builder for an AttributeDefinition.
+     *
+     * @param name the attribute name
+     * @param type the attribute type
+     * @return a new builder
+     */
+    public static Builder builder(String name, AttributeType type) {
+        return new Builder(name, type);
+    }
+
+    /**
+     * Builder for {@link AttributeDefinition}.
+     */
+    public static final class Builder {
+
+        private final String name;
+        private final AttributeType type;
+        private AttributeValue defaultValue;
+        private String description = "";
+        private List<String> suggestedValues = List.of();
+        private boolean readOnly;
+        private boolean intrinsic;
+        private boolean system;
+
+        private Builder(String name, AttributeType type) {
+            this.name = Objects.requireNonNull(name, "name must not be null");
+            this.type = Objects.requireNonNull(type, "type must not be null");
+        }
+
+        /** Sets the default value. */
+        public Builder defaultValue(AttributeValue value) {
+            this.defaultValue = value;
+            return this;
+        }
+
+        /** Sets the description. */
+        public Builder description(String desc) {
+            this.description = desc;
+            return this;
+        }
+
+        /** Sets the suggested values. */
+        public Builder suggestedValues(List<String> values) {
+            this.suggestedValues = values;
+            return this;
+        }
+
+        /** Sets the read-only flag. */
+        public Builder readOnly(boolean flag) {
+            this.readOnly = flag;
+            return this;
+        }
+
+        /** Sets the intrinsic flag. */
+        public Builder intrinsic(boolean flag) {
+            this.intrinsic = flag;
+            return this;
+        }
+
+        /** Sets the system flag. */
+        public Builder system(boolean flag) {
+            this.system = flag;
+            return this;
+        }
+
+        /**
+         * Builds the AttributeDefinition.
+         *
+         * @return the attribute definition
+         */
+        public AttributeDefinition build() {
+            Objects.requireNonNull(defaultValue, "defaultValue must not be null");
+            return new AttributeDefinition(
+                    name, type, defaultValue, description,
+                    suggestedValues, readOnly, intrinsic, system);
+        }
+    }
+}

--- a/src/main/java/com/embervault/domain/AttributeMap.java
+++ b/src/main/java/com/embervault/domain/AttributeMap.java
@@ -1,0 +1,94 @@
+package com.embervault.domain;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A sparse map holding a note's locally-set attribute values.
+ *
+ * <p>Only attributes that have been explicitly set on a note are stored here.
+ * Attributes not present in the map should be resolved through the prototype
+ * chain and then the document default.</p>
+ */
+public final class AttributeMap {
+
+    private final Map<String, AttributeValue> values;
+
+    /**
+     * Creates an empty attribute map.
+     */
+    public AttributeMap() {
+        this.values = new LinkedHashMap<>();
+    }
+
+    /**
+     * Creates a copy of the given attribute map.
+     *
+     * @param other the map to copy
+     */
+    public AttributeMap(AttributeMap other) {
+        this.values = new LinkedHashMap<>(other.values);
+    }
+
+    /**
+     * Gets the locally-set value for the given attribute name.
+     *
+     * @param name the attribute name
+     * @return an optional containing the value, or empty if not locally set
+     */
+    public Optional<AttributeValue> get(String name) {
+        return Optional.ofNullable(values.get(name));
+    }
+
+    /**
+     * Sets a local value for the given attribute name.
+     *
+     * @param name  the attribute name
+     * @param value the value to set
+     */
+    public void set(String name, AttributeValue value) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        values.put(name, value);
+    }
+
+    /**
+     * Removes the local value for the given attribute name.
+     *
+     * @param name the attribute name
+     */
+    public void remove(String name) {
+        values.remove(name);
+    }
+
+    /**
+     * Returns whether the given attribute has a locally-set value.
+     *
+     * @param name the attribute name
+     * @return true if the attribute is locally set
+     */
+    public boolean hasLocalValue(String name) {
+        return values.containsKey(name);
+    }
+
+    /**
+     * Returns an unmodifiable view of all locally-set entries.
+     *
+     * @return an unmodifiable map of attribute names to values
+     */
+    public Map<String, AttributeValue> localEntries() {
+        return Collections.unmodifiableMap(values);
+    }
+
+    /**
+     * Returns the number of locally-set attributes.
+     *
+     * @return the count
+     */
+    public int size() {
+        return values.size();
+    }
+}

--- a/src/main/java/com/embervault/domain/AttributeResolver.java
+++ b/src/main/java/com/embervault/domain/AttributeResolver.java
@@ -1,0 +1,82 @@
+package com.embervault.domain;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * Domain service that resolves attribute values through the inheritance chain.
+ *
+ * <p>Resolution order:
+ * <ol>
+ *   <li>Check the note's own AttributeMap</li>
+ *   <li>If intrinsic, return the document default (skip prototype chain)</li>
+ *   <li>Walk the prototype chain looking for a value</li>
+ *   <li>Fall back to the AttributeDefinition's default value</li>
+ * </ol>
+ *
+ * <p>Takes a {@code Function<UUID, Optional<Note>>} for note lookups to avoid
+ * a domain dependency on the application layer's NoteRepository port.</p>
+ */
+public final class AttributeResolver {
+
+    private static final AttributeValue UNKNOWN_DEFAULT = new AttributeValue.StringValue("");
+
+    private final AttributeSchemaRegistry schemaRegistry;
+
+    /**
+     * Constructs an AttributeResolver backed by the given schema registry.
+     *
+     * @param schemaRegistry the schema registry
+     */
+    public AttributeResolver(AttributeSchemaRegistry schemaRegistry) {
+        this.schemaRegistry = Objects.requireNonNull(schemaRegistry,
+                "schemaRegistry must not be null");
+    }
+
+    /**
+     * Resolves the value of the named attribute for the given note.
+     *
+     * @param note          the note to resolve the attribute for
+     * @param attributeName the attribute name
+     * @param noteLookup    a function that looks up notes by id
+     * @return the resolved attribute value
+     */
+    public AttributeValue resolve(Note note, String attributeName,
+            Function<UUID, Optional<Note>> noteLookup) {
+        // 1. Local value
+        if (note.getAttributes().hasLocalValue(attributeName)) {
+            return note.getAttributes().get(attributeName).orElseThrow();
+        }
+
+        // 2. Look up definition
+        Optional<AttributeDefinition> optDef = schemaRegistry.get(attributeName);
+        if (optDef.isEmpty()) {
+            return UNKNOWN_DEFAULT;
+        }
+        AttributeDefinition def = optDef.get();
+
+        // 3. If intrinsic, skip prototype chain
+        if (def.intrinsic()) {
+            return def.defaultValue();
+        }
+
+        // 4. Walk prototype chain
+        Optional<UUID> protoId = note.getPrototypeId();
+        while (protoId.isPresent()) {
+            Optional<Note> protoOpt = noteLookup.apply(protoId.get());
+            if (protoOpt.isEmpty()) {
+                break;
+            }
+            Note proto = protoOpt.get();
+            if (proto.getAttributes().hasLocalValue(attributeName)) {
+                return proto.getAttributes().get(attributeName).orElseThrow();
+            }
+            protoId = proto.getPrototypeId();
+        }
+
+        // 5. Document default
+        return def.defaultValue();
+    }
+}

--- a/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
+++ b/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
@@ -1,0 +1,141 @@
+package com.embervault.domain;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Registry of all known attribute definitions, pre-populated with system attributes.
+ *
+ * <p>Manages both system-defined and user-defined attributes. System attributes
+ * follow the Tinderbox "$" naming convention.</p>
+ */
+public final class AttributeSchemaRegistry {
+
+    private final Map<String, AttributeDefinition> definitions = new LinkedHashMap<>();
+
+    /**
+     * Creates a new registry pre-populated with the essential system attributes.
+     */
+    public AttributeSchemaRegistry() {
+        registerSystemAttributes();
+    }
+
+    /**
+     * Returns the definition for the given attribute name.
+     *
+     * @param name the attribute name
+     * @return an optional containing the definition, or empty if unknown
+     */
+    public Optional<AttributeDefinition> get(String name) {
+        return Optional.ofNullable(definitions.get(name));
+    }
+
+    /**
+     * Returns all registered definitions.
+     *
+     * @return an unmodifiable list of all definitions
+     */
+    public List<AttributeDefinition> getAll() {
+        return List.copyOf(definitions.values());
+    }
+
+    /**
+     * Returns definitions filtered by the given attribute type.
+     *
+     * @param type the attribute type to filter by
+     * @return an unmodifiable list of matching definitions
+     */
+    public List<AttributeDefinition> getByType(AttributeType type) {
+        return definitions.values().stream()
+                .filter(d -> d.type() == type)
+                .toList();
+    }
+
+    /**
+     * Returns whether the given attribute name is a system attribute.
+     *
+     * @param name the attribute name
+     * @return true if it is a system attribute
+     */
+    public boolean isSystemAttribute(String name) {
+        AttributeDefinition def = definitions.get(name);
+        return def != null && def.system();
+    }
+
+    /**
+     * Registers a user-defined attribute.
+     *
+     * @param definition the attribute definition to register
+     * @throws IllegalArgumentException if an attribute with this name already exists
+     */
+    public void register(AttributeDefinition definition) {
+        Objects.requireNonNull(definition, "definition must not be null");
+        if (definitions.containsKey(definition.name())) {
+            throw new IllegalArgumentException(
+                    "Attribute already registered: " + definition.name());
+        }
+        definitions.put(definition.name(), definition);
+    }
+
+    private void registerSystemAttributes() {
+        // Identity & Structure
+        systemAttr("$Name", AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr("$IsPrototype", AttributeType.BOOLEAN, new AttributeValue.BooleanValue(false));
+        systemAttr("$Prototype", AttributeType.STRING, new AttributeValue.StringValue(""));
+
+        // Content
+        systemAttr("$Text", AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr("$Subtitle", AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr("$Caption", AttributeType.STRING, new AttributeValue.StringValue(""));
+
+        // Appearance
+        systemAttr("$Color", AttributeType.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("warm gray")));
+        systemAttr("$BorderColor", AttributeType.COLOR,
+                new AttributeValue.ColorValue(TbxColor.hex("#000000")));
+        systemAttr("$Shape", AttributeType.STRING, new AttributeValue.StringValue("normal"));
+
+        // Position & Size (intrinsic)
+        intrinsicAttr("$Xpos", AttributeType.NUMBER, new AttributeValue.NumberValue(0), false);
+        intrinsicAttr("$Ypos", AttributeType.NUMBER, new AttributeValue.NumberValue(0), false);
+        intrinsicAttr("$Width", AttributeType.NUMBER, new AttributeValue.NumberValue(6), false);
+        intrinsicAttr("$Height", AttributeType.NUMBER, new AttributeValue.NumberValue(4), false);
+
+        // Dates (intrinsic, read-only)
+        intrinsicAttr("$Created", AttributeType.DATE,
+                new AttributeValue.DateValue(Instant.EPOCH), true);
+        intrinsicAttr("$Modified", AttributeType.DATE,
+                new AttributeValue.DateValue(Instant.EPOCH), true);
+
+        // Flags & State
+        systemAttr("$Checked", AttributeType.BOOLEAN, new AttributeValue.BooleanValue(false));
+        systemAttr("$URL", AttributeType.URL, new AttributeValue.UrlValue(""));
+
+        // Display
+        systemAttr("$DisplayedAttributes", AttributeType.SET,
+                new AttributeValue.SetValue(Set.of()));
+        systemAttr("$Flags", AttributeType.SET, new AttributeValue.SetValue(Set.of()));
+    }
+
+    private void systemAttr(String name, AttributeType type, AttributeValue defaultValue) {
+        definitions.put(name, AttributeDefinition.builder(name, type)
+                .defaultValue(defaultValue)
+                .system(true)
+                .build());
+    }
+
+    private void intrinsicAttr(String name, AttributeType type,
+            AttributeValue defaultValue, boolean readOnly) {
+        definitions.put(name, AttributeDefinition.builder(name, type)
+                .defaultValue(defaultValue)
+                .intrinsic(true)
+                .readOnly(readOnly)
+                .system(true)
+                .build());
+    }
+}

--- a/src/main/java/com/embervault/domain/AttributeType.java
+++ b/src/main/java/com/embervault/domain/AttributeType.java
@@ -1,0 +1,60 @@
+package com.embervault.domain;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Defines the 11 Tinderbox attribute types with their Java mappings.
+ */
+public enum AttributeType {
+
+    /** A string attribute. */
+    STRING(String.class),
+
+    /** A numeric attribute stored as a double. */
+    NUMBER(Double.class),
+
+    /** A boolean attribute. */
+    BOOLEAN(Boolean.class),
+
+    /** A color attribute stored as a {@link TbxColor}. */
+    COLOR(TbxColor.class),
+
+    /** A date/time attribute stored as an {@link Instant}. */
+    DATE(Instant.class),
+
+    /** A time interval attribute stored as a {@link Duration}. */
+    INTERVAL(Duration.class),
+
+    /** A file path attribute stored as a string. */
+    FILE(String.class),
+
+    /** A URL attribute stored as a string. */
+    URL(String.class),
+
+    /** An ordered list of strings. */
+    LIST(List.class),
+
+    /** An unordered set of strings with no duplicates. */
+    SET(Set.class),
+
+    /** An action expression stored as a string. */
+    ACTION(String.class);
+
+    private final Class<?> javaType;
+
+    AttributeType(Class<?> javaType) {
+        this.javaType = javaType;
+    }
+
+    /**
+     * Returns the Java class that corresponds to this attribute type.
+     *
+     * @return the Java type
+     */
+    public Class<?> javaType() {
+        return javaType;
+    }
+}

--- a/src/main/java/com/embervault/domain/AttributeValue.java
+++ b/src/main/java/com/embervault/domain/AttributeValue.java
@@ -1,0 +1,144 @@
+package com.embervault.domain;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A sealed interface representing a typed attribute value in the Tinderbox model.
+ *
+ * <p>Uses Java sealed types with record variants for compile-time type safety
+ * and exhaustive pattern matching in switch expressions.</p>
+ */
+public sealed interface AttributeValue
+        permits AttributeValue.StringValue,
+        AttributeValue.NumberValue,
+        AttributeValue.BooleanValue,
+        AttributeValue.ColorValue,
+        AttributeValue.DateValue,
+        AttributeValue.IntervalValue,
+        AttributeValue.FileValue,
+        AttributeValue.UrlValue,
+        AttributeValue.ListValue,
+        AttributeValue.SetValue,
+        AttributeValue.ActionValue {
+
+    /**
+     * Infers the appropriate {@code AttributeValue} variant from a Java object.
+     *
+     * @param value the Java object to wrap
+     * @return the corresponding AttributeValue
+     * @throws IllegalArgumentException if the type cannot be mapped
+     */
+    static AttributeValue of(Object value) {
+        Objects.requireNonNull(value, "value must not be null");
+        return switch (value) {
+            case String s -> new StringValue(s);
+            case Double d -> new NumberValue(d);
+            case Integer i -> new NumberValue(i.doubleValue());
+            case Boolean b -> new BooleanValue(b);
+            case TbxColor c -> new ColorValue(c);
+            case Instant inst -> new DateValue(inst);
+            case Duration dur -> new IntervalValue(dur);
+            default -> throw new IllegalArgumentException(
+                    "Cannot infer AttributeValue from: " + value.getClass().getName());
+        };
+    }
+
+    /**
+     * A string attribute value.
+     *
+     * @param value the string value
+     */
+    record StringValue(String value) implements AttributeValue {}
+
+    /**
+     * A numeric attribute value.
+     *
+     * @param value the double value
+     */
+    record NumberValue(double value) implements AttributeValue {}
+
+    /**
+     * A boolean attribute value.
+     *
+     * @param value the boolean value
+     */
+    record BooleanValue(boolean value) implements AttributeValue {}
+
+    /**
+     * A color attribute value.
+     *
+     * @param value the TbxColor value
+     */
+    record ColorValue(TbxColor value) implements AttributeValue {}
+
+    /**
+     * A date/time attribute value.
+     *
+     * @param value the Instant value
+     */
+    record DateValue(Instant value) implements AttributeValue {}
+
+    /**
+     * A time interval attribute value.
+     *
+     * @param value the Duration value
+     */
+    record IntervalValue(Duration value) implements AttributeValue {}
+
+    /**
+     * A file path attribute value.
+     *
+     * @param path the file path
+     */
+    record FileValue(String path) implements AttributeValue {}
+
+    /**
+     * A URL attribute value.
+     *
+     * @param url the URL string
+     */
+    record UrlValue(String url) implements AttributeValue {}
+
+    /**
+     * An ordered list of string values.
+     *
+     * @param values the list of strings (defensively copied)
+     */
+    record ListValue(List<String> values) implements AttributeValue {
+        /**
+         * Creates a ListValue with a defensive copy of the provided list.
+         *
+         * @param values the list of strings
+         */
+        public ListValue {
+            values = List.copyOf(values);
+        }
+    }
+
+    /**
+     * An unordered set of unique string values.
+     *
+     * @param values the set of strings (defensively copied)
+     */
+    record SetValue(Set<String> values) implements AttributeValue {
+        /**
+         * Creates a SetValue with a defensive copy of the provided set.
+         *
+         * @param values the set of strings
+         */
+        public SetValue {
+            values = Set.copyOf(values);
+        }
+    }
+
+    /**
+     * An action expression attribute value.
+     *
+     * @param expression the action expression string
+     */
+    record ActionValue(String expression) implements AttributeValue {}
+}

--- a/src/main/java/com/embervault/domain/Note.java
+++ b/src/main/java/com/embervault/domain/Note.java
@@ -2,21 +2,41 @@ package com.embervault.domain;
 
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
- * A note entity representing a titled piece of content.
+ * A note entity backed by a type-safe attribute map.
+ *
+ * <p>Provides backward-compatible convenience methods ({@code getName()},
+ * {@code getText()}, etc.) that delegate to the underlying attribute map.
+ * Core Tinderbox attributes are stored as {@code $Name}, {@code $Text},
+ * {@code $Created}, and {@code $Modified}.</p>
  */
 public final class Note {
 
     private final UUID id;
-    private String title;
-    private String content;
-    private final Instant createdAt;
-    private Instant updatedAt;
+    private final AttributeMap attributes;
+    private UUID prototypeId;
+
+    /**
+     * Creates a new Note with the given id and pre-populated attribute map.
+     *
+     * @param id         the unique identifier
+     * @param attributes the attribute map
+     */
+    public Note(UUID id, AttributeMap attributes) {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(attributes, "attributes must not be null");
+        this.id = id;
+        this.attributes = attributes;
+    }
 
     /**
      * Creates a new Note with the given id, title, content, and timestamps.
+     *
+     * <p>This constructor provides backward compatibility with the original
+     * Note API.</p>
      */
     public Note(UUID id, String title, String content,
             Instant createdAt, Instant updatedAt) {
@@ -31,10 +51,11 @@ public final class Note {
         }
 
         this.id = id;
-        this.title = title;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
+        this.attributes = new AttributeMap();
+        this.attributes.set("$Name", new AttributeValue.StringValue(title));
+        this.attributes.set("$Text", new AttributeValue.StringValue(content));
+        this.attributes.set("$Created", new AttributeValue.DateValue(createdAt));
+        this.attributes.set("$Modified", new AttributeValue.DateValue(updatedAt));
     }
 
     /**
@@ -50,24 +71,90 @@ public final class Note {
         return id;
     }
 
-    /** Returns the title. */
+    /** Returns the title ($Name attribute). */
     public String getTitle() {
-        return title;
+        return attributes.get("$Name")
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .orElse("");
     }
 
-    /** Returns the content. */
+    /** Returns the title ($Name attribute). Alias for getTitle(). */
+    public String getName() {
+        return getTitle();
+    }
+
+    /** Returns the content ($Text attribute). */
     public String getContent() {
-        return content;
+        return attributes.get("$Text")
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .orElse("");
     }
 
-    /** Returns the creation timestamp. */
+    /** Returns the content ($Text attribute). Alias for getContent(). */
+    public String getText() {
+        return getContent();
+    }
+
+    /** Returns the creation timestamp ($Created attribute). */
     public Instant getCreatedAt() {
-        return createdAt;
+        return attributes.get("$Created")
+                .map(v -> ((AttributeValue.DateValue) v).value())
+                .orElse(Instant.EPOCH);
     }
 
-    /** Returns the last-updated timestamp. */
+    /** Returns the last-updated timestamp ($Modified attribute). */
     public Instant getUpdatedAt() {
-        return updatedAt;
+        return attributes.get("$Modified")
+                .map(v -> ((AttributeValue.DateValue) v).value())
+                .orElse(Instant.EPOCH);
+    }
+
+    /** Returns the underlying attribute map. */
+    public AttributeMap getAttributes() {
+        return attributes;
+    }
+
+    /**
+     * Gets a specific attribute value by name.
+     *
+     * @param name the attribute name
+     * @return an optional containing the value, or empty
+     */
+    public Optional<AttributeValue> getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    /**
+     * Sets a specific attribute value by name.
+     *
+     * @param name  the attribute name
+     * @param value the value to set
+     */
+    public void setAttribute(String name, AttributeValue value) {
+        attributes.set(name, value);
+    }
+
+    /**
+     * Removes a local attribute value.
+     *
+     * @param name the attribute name
+     */
+    public void removeAttribute(String name) {
+        attributes.remove(name);
+    }
+
+    /** Returns the prototype note id, if set. */
+    public Optional<UUID> getPrototypeId() {
+        return Optional.ofNullable(prototypeId);
+    }
+
+    /**
+     * Sets the prototype note id.
+     *
+     * @param protoId the prototype note id, or null to clear
+     */
+    public void setPrototypeId(UUID protoId) {
+        this.prototypeId = protoId;
     }
 
     /**
@@ -81,9 +168,9 @@ public final class Note {
             throw new IllegalArgumentException("title must not be blank");
         }
 
-        this.title = newTitle;
-        this.content = newContent;
-        this.updatedAt = Instant.now();
+        this.attributes.set("$Name", new AttributeValue.StringValue(newTitle));
+        this.attributes.set("$Text", new AttributeValue.StringValue(newContent));
+        this.attributes.set("$Modified", new AttributeValue.DateValue(Instant.now()));
     }
 
     @Override
@@ -104,6 +191,6 @@ public final class Note {
 
     @Override
     public String toString() {
-        return "Note{id=" + id + ", title='" + title + "'}";
+        return "Note{id=" + id + ", title='" + getTitle() + "'}";
     }
 }

--- a/src/main/java/com/embervault/domain/TbxColor.java
+++ b/src/main/java/com/embervault/domain/TbxColor.java
@@ -1,0 +1,214 @@
+package com.embervault.domain;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A domain value object representing a color in the Tinderbox attribute system.
+ *
+ * <p>Named {@code TbxColor} to avoid conflicts with {@code javafx.scene.paint.Color}.
+ * Stores colors internally as a hex string and provides factory methods for
+ * named, hex, RGB, and HSV formats.</p>
+ */
+public final class TbxColor {
+
+    private static final Map<String, String> NAMED_COLORS = Map.ofEntries(
+            Map.entry("red", "#FF0000"),
+            Map.entry("green", "#00FF00"),
+            Map.entry("blue", "#0000FF"),
+            Map.entry("black", "#000000"),
+            Map.entry("white", "#FFFFFF"),
+            Map.entry("yellow", "#FFFF00"),
+            Map.entry("cyan", "#00FFFF"),
+            Map.entry("magenta", "#FF00FF"),
+            Map.entry("orange", "#FFA500"),
+            Map.entry("purple", "#800080"),
+            Map.entry("warm gray", "#808080"),
+            Map.entry("poppy", "#E35335")
+    );
+
+    private static final int HEX_LENGTH = 7;
+    private static final int HEX_RADIX = 16;
+    private static final int MAX_RGB = 255;
+    private static final int MAX_HUE = 360;
+    private static final int MAX_SV = 100;
+    private static final double SV_SCALE = 100.0;
+    private static final double HUE_SECTOR = 60.0;
+    private static final int SECTOR_COUNT = 6;
+
+    private final String hex;
+    private final String name;
+
+    private TbxColor(String hex, String name) {
+        this.hex = hex;
+        this.name = name;
+    }
+
+    /**
+     * Creates a color from a hex string (e.g., "#A482BF").
+     *
+     * @param hexValue the hex color string starting with '#'
+     * @return the color
+     * @throws IllegalArgumentException if the format is invalid
+     */
+    public static TbxColor hex(String hexValue) {
+        Objects.requireNonNull(hexValue, "hexValue must not be null");
+        String upper = hexValue.toUpperCase();
+        if (!upper.matches("#[0-9A-F]{6}")) {
+            throw new IllegalArgumentException("Invalid hex color: " + hexValue);
+        }
+        return new TbxColor(upper, null);
+    }
+
+    /**
+     * Creates a color from a known name (e.g., "red", "warm gray").
+     *
+     * @param colorName the color name
+     * @return the color
+     * @throws IllegalArgumentException if the name is blank or unknown
+     */
+    public static TbxColor named(String colorName) {
+        Objects.requireNonNull(colorName, "colorName must not be null");
+        if (colorName.isBlank()) {
+            throw new IllegalArgumentException("colorName must not be blank");
+        }
+        String lower = colorName.toLowerCase();
+        String hexValue = NAMED_COLORS.get(lower);
+        if (hexValue == null) {
+            throw new IllegalArgumentException("Unknown color name: " + colorName);
+        }
+        return new TbxColor(hexValue, colorName.toLowerCase());
+    }
+
+    /**
+     * Creates a color from RGB components (0-255 each).
+     *
+     * @param red   the red component (0-255)
+     * @param green the green component (0-255)
+     * @param blue  the blue component (0-255)
+     * @return the color
+     * @throws IllegalArgumentException if any component is out of range
+     */
+    public static TbxColor rgb(int red, int green, int blue) {
+        validateRange(red, 0, MAX_RGB, "red");
+        validateRange(green, 0, MAX_RGB, "green");
+        validateRange(blue, 0, MAX_RGB, "blue");
+        String hexValue = String.format("#%02X%02X%02X", red, green, blue);
+        return new TbxColor(hexValue, null);
+    }
+
+    /**
+     * Creates a color from HSV components.
+     *
+     * @param hue        the hue (0-360)
+     * @param saturation the saturation (0-100)
+     * @param value      the value/brightness (0-100)
+     * @return the color
+     * @throws IllegalArgumentException if any component is out of range
+     */
+    public static TbxColor hsv(int hue, int saturation, int value) {
+        validateRange(hue, 0, MAX_HUE, "hue");
+        validateRange(saturation, 0, MAX_SV, "saturation");
+        validateRange(value, 0, MAX_SV, "value");
+
+        double s = saturation / SV_SCALE;
+        double v = value / SV_SCALE;
+        double c = v * s;
+        double x = c * (1 - Math.abs((hue / HUE_SECTOR) % 2 - 1));
+        double m = v - c;
+
+        double r;
+        double g;
+        double b;
+        int sector = (hue / (int) HUE_SECTOR) % SECTOR_COUNT;
+
+        switch (sector) {
+            case 0 -> {
+                r = c;
+                g = x;
+                b = 0;
+            }
+            case 1 -> {
+                r = x;
+                g = c;
+                b = 0;
+            }
+            case 2 -> {
+                r = 0;
+                g = c;
+                b = x;
+            }
+            case 3 -> {
+                r = 0;
+                g = x;
+                b = c;
+            }
+            case 4 -> {
+                r = x;
+                g = 0;
+                b = c;
+            }
+            default -> {
+                r = c;
+                g = 0;
+                b = x;
+            }
+        }
+
+        int red = (int) Math.round((r + m) * MAX_RGB);
+        int green = (int) Math.round((g + m) * MAX_RGB);
+        int blue = (int) Math.round((b + m) * MAX_RGB);
+
+        return rgb(red, green, blue);
+    }
+
+    /**
+     * Returns the hex representation of this color (e.g., "#A482BF").
+     *
+     * @return the hex string
+     */
+    public String toHex() {
+        return hex;
+    }
+
+    /**
+     * Returns the name of this color if it was created via {@link #named(String)}.
+     *
+     * @return an optional containing the name, or empty
+     */
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof TbxColor other)) {
+            return false;
+        }
+        return hex.equals(other.hex);
+    }
+
+    @Override
+    public int hashCode() {
+        return hex.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        if (name != null) {
+            return "TbxColor{name='" + name + "', hex=" + hex + "}";
+        }
+        return "TbxColor{hex=" + hex + "}";
+    }
+
+    private static void validateRange(int value, int min, int max, String name) {
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(
+                    name + " must be between " + min + " and " + max + ", got: " + value);
+        }
+    }
+}

--- a/src/test/java/com/embervault/domain/AttributeDefinitionTest.java
+++ b/src/test/java/com/embervault/domain/AttributeDefinitionTest.java
@@ -1,0 +1,85 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttributeDefinitionTest {
+
+    @Test
+    @DisplayName("Builder creates definition with all fields")
+    void builder_createsDefinition() {
+        AttributeDefinition def = AttributeDefinition.builder("$Name", AttributeType.STRING)
+                .defaultValue(new AttributeValue.StringValue(""))
+                .description("The name of the note")
+                .suggestedValues(List.of("Untitled", "New Note"))
+                .readOnly(false)
+                .intrinsic(false)
+                .system(true)
+                .build();
+
+        assertEquals("$Name", def.name());
+        assertEquals(AttributeType.STRING, def.type());
+        assertEquals(new AttributeValue.StringValue(""), def.defaultValue());
+        assertEquals("The name of the note", def.description());
+        assertEquals(List.of("Untitled", "New Note"), def.suggestedValues());
+        assertFalse(def.readOnly());
+        assertFalse(def.intrinsic());
+        assertTrue(def.system());
+    }
+
+    @Test
+    @DisplayName("Builder provides sensible defaults")
+    void builder_sensibleDefaults() {
+        AttributeDefinition def = AttributeDefinition.builder("$Test", AttributeType.STRING)
+                .defaultValue(new AttributeValue.StringValue(""))
+                .build();
+
+        assertEquals("", def.description());
+        assertTrue(def.suggestedValues().isEmpty());
+        assertFalse(def.readOnly());
+        assertFalse(def.intrinsic());
+        assertFalse(def.system());
+    }
+
+    @Test
+    @DisplayName("Builder rejects null name")
+    void builder_rejectsNullName() {
+        assertThrows(NullPointerException.class,
+                () -> AttributeDefinition.builder(null, AttributeType.STRING));
+    }
+
+    @Test
+    @DisplayName("Builder rejects null type")
+    void builder_rejectsNullType() {
+        assertThrows(NullPointerException.class,
+                () -> AttributeDefinition.builder("$Name", null));
+    }
+
+    @Test
+    @DisplayName("Builder rejects null defaultValue")
+    void builder_rejectsNullDefaultValue() {
+        assertThrows(NullPointerException.class,
+                () -> AttributeDefinition.builder("$Name", AttributeType.STRING)
+                        .defaultValue(null)
+                        .build());
+    }
+
+    @Test
+    @DisplayName("suggestedValues list is immutable")
+    void suggestedValues_isImmutable() {
+        AttributeDefinition def = AttributeDefinition.builder("$Test", AttributeType.STRING)
+                .defaultValue(new AttributeValue.StringValue(""))
+                .suggestedValues(List.of("a"))
+                .build();
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> def.suggestedValues().add("b"));
+    }
+}

--- a/src/test/java/com/embervault/domain/AttributeMapTest.java
+++ b/src/test/java/com/embervault/domain/AttributeMapTest.java
@@ -1,0 +1,129 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttributeMapTest {
+
+    private AttributeMap map;
+
+    @BeforeEach
+    void setUp() {
+        map = new AttributeMap();
+    }
+
+    @Test
+    @DisplayName("get() returns empty for unset attribute")
+    void get_returnsEmptyForUnset() {
+        assertEquals(Optional.empty(), map.get("$Name"));
+    }
+
+    @Test
+    @DisplayName("set() and get() round-trip a value")
+    void set_andGet_roundTrip() {
+        map.set("$Name", new AttributeValue.StringValue("Hello"));
+        assertEquals(Optional.of(new AttributeValue.StringValue("Hello")), map.get("$Name"));
+    }
+
+    @Test
+    @DisplayName("set() overwrites a previous value")
+    void set_overwritesPrevious() {
+        map.set("$Name", new AttributeValue.StringValue("Old"));
+        map.set("$Name", new AttributeValue.StringValue("New"));
+        assertEquals(Optional.of(new AttributeValue.StringValue("New")), map.get("$Name"));
+    }
+
+    @Test
+    @DisplayName("remove() clears a local value")
+    void remove_clearsValue() {
+        map.set("$Name", new AttributeValue.StringValue("Hello"));
+        map.remove("$Name");
+        assertTrue(map.get("$Name").isEmpty());
+    }
+
+    @Test
+    @DisplayName("remove() is safe for unset attribute")
+    void remove_safeForUnset() {
+        map.remove("$Name");
+        // no exception
+    }
+
+    @Test
+    @DisplayName("hasLocalValue() returns true for set attributes")
+    void hasLocalValue_trueForSet() {
+        map.set("$Name", new AttributeValue.StringValue("Hello"));
+        assertTrue(map.hasLocalValue("$Name"));
+    }
+
+    @Test
+    @DisplayName("hasLocalValue() returns false for unset attributes")
+    void hasLocalValue_falseForUnset() {
+        assertFalse(map.hasLocalValue("$Name"));
+    }
+
+    @Test
+    @DisplayName("localEntries() returns only set attributes")
+    void localEntries_returnsSetOnly() {
+        map.set("$Name", new AttributeValue.StringValue("Hello"));
+        map.set("$Color", new AttributeValue.ColorValue(TbxColor.named("red")));
+
+        Map<String, AttributeValue> entries = map.localEntries();
+        assertEquals(2, entries.size());
+        assertTrue(entries.containsKey("$Name"));
+        assertTrue(entries.containsKey("$Color"));
+    }
+
+    @Test
+    @DisplayName("localEntries() returns an unmodifiable map")
+    void localEntries_isUnmodifiable() {
+        map.set("$Name", new AttributeValue.StringValue("Hello"));
+
+        Map<String, AttributeValue> entries = map.localEntries();
+        assertThrows(UnsupportedOperationException.class,
+                () -> entries.put("$Test", new AttributeValue.StringValue("fail")));
+    }
+
+    @Test
+    @DisplayName("size() returns the number of set attributes")
+    void size_returnsCount() {
+        assertEquals(0, map.size());
+        map.set("$Name", new AttributeValue.StringValue("Hello"));
+        assertEquals(1, map.size());
+        map.set("$Text", new AttributeValue.StringValue("World"));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    @DisplayName("set() rejects null name")
+    void set_rejectsNullName() {
+        assertThrows(NullPointerException.class,
+                () -> map.set(null, new AttributeValue.StringValue("x")));
+    }
+
+    @Test
+    @DisplayName("set() rejects null value")
+    void set_rejectsNullValue() {
+        assertThrows(NullPointerException.class,
+                () -> map.set("$Name", null));
+    }
+
+    @Test
+    @DisplayName("Copy constructor creates independent copy")
+    void copyConstructor_createsIndependentCopy() {
+        map.set("$Name", new AttributeValue.StringValue("Hello"));
+        AttributeMap copy = new AttributeMap(map);
+        copy.set("$Name", new AttributeValue.StringValue("Changed"));
+
+        assertEquals(Optional.of(new AttributeValue.StringValue("Hello")), map.get("$Name"));
+        assertEquals(Optional.of(new AttributeValue.StringValue("Changed")), copy.get("$Name"));
+    }
+}

--- a/src/test/java/com/embervault/domain/AttributeResolverTest.java
+++ b/src/test/java/com/embervault/domain/AttributeResolverTest.java
@@ -1,0 +1,166 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttributeResolverTest {
+
+    private AttributeSchemaRegistry registry;
+    private AttributeResolver resolver;
+    private Map<UUID, Note> noteStore;
+    private Function<UUID, Optional<Note>> noteLookup;
+
+    @BeforeEach
+    void setUp() {
+        registry = new AttributeSchemaRegistry();
+        resolver = new AttributeResolver(registry);
+        noteStore = new HashMap<>();
+        noteLookup = id -> Optional.ofNullable(noteStore.get(id));
+    }
+
+    private void store(Note note) {
+        noteStore.put(note.getId(), note);
+    }
+
+    @Test
+    @DisplayName("resolves locally-set attribute value")
+    void resolves_localValue() {
+        Note note = Note.create("Test", "");
+        note.setAttribute("$Shape", new AttributeValue.StringValue("cloud"));
+        store(note);
+
+        AttributeValue result = resolver.resolve(note, "$Shape", noteLookup);
+        assertEquals(new AttributeValue.StringValue("cloud"), result);
+    }
+
+    @Test
+    @DisplayName("falls back to document default when no local value")
+    void fallsBack_toDefault() {
+        Note note = Note.create("Test", "");
+        store(note);
+
+        AttributeValue result = resolver.resolve(note, "$Shape", noteLookup);
+        assertEquals(new AttributeValue.StringValue("normal"), result);
+    }
+
+    @Test
+    @DisplayName("inherits value from prototype")
+    void inherits_fromPrototype() {
+        Note proto = Note.create("Prototype", "");
+        proto.setAttribute("$Shape", new AttributeValue.StringValue("oval"));
+        proto.setAttribute("$IsPrototype", new AttributeValue.BooleanValue(true));
+        store(proto);
+
+        Note child = Note.create("Child", "");
+        child.setPrototypeId(proto.getId());
+        store(child);
+
+        AttributeValue result = resolver.resolve(child, "$Shape", noteLookup);
+        assertEquals(new AttributeValue.StringValue("oval"), result);
+    }
+
+    @Test
+    @DisplayName("local value overrides inherited value")
+    void localOverridesInherited() {
+        Note proto = Note.create("Prototype", "");
+        proto.setAttribute("$Shape", new AttributeValue.StringValue("oval"));
+        store(proto);
+
+        Note child = Note.create("Child", "");
+        child.setPrototypeId(proto.getId());
+        child.setAttribute("$Shape", new AttributeValue.StringValue("square"));
+        store(child);
+
+        AttributeValue result = resolver.resolve(child, "$Shape", noteLookup);
+        assertEquals(new AttributeValue.StringValue("square"), result);
+    }
+
+    @Test
+    @DisplayName("intrinsic attributes skip prototype chain")
+    void intrinsic_skipsPrototypeChain() {
+        Note proto = Note.create("Prototype", "");
+        proto.setAttribute("$Xpos", new AttributeValue.NumberValue(100));
+        store(proto);
+
+        Note child = Note.create("Child", "");
+        child.setPrototypeId(proto.getId());
+        store(child);
+
+        // $Xpos is intrinsic, so child should get the document default (0), not proto's 100
+        AttributeValue result = resolver.resolve(child, "$Xpos", noteLookup);
+        assertEquals(new AttributeValue.NumberValue(0), result);
+    }
+
+    @Test
+    @DisplayName("intrinsic attribute with local value returns local value")
+    void intrinsic_localValueReturned() {
+        Note note = Note.create("Test", "");
+        note.setAttribute("$Xpos", new AttributeValue.NumberValue(42));
+        store(note);
+
+        AttributeValue result = resolver.resolve(note, "$Xpos", noteLookup);
+        assertEquals(new AttributeValue.NumberValue(42), result);
+    }
+
+    @Test
+    @DisplayName("multi-level prototype chain works")
+    void multiLevelPrototypeChain() {
+        Note grandProto = Note.create("GrandProto", "");
+        grandProto.setAttribute("$Shape", new AttributeValue.StringValue("diamond"));
+        store(grandProto);
+
+        Note proto = Note.create("Proto", "");
+        proto.setPrototypeId(grandProto.getId());
+        store(proto);
+
+        Note child = Note.create("Child", "");
+        child.setPrototypeId(proto.getId());
+        store(child);
+
+        AttributeValue result = resolver.resolve(child, "$Shape", noteLookup);
+        assertEquals(new AttributeValue.StringValue("diamond"), result);
+    }
+
+    @Test
+    @DisplayName("removing local value reverts to inherited")
+    void removingLocalRevertsToInherited() {
+        Note proto = Note.create("Proto", "");
+        proto.setAttribute("$Shape", new AttributeValue.StringValue("oval"));
+        store(proto);
+
+        Note child = Note.create("Child", "");
+        child.setPrototypeId(proto.getId());
+        child.setAttribute("$Shape", new AttributeValue.StringValue("square"));
+        store(child);
+
+        // Verify local value first
+        assertEquals(new AttributeValue.StringValue("square"),
+                resolver.resolve(child, "$Shape", noteLookup));
+
+        // Remove local value
+        child.removeAttribute("$Shape");
+
+        // Should now inherit from prototype
+        assertEquals(new AttributeValue.StringValue("oval"),
+                resolver.resolve(child, "$Shape", noteLookup));
+    }
+
+    @Test
+    @DisplayName("unknown attribute returns string empty default")
+    void unknownAttribute_returnsStringDefault() {
+        Note note = Note.create("Test", "");
+        store(note);
+
+        AttributeValue result = resolver.resolve(note, "$Unknown", noteLookup);
+        assertEquals(new AttributeValue.StringValue(""), result);
+    }
+}

--- a/src/test/java/com/embervault/domain/AttributeSchemaRegistryTest.java
+++ b/src/test/java/com/embervault/domain/AttributeSchemaRegistryTest.java
@@ -1,0 +1,174 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttributeSchemaRegistryTest {
+
+    private AttributeSchemaRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new AttributeSchemaRegistry();
+    }
+
+    @Test
+    @DisplayName("get() returns $Name definition")
+    void get_returnsName() {
+        Optional<AttributeDefinition> def = registry.get("$Name");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.STRING, def.get().type());
+    }
+
+    @Test
+    @DisplayName("get() returns $Text definition")
+    void get_returnsText() {
+        Optional<AttributeDefinition> def = registry.get("$Text");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.STRING, def.get().type());
+    }
+
+    @Test
+    @DisplayName("get() returns $Color definition")
+    void get_returnsColor() {
+        Optional<AttributeDefinition> def = registry.get("$Color");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.COLOR, def.get().type());
+    }
+
+    @Test
+    @DisplayName("get() returns $Created as intrinsic and read-only")
+    void get_returnsCreatedAsIntrinsic() {
+        Optional<AttributeDefinition> def = registry.get("$Created");
+        assertTrue(def.isPresent());
+        assertTrue(def.get().intrinsic());
+        assertTrue(def.get().readOnly());
+    }
+
+    @Test
+    @DisplayName("get() returns $Modified as intrinsic and read-only")
+    void get_returnsModifiedAsIntrinsic() {
+        Optional<AttributeDefinition> def = registry.get("$Modified");
+        assertTrue(def.isPresent());
+        assertTrue(def.get().intrinsic());
+        assertTrue(def.get().readOnly());
+    }
+
+    @Test
+    @DisplayName("get() returns $Xpos as intrinsic")
+    void get_returnsXposAsIntrinsic() {
+        Optional<AttributeDefinition> def = registry.get("$Xpos");
+        assertTrue(def.isPresent());
+        assertTrue(def.get().intrinsic());
+        assertEquals(AttributeType.NUMBER, def.get().type());
+    }
+
+    @Test
+    @DisplayName("get() returns empty for unknown attribute")
+    void get_returnsEmptyForUnknown() {
+        assertTrue(registry.get("$Nonexistent").isEmpty());
+    }
+
+    @Test
+    @DisplayName("getAll() returns all registered definitions")
+    void getAll_returnsAll() {
+        List<AttributeDefinition> all = registry.getAll();
+        assertFalse(all.isEmpty());
+        assertTrue(all.size() >= 17);
+    }
+
+    @Test
+    @DisplayName("getByType() filters by attribute type")
+    void getByType_filters() {
+        List<AttributeDefinition> booleans = registry.getByType(AttributeType.BOOLEAN);
+        assertFalse(booleans.isEmpty());
+        assertTrue(booleans.stream().allMatch(d -> d.type() == AttributeType.BOOLEAN));
+    }
+
+    @Test
+    @DisplayName("isSystemAttribute() returns true for built-in attributes")
+    void isSystemAttribute_trueForBuiltIn() {
+        assertTrue(registry.isSystemAttribute("$Name"));
+    }
+
+    @Test
+    @DisplayName("isSystemAttribute() returns false for unknown attributes")
+    void isSystemAttribute_falseForUnknown() {
+        assertFalse(registry.isSystemAttribute("$MyCustom"));
+    }
+
+    @Test
+    @DisplayName("register() adds a user attribute")
+    void register_addsUserAttribute() {
+        AttributeDefinition userAttr = AttributeDefinition
+                .builder("$MyAttr", AttributeType.STRING)
+                .defaultValue(new AttributeValue.StringValue(""))
+                .build();
+
+        registry.register(userAttr);
+
+        assertTrue(registry.get("$MyAttr").isPresent());
+        assertFalse(registry.isSystemAttribute("$MyAttr"));
+    }
+
+    @Test
+    @DisplayName("register() rejects duplicate names")
+    void register_rejectsDuplicates() {
+        AttributeDefinition userAttr = AttributeDefinition
+                .builder("$Name", AttributeType.STRING)
+                .defaultValue(new AttributeValue.StringValue(""))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> registry.register(userAttr));
+    }
+
+    @Test
+    @DisplayName("$IsPrototype is a boolean system attribute")
+    void isPrototype_isBooleanSystem() {
+        Optional<AttributeDefinition> def = registry.get("$IsPrototype");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.BOOLEAN, def.get().type());
+        assertTrue(def.get().system());
+    }
+
+    @Test
+    @DisplayName("$Prototype is a string system attribute")
+    void prototype_isStringSystem() {
+        Optional<AttributeDefinition> def = registry.get("$Prototype");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.STRING, def.get().type());
+    }
+
+    @Test
+    @DisplayName("$URL is a URL system attribute")
+    void url_isUrlSystem() {
+        Optional<AttributeDefinition> def = registry.get("$URL");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.URL, def.get().type());
+    }
+
+    @Test
+    @DisplayName("$DisplayedAttributes is a set system attribute")
+    void displayedAttributes_isSetSystem() {
+        Optional<AttributeDefinition> def = registry.get("$DisplayedAttributes");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.SET, def.get().type());
+    }
+
+    @Test
+    @DisplayName("$Flags is a set system attribute")
+    void flags_isSetSystem() {
+        Optional<AttributeDefinition> def = registry.get("$Flags");
+        assertTrue(def.isPresent());
+        assertEquals(AttributeType.SET, def.get().type());
+    }
+}

--- a/src/test/java/com/embervault/domain/AttributeTypeTest.java
+++ b/src/test/java/com/embervault/domain/AttributeTypeTest.java
@@ -1,0 +1,95 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttributeTypeTest {
+
+    @Test
+    @DisplayName("STRING javaType returns String.class")
+    void string_javaType() {
+        assertEquals(String.class, AttributeType.STRING.javaType());
+    }
+
+    @Test
+    @DisplayName("NUMBER javaType returns Double.class")
+    void number_javaType() {
+        assertEquals(Double.class, AttributeType.NUMBER.javaType());
+    }
+
+    @Test
+    @DisplayName("BOOLEAN javaType returns Boolean.class")
+    void boolean_javaType() {
+        assertEquals(Boolean.class, AttributeType.BOOLEAN.javaType());
+    }
+
+    @Test
+    @DisplayName("COLOR javaType returns TbxColor.class")
+    void color_javaType() {
+        assertEquals(TbxColor.class, AttributeType.COLOR.javaType());
+    }
+
+    @Test
+    @DisplayName("DATE javaType returns Instant.class")
+    void date_javaType() {
+        assertEquals(Instant.class, AttributeType.DATE.javaType());
+    }
+
+    @Test
+    @DisplayName("INTERVAL javaType returns Duration.class")
+    void interval_javaType() {
+        assertEquals(Duration.class, AttributeType.INTERVAL.javaType());
+    }
+
+    @Test
+    @DisplayName("FILE javaType returns String.class")
+    void file_javaType() {
+        assertEquals(String.class, AttributeType.FILE.javaType());
+    }
+
+    @Test
+    @DisplayName("URL javaType returns String.class")
+    void url_javaType() {
+        assertEquals(String.class, AttributeType.URL.javaType());
+    }
+
+    @Test
+    @DisplayName("LIST javaType returns List.class")
+    void list_javaType() {
+        assertEquals(List.class, AttributeType.LIST.javaType());
+    }
+
+    @Test
+    @DisplayName("SET javaType returns Set.class")
+    void set_javaType() {
+        assertEquals(Set.class, AttributeType.SET.javaType());
+    }
+
+    @Test
+    @DisplayName("ACTION javaType returns String.class")
+    void action_javaType() {
+        assertEquals(String.class, AttributeType.ACTION.javaType());
+    }
+
+    @Test
+    @DisplayName("All 11 attribute types are defined")
+    void allTypesExist() {
+        assertEquals(11, AttributeType.values().length);
+    }
+
+    @Test
+    @DisplayName("Every type has a non-null javaType")
+    void everyTypeHasJavaType() {
+        for (AttributeType type : AttributeType.values()) {
+            assertNotNull(type.javaType(), "javaType for " + type + " must not be null");
+        }
+    }
+}

--- a/src/test/java/com/embervault/domain/AttributeValueTest.java
+++ b/src/test/java/com/embervault/domain/AttributeValueTest.java
@@ -1,0 +1,192 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttributeValueTest {
+
+    @Test
+    @DisplayName("StringValue holds a string")
+    void stringValue() {
+        var val = new AttributeValue.StringValue("hello");
+        assertEquals("hello", val.value());
+    }
+
+    @Test
+    @DisplayName("NumberValue holds a double")
+    void numberValue() {
+        var val = new AttributeValue.NumberValue(3.14);
+        assertEquals(3.14, val.value());
+    }
+
+    @Test
+    @DisplayName("BooleanValue holds a boolean")
+    void booleanValue() {
+        var val = new AttributeValue.BooleanValue(true);
+        assertEquals(true, val.value());
+    }
+
+    @Test
+    @DisplayName("ColorValue holds a TbxColor")
+    void colorValue() {
+        TbxColor color = TbxColor.hex("#FF0000");
+        var val = new AttributeValue.ColorValue(color);
+        assertEquals(color, val.value());
+    }
+
+    @Test
+    @DisplayName("DateValue holds an Instant")
+    void dateValue() {
+        Instant now = Instant.now();
+        var val = new AttributeValue.DateValue(now);
+        assertEquals(now, val.value());
+    }
+
+    @Test
+    @DisplayName("IntervalValue holds a Duration")
+    void intervalValue() {
+        Duration dur = Duration.ofHours(2);
+        var val = new AttributeValue.IntervalValue(dur);
+        assertEquals(dur, val.value());
+    }
+
+    @Test
+    @DisplayName("FileValue holds a path string")
+    void fileValue() {
+        var val = new AttributeValue.FileValue("/path/to/file");
+        assertEquals("/path/to/file", val.path());
+    }
+
+    @Test
+    @DisplayName("UrlValue holds a URL string")
+    void urlValue() {
+        var val = new AttributeValue.UrlValue("https://example.com");
+        assertEquals("https://example.com", val.url());
+    }
+
+    @Test
+    @DisplayName("ListValue holds a list of strings")
+    void listValue() {
+        var val = new AttributeValue.ListValue(List.of("a", "b", "c"));
+        assertEquals(List.of("a", "b", "c"), val.values());
+    }
+
+    @Test
+    @DisplayName("SetValue holds a set of strings")
+    void setValue() {
+        var val = new AttributeValue.SetValue(Set.of("x", "y"));
+        assertEquals(Set.of("x", "y"), val.values());
+    }
+
+    @Test
+    @DisplayName("ActionValue holds an expression string")
+    void actionValue() {
+        var val = new AttributeValue.ActionValue("$Name + ' suffix'");
+        assertEquals("$Name + ' suffix'", val.expression());
+    }
+
+    @Test
+    @DisplayName("Pattern matching works with switch on sealed interface")
+    void patternMatching() {
+        AttributeValue val = new AttributeValue.StringValue("test");
+        String result = switch (val) {
+            case AttributeValue.StringValue s -> "string:" + s.value();
+            case AttributeValue.NumberValue n -> "number:" + n.value();
+            case AttributeValue.BooleanValue b -> "bool:" + b.value();
+            case AttributeValue.ColorValue c -> "color:" + c.value();
+            case AttributeValue.DateValue d -> "date:" + d.value();
+            case AttributeValue.IntervalValue i -> "interval:" + i.value();
+            case AttributeValue.FileValue f -> "file:" + f.path();
+            case AttributeValue.UrlValue u -> "url:" + u.url();
+            case AttributeValue.ListValue l -> "list:" + l.values();
+            case AttributeValue.SetValue sv -> "set:" + sv.values();
+            case AttributeValue.ActionValue a -> "action:" + a.expression();
+        };
+        assertEquals("string:test", result);
+    }
+
+    @Test
+    @DisplayName("of() infers StringValue from String")
+    void of_infersString() {
+        assertInstanceOf(AttributeValue.StringValue.class, AttributeValue.of("hello"));
+    }
+
+    @Test
+    @DisplayName("of() infers NumberValue from Double")
+    void of_infersDouble() {
+        assertInstanceOf(AttributeValue.NumberValue.class, AttributeValue.of(3.14));
+    }
+
+    @Test
+    @DisplayName("of() infers NumberValue from Integer")
+    void of_infersInteger() {
+        AttributeValue val = AttributeValue.of(42);
+        assertInstanceOf(AttributeValue.NumberValue.class, val);
+        assertEquals(42.0, ((AttributeValue.NumberValue) val).value());
+    }
+
+    @Test
+    @DisplayName("of() infers BooleanValue from Boolean")
+    void of_infersBoolean() {
+        assertInstanceOf(AttributeValue.BooleanValue.class, AttributeValue.of(true));
+    }
+
+    @Test
+    @DisplayName("of() infers ColorValue from TbxColor")
+    void of_infersColor() {
+        assertInstanceOf(AttributeValue.ColorValue.class,
+                AttributeValue.of(TbxColor.hex("#FF0000")));
+    }
+
+    @Test
+    @DisplayName("of() infers DateValue from Instant")
+    void of_infersInstant() {
+        assertInstanceOf(AttributeValue.DateValue.class, AttributeValue.of(Instant.now()));
+    }
+
+    @Test
+    @DisplayName("of() infers IntervalValue from Duration")
+    void of_infersDuration() {
+        assertInstanceOf(AttributeValue.IntervalValue.class,
+                AttributeValue.of(Duration.ofHours(1)));
+    }
+
+    @Test
+    @DisplayName("of() rejects null")
+    void of_rejectsNull() {
+        assertThrows(NullPointerException.class, () -> AttributeValue.of(null));
+    }
+
+    @Test
+    @DisplayName("of() rejects unknown types")
+    void of_rejectsUnknown() {
+        assertThrows(IllegalArgumentException.class, () -> AttributeValue.of(new Object()));
+    }
+
+    @Test
+    @DisplayName("ListValue makes a defensive copy")
+    void listValue_defensiveCopy() {
+        var mutable = new java.util.ArrayList<>(List.of("a", "b"));
+        var val = new AttributeValue.ListValue(mutable);
+        mutable.add("c");
+        assertEquals(List.of("a", "b"), val.values());
+    }
+
+    @Test
+    @DisplayName("SetValue makes a defensive copy")
+    void setValue_defensiveCopy() {
+        var mutable = new java.util.HashSet<>(Set.of("a", "b"));
+        var val = new AttributeValue.SetValue(mutable);
+        mutable.add("c");
+        assertEquals(Set.of("a", "b"), val.values());
+    }
+}

--- a/src/test/java/com/embervault/domain/TbxColorTest.java
+++ b/src/test/java/com/embervault/domain/TbxColorTest.java
@@ -1,0 +1,154 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TbxColorTest {
+
+    @Test
+    @DisplayName("hex() creates a color from a hex string")
+    void hex_createsColor() {
+        TbxColor color = TbxColor.hex("#A482BF");
+        assertEquals("#A482BF", color.toHex());
+    }
+
+    @Test
+    @DisplayName("hex() normalises to uppercase")
+    void hex_normalisesToUppercase() {
+        TbxColor color = TbxColor.hex("#a482bf");
+        assertEquals("#A482BF", color.toHex());
+    }
+
+    @Test
+    @DisplayName("hex() rejects invalid format")
+    void hex_rejectsInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> TbxColor.hex("not-a-color"));
+    }
+
+    @Test
+    @DisplayName("hex() rejects null")
+    void hex_rejectsNull() {
+        assertThrows(NullPointerException.class, () -> TbxColor.hex(null));
+    }
+
+    @Test
+    @DisplayName("named() creates a color with a name")
+    void named_createsColor() {
+        TbxColor color = TbxColor.named("red");
+        assertEquals(Optional.of("red"), color.getName());
+    }
+
+    @Test
+    @DisplayName("named() maps known names to hex values")
+    void named_mapsKnownColors() {
+        TbxColor red = TbxColor.named("red");
+        assertEquals("#FF0000", red.toHex());
+    }
+
+    @Test
+    @DisplayName("named() rejects null")
+    void named_rejectsNull() {
+        assertThrows(NullPointerException.class, () -> TbxColor.named(null));
+    }
+
+    @Test
+    @DisplayName("named() rejects blank")
+    void named_rejectsBlank() {
+        assertThrows(IllegalArgumentException.class, () -> TbxColor.named("  "));
+    }
+
+    @Test
+    @DisplayName("rgb() creates a color from RGB components")
+    void rgb_createsColor() {
+        TbxColor color = TbxColor.rgb(255, 0, 0);
+        assertEquals("#FF0000", color.toHex());
+    }
+
+    @Test
+    @DisplayName("rgb() rejects out-of-range values")
+    void rgb_rejectsOutOfRange() {
+        assertThrows(IllegalArgumentException.class, () -> TbxColor.rgb(256, 0, 0));
+        assertThrows(IllegalArgumentException.class, () -> TbxColor.rgb(-1, 0, 0));
+    }
+
+    @Test
+    @DisplayName("hsv() creates a color from HSV components")
+    void hsv_createsColor() {
+        TbxColor color = TbxColor.hsv(0, 100, 100);
+        assertEquals("#FF0000", color.toHex());
+    }
+
+    @Test
+    @DisplayName("hsv() produces correct blue")
+    void hsv_producesBlue() {
+        TbxColor color = TbxColor.hsv(240, 100, 100);
+        assertEquals("#0000FF", color.toHex());
+    }
+
+    @Test
+    @DisplayName("hsv() produces correct green")
+    void hsv_producesGreen() {
+        TbxColor color = TbxColor.hsv(120, 100, 100);
+        assertEquals("#00FF00", color.toHex());
+    }
+
+    @Test
+    @DisplayName("hsv() with zero saturation produces gray")
+    void hsv_zeroSaturationProducesGray() {
+        TbxColor color = TbxColor.hsv(0, 0, 50);
+        assertEquals("#808080", color.toHex());
+    }
+
+    @Test
+    @DisplayName("equals() is based on hex value")
+    void equals_basedOnHex() {
+        TbxColor a = TbxColor.hex("#FF0000");
+        TbxColor b = TbxColor.rgb(255, 0, 0);
+        assertEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("equals() returns false for different colors")
+    void equals_falseForDifferent() {
+        TbxColor a = TbxColor.hex("#FF0000");
+        TbxColor b = TbxColor.hex("#00FF00");
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("hashCode() is consistent with equals()")
+    void hashCode_consistentWithEquals() {
+        TbxColor a = TbxColor.hex("#FF0000");
+        TbxColor b = TbxColor.rgb(255, 0, 0);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    @DisplayName("getName() returns empty for hex-created colors")
+    void getName_emptyForHex() {
+        TbxColor color = TbxColor.hex("#A482BF");
+        assertTrue(color.getName().isEmpty());
+    }
+
+    @Test
+    @DisplayName("named() with warm gray produces valid color")
+    void named_warmGray() {
+        TbxColor color = TbxColor.named("warm gray");
+        assertEquals(Optional.of("warm gray"), color.getName());
+        assertEquals("#808080", color.toHex());
+    }
+
+    @Test
+    @DisplayName("toString() includes hex value")
+    void toString_includesHex() {
+        TbxColor color = TbxColor.hex("#A482BF");
+        assertTrue(color.toString().contains("#A482BF"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add complete type-safe attribute system with 11 Tinderbox attribute types (`AttributeType` enum, `AttributeValue` sealed interface with record variants, `TbxColor` value object)
- Add schema layer: `AttributeDefinition`, `AttributeMap` (sparse storage), `AttributeSchemaRegistry` (19 pre-populated system attributes with `$` prefix)
- Add `AttributeResolver` domain service implementing prototype-chain inheritance (local -> prototype chain -> document default), with intrinsic attributes skipping the chain
- Refactor `Note` to use `AttributeMap` internally while keeping backward-compatible `getTitle()`/`getContent()`/`getCreatedAt()`/`getUpdatedAt()` convenience methods
- All 219 tests pass, including existing tests unchanged. Checkstyle, JaCoCo (80%+ line/branch), and ArchUnit all green.

## Test plan
- [x] `AttributeTypeTest` -- all 11 types defined with correct `javaType()` mappings
- [x] `TbxColorTest` -- hex, named, RGB, HSV factory methods; equality; toString
- [x] `AttributeValueTest` -- all 11 variants; pattern matching switch; `of()` factory; defensive copies
- [x] `AttributeDefinitionTest` -- builder API; immutability; null rejection
- [x] `AttributeMapTest` -- get/set/remove/hasLocalValue/localEntries/size; copy constructor
- [x] `AttributeSchemaRegistryTest` -- system attributes; type filtering; user attribute registration
- [x] `AttributeResolverTest` -- local value, prototype inheritance, multi-level chain, intrinsic skip, removal revert
- [x] All existing `NoteTest`, `NoteServiceImplTest`, `InMemoryNoteRepositoryTest`, `NoteViewModelTest`, `ArchitectureTest` pass unchanged
- [x] `mvn verify` passes (tests + checkstyle + jacoco + archunit)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)