### PR TITLE
Enable creating new child notes in Map and Outline views

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -51,6 +51,9 @@ public class App extends Application {
         // Save root note to repository so children can reference it
         noteRepository.save(project.getRootNote());
 
+        // Create a welcome note so the views have something to display
+        noteService.createChildNote(project.getRootNote().getId(), "Welcome to EmberVault");
+
         // Observable note title for binding to ViewModels
         StringProperty rootNoteTitle = new SimpleStringProperty(
                 project.getRootNote().getTitle());
@@ -76,13 +79,25 @@ public class App extends Application {
         OutlineViewController outlineController = outlineLoader.getController();
         outlineController.initViewModel(outlineViewModel);
 
-        // Synchronize: when map creates a note, refresh outline and vice versa
+        // Synchronize: when map creates a note, refresh outline and vice versa.
+        // Use a flag to prevent infinite listener loops.
+        final boolean[] syncing = {false};
         mapViewModel.getNoteItems().addListener(
-                (javafx.collections.ListChangeListener<Object>) change ->
-                        outlineViewModel.loadNotes());
+                (javafx.collections.ListChangeListener<Object>) change -> {
+                    if (!syncing[0]) {
+                        syncing[0] = true;
+                        outlineViewModel.loadNotes();
+                        syncing[0] = false;
+                    }
+                });
         outlineViewModel.getRootItems().addListener(
-                (javafx.collections.ListChangeListener<Object>) change ->
-                        mapViewModel.loadNotes());
+                (javafx.collections.ListChangeListener<Object>) change -> {
+                    if (!syncing[0]) {
+                        syncing[0] = true;
+                        mapViewModel.loadNotes();
+                        syncing[0] = false;
+                    }
+                });
 
         // SplitPane with Map on left, Outline on right
         SplitPane splitPane = new SplitPane(mapView, outlineView);

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -6,8 +6,12 @@ import com.embervault.adapter.in.ui.view.MapViewController;
 import com.embervault.adapter.in.ui.view.OutlineViewController;
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.ProjectServiceImpl;
+import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.ProjectService;
+import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.Project;
 import javafx.application.Application;
 import javafx.beans.property.SimpleStringProperty;
@@ -29,13 +33,23 @@ public class App extends Application {
         ProjectService projectService = new ProjectServiceImpl();
         Project project = projectService.createEmptyProject();
 
+        // Create shared NoteRepository and NoteService
+        NoteRepository noteRepository = new InMemoryNoteRepository();
+        NoteService noteService = new NoteServiceImpl(noteRepository);
+
+        // Save root note to repository so children can reference it
+        noteRepository.save(project.getRootNote());
+
         // Observable note title for binding to ViewModels
         StringProperty rootNoteTitle = new SimpleStringProperty(
                 project.getRootNote().getTitle());
 
-        // Create ViewModels
-        MapViewModel mapViewModel = new MapViewModel(rootNoteTitle);
-        OutlineViewModel outlineViewModel = new OutlineViewModel(rootNoteTitle);
+        // Create ViewModels with shared NoteService
+        MapViewModel mapViewModel = new MapViewModel(rootNoteTitle, noteService);
+        mapViewModel.setBaseNoteId(project.getRootNote().getId());
+
+        OutlineViewModel outlineViewModel = new OutlineViewModel(rootNoteTitle, noteService);
+        outlineViewModel.setBaseNoteId(project.getRootNote().getId());
 
         // Load MapView
         FXMLLoader mapLoader = new FXMLLoader(getClass().getResource(
@@ -50,6 +64,14 @@ public class App extends Application {
         Parent outlineView = outlineLoader.load();
         OutlineViewController outlineController = outlineLoader.getController();
         outlineController.initViewModel(outlineViewModel);
+
+        // Synchronize: when map creates a note, refresh outline and vice versa
+        mapViewModel.getNoteItems().addListener(
+                (javafx.collections.ListChangeListener<Object>) change ->
+                        outlineViewModel.loadNotes());
+        outlineViewModel.getRootItems().addListener(
+                (javafx.collections.ListChangeListener<Object>) change ->
+                        mapViewModel.loadNotes());
 
         // SplitPane with Map on left, Outline on right
         SplitPane splitPane = new SplitPane(mapView, outlineView);

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -19,13 +19,24 @@ import javafx.beans.property.StringProperty;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.SplitPane;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Main application entry point for EmberVault.
  */
 public class App extends Application {
+
+    private static final Logger LOG = LoggerFactory.getLogger(App.class);
 
     @Override
     public void start(Stage stage) throws IOException {
@@ -77,10 +88,49 @@ public class App extends Application {
         SplitPane splitPane = new SplitPane(mapView, outlineView);
         splitPane.setDividerPositions(0.5);
 
-        Scene scene = new Scene(splitPane, 1024, 768);
+        // Menu bar
+        MenuBar menuBar = createMenuBar(mapViewModel, outlineViewModel);
+
+        // BorderPane: menu bar on top, split pane in center
+        BorderPane root = new BorderPane();
+        root.setTop(menuBar);
+        root.setCenter(splitPane);
+
+        Scene scene = new Scene(root, 1024, 768);
         stage.setTitle("EmberVault - " + project.getName());
         stage.setScene(scene);
         stage.show();
+    }
+
+    private MenuBar createMenuBar(MapViewModel mapViewModel,
+                                   OutlineViewModel outlineViewModel) {
+        // Note menu
+        MenuItem createNote = new MenuItem("Create Note");
+        createNote.setAccelerator(
+                new KeyCodeCombination(KeyCode.N, KeyCombination.SHORTCUT_DOWN));
+        createNote.setOnAction(e -> {
+            // Create a child under the selected note in the map, or under root
+            mapViewModel.createChildNote("Untitled");
+        });
+
+        Menu noteMenu = new Menu("Note");
+        noteMenu.getItems().add(createNote);
+
+        // View menu
+        MenuItem mapViewItem = new MenuItem("Map");
+        mapViewItem.setOnAction(e ->
+                LOG.debug("Map view placeholder selected"));
+
+        MenuItem outlineViewItem = new MenuItem("Outline");
+        outlineViewItem.setOnAction(e ->
+                LOG.debug("Outline view placeholder selected"));
+
+        Menu viewMenu = new Menu("View");
+        viewMenu.getItems().addAll(mapViewItem, outlineViewItem);
+
+        MenuBar menuBar = new MenuBar(noteMenu, viewMenu);
+        menuBar.setUseSystemMenuBar(true);
+        return menuBar;
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -6,7 +6,10 @@ import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Pane;
@@ -15,6 +18,8 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * FXML controller for the Map view.
@@ -25,6 +30,7 @@ import javafx.scene.text.TextAlignment;
  */
 public class MapViewController {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MapViewController.class);
     private static final double SELECTED_BORDER_WIDTH = 3.0;
     private static final double NORMAL_BORDER_WIDTH = 1.0;
     private static final double FONT_SIZE = 12.0;
@@ -63,12 +69,31 @@ public class MapViewController {
             }
         });
 
+        // Context menu
+        ContextMenu contextMenu = createContextMenu();
+        mapCanvas.setOnContextMenuRequested(event -> {
+            contextMenu.getItems().get(0).setOnAction(e ->
+                    viewModel.createChildNoteAt("Untitled", event.getX(), event.getY()));
+            contextMenu.show(mapCanvas, event.getScreenX(), event.getScreenY());
+            event.consume();
+        });
+
         mapCanvas.setFocusTraversable(true);
     }
 
     /** Returns the associated ViewModel. */
     public MapViewModel getViewModel() {
         return viewModel;
+    }
+
+    private ContextMenu createContextMenu() {
+        MenuItem createNote = new MenuItem("Create Note");
+        // Action is set dynamically in the context menu request handler to capture coordinates
+
+        MenuItem outlineView = new MenuItem("Outline View");
+        outlineView.setOnAction(e -> LOG.debug("Outline View placeholder selected"));
+
+        return new ContextMenu(createNote, new SeparatorMenuItem(), outlineView);
     }
 
     private void renderAllNotes() {

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -1,17 +1,35 @@
 package com.embervault.adapter.in.ui.view;
 
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.control.Label;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.text.Font;
+import javafx.scene.text.TextAlignment;
 
 /**
  * FXML controller for the Map view.
  *
- * <p>Contains no business logic; all state is managed by the {@link MapViewModel}.</p>
+ * <p>Renders notes as colored rectangles on a spatial canvas. Notes are
+ * draggable and selectable. New notes can be created by pressing Return
+ * or double-clicking the background.</p>
  */
 public class MapViewController {
 
-    @FXML private Label mapLabel;
+    private static final double SELECTED_BORDER_WIDTH = 3.0;
+    private static final double NORMAL_BORDER_WIDTH = 1.0;
+    private static final double FONT_SIZE = 12.0;
+
+    @FXML private Pane mapCanvas;
 
     private MapViewModel viewModel;
 
@@ -20,10 +38,125 @@ public class MapViewController {
      */
     public void initViewModel(MapViewModel viewModel) {
         this.viewModel = viewModel;
+
+        // Render existing notes
+        viewModel.loadNotes();
+        renderAllNotes();
+
+        // Re-render when note list changes
+        viewModel.getNoteItems().addListener(
+                (ListChangeListener<NoteDisplayItem>) change -> renderAllNotes());
+
+        // Double-click background to create new note
+        mapCanvas.setOnMouseClicked(event -> {
+            if (event.getClickCount() == 2
+                    && event.getButton() == MouseButton.PRIMARY
+                    && event.getTarget() == mapCanvas) {
+                viewModel.createChildNote("Untitled");
+            }
+        });
+
+        // Return key to create new note
+        mapCanvas.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                viewModel.createChildNote("Untitled");
+            }
+        });
+
+        mapCanvas.setFocusTraversable(true);
     }
 
     /** Returns the associated ViewModel. */
     public MapViewModel getViewModel() {
         return viewModel;
+    }
+
+    private void renderAllNotes() {
+        mapCanvas.getChildren().clear();
+        for (NoteDisplayItem item : viewModel.getNoteItems()) {
+            StackPane noteNode = createNoteNode(item);
+            mapCanvas.getChildren().add(noteNode);
+        }
+    }
+
+    private StackPane createNoteNode(NoteDisplayItem item) {
+        Rectangle rect = new Rectangle(item.getWidth(), item.getHeight());
+        rect.setFill(Color.web(item.getColorHex()));
+        rect.setStroke(Color.BLACK);
+        rect.setStrokeWidth(NORMAL_BORDER_WIDTH);
+        rect.setArcWidth(4);
+        rect.setArcHeight(4);
+
+        Label titleLabel = new Label(item.getTitle());
+        titleLabel.setFont(Font.font(FONT_SIZE));
+        titleLabel.setTextAlignment(TextAlignment.CENTER);
+        titleLabel.setAlignment(Pos.CENTER);
+        titleLabel.setMaxWidth(item.getWidth() - 8);
+        titleLabel.setWrapText(true);
+        titleLabel.setMouseTransparent(true);
+
+        StackPane notePane = new StackPane(rect, titleLabel);
+        notePane.setLayoutX(item.getXpos());
+        notePane.setLayoutY(item.getYpos());
+        notePane.setCursor(Cursor.HAND);
+
+        // Click to select
+        notePane.setOnMouseClicked(event -> {
+            viewModel.selectNote(item.getId());
+            highlightSelected(notePane);
+            event.consume();
+        });
+
+        // Drag support
+        enableDrag(notePane, item);
+
+        // Highlight if currently selected
+        if (item.getId().equals(viewModel.selectedNoteIdProperty().get())) {
+            rect.setStrokeWidth(SELECTED_BORDER_WIDTH);
+            rect.setStroke(Color.DODGERBLUE);
+        }
+
+        return notePane;
+    }
+
+    private void enableDrag(StackPane notePane, NoteDisplayItem item) {
+        final double[] dragDelta = new double[2];
+
+        notePane.setOnMousePressed(event -> {
+            dragDelta[0] = notePane.getLayoutX() - event.getSceneX();
+            dragDelta[1] = notePane.getLayoutY() - event.getSceneY();
+            viewModel.selectNote(item.getId());
+            highlightSelected(notePane);
+            event.consume();
+        });
+
+        notePane.setOnMouseDragged(event -> {
+            double newX = Math.max(0, event.getSceneX() + dragDelta[0]);
+            double newY = Math.max(0, event.getSceneY() + dragDelta[1]);
+            notePane.setLayoutX(newX);
+            notePane.setLayoutY(newY);
+            event.consume();
+        });
+
+        notePane.setOnMouseReleased(event -> {
+            viewModel.updateNotePosition(
+                    item.getId(), notePane.getLayoutX(), notePane.getLayoutY());
+            event.consume();
+        });
+    }
+
+    private void highlightSelected(StackPane selected) {
+        for (javafx.scene.Node child : mapCanvas.getChildren()) {
+            if (child instanceof StackPane sp && !sp.getChildren().isEmpty()
+                    && sp.getChildren().get(0) instanceof Rectangle r) {
+                r.setStrokeWidth(NORMAL_BORDER_WIDTH);
+                r.setStroke(Color.BLACK);
+            }
+        }
+        if (!selected.getChildren().isEmpty()
+                && selected.getChildren().get(0) instanceof Rectangle r) {
+            r.setStrokeWidth(SELECTED_BORDER_WIDTH);
+            r.setStroke(Color.DODGERBLUE);
+        }
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -6,11 +6,16 @@ import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.text.TextAlignment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * FXML controller for the Outline view.
@@ -19,6 +24,8 @@ import javafx.scene.text.TextAlignment;
  * New child notes can be created by pressing Return.</p>
  */
 public class OutlineViewController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OutlineViewController.class);
 
     @FXML private TreeView<NoteDisplayItem> outlineTreeView;
 
@@ -69,11 +76,24 @@ public class OutlineViewController {
                 event.consume();
             }
         });
+
+        // Context menu
+        outlineTreeView.setContextMenu(createContextMenu());
     }
 
     /** Returns the associated ViewModel. */
     public OutlineViewModel getViewModel() {
         return viewModel;
+    }
+
+    private ContextMenu createContextMenu() {
+        MenuItem createNote = new MenuItem("Create Note");
+        createNote.setOnAction(e -> createChildUnderSelected());
+
+        MenuItem mapView = new MenuItem("Map View");
+        mapView.setOnAction(e -> LOG.debug("Map View placeholder selected"));
+
+        return new ContextMenu(createNote, new SeparatorMenuItem(), mapView);
     }
 
     private void buildTree() {

--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -1,17 +1,26 @@
 package com.embervault.adapter.in.ui.view;
 
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
-import javafx.scene.control.Label;
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.text.TextAlignment;
 
 /**
  * FXML controller for the Outline view.
  *
- * <p>Contains no business logic; all state is managed by the {@link OutlineViewModel}.</p>
+ * <p>Renders notes as a hierarchical tree. Notes are selectable.
+ * New child notes can be created by pressing Return.</p>
  */
 public class OutlineViewController {
 
-    @FXML private Label outlineLabel;
+    @FXML private TreeView<NoteDisplayItem> outlineTreeView;
 
     private OutlineViewModel viewModel;
 
@@ -20,10 +29,91 @@ public class OutlineViewController {
      */
     public void initViewModel(OutlineViewModel viewModel) {
         this.viewModel = viewModel;
+
+        // Set up cell factory for single-line display with ellipsis
+        outlineTreeView.setCellFactory(tv -> new TreeCell<>() {
+            @Override
+            protected void updateItem(NoteDisplayItem item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(null);
+                } else {
+                    setText(item.getTitle());
+                    setTextAlignment(TextAlignment.LEFT);
+                }
+            }
+        });
+
+        // Load initial data
+        viewModel.loadNotes();
+        buildTree();
+
+        // Re-build tree when root items change
+        viewModel.getRootItems().addListener(
+                (ListChangeListener<NoteDisplayItem>) change -> buildTree());
+
+        // Selection listener
+        outlineTreeView.getSelectionModel().selectedItemProperty()
+                .addListener((obs, oldVal, newVal) -> {
+                    if (newVal != null && newVal.getValue() != null) {
+                        viewModel.selectNote(newVal.getValue().getId());
+                    } else {
+                        viewModel.selectNote(null);
+                    }
+                });
+
+        // Return key to create new child note under selected
+        outlineTreeView.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                createChildUnderSelected();
+                event.consume();
+            }
+        });
     }
 
     /** Returns the associated ViewModel. */
     public OutlineViewModel getViewModel() {
         return viewModel;
+    }
+
+    private void buildTree() {
+        // Root item represents the base note (hidden)
+        TreeItem<NoteDisplayItem> rootTreeItem = new TreeItem<>();
+        rootTreeItem.setExpanded(true);
+
+        for (NoteDisplayItem item : viewModel.getRootItems()) {
+            TreeItem<NoteDisplayItem> treeItem = buildTreeItem(item);
+            rootTreeItem.getChildren().add(treeItem);
+        }
+
+        outlineTreeView.setRoot(rootTreeItem);
+        outlineTreeView.setShowRoot(false);
+    }
+
+    private TreeItem<NoteDisplayItem> buildTreeItem(NoteDisplayItem item) {
+        TreeItem<NoteDisplayItem> treeItem = new TreeItem<>(item);
+        treeItem.setExpanded(true);
+
+        if (item.isHasChildren()) {
+            for (NoteDisplayItem child : viewModel.getChildren(item.getId())) {
+                treeItem.getChildren().add(buildTreeItem(child));
+            }
+        }
+
+        return treeItem;
+    }
+
+    private void createChildUnderSelected() {
+        TreeItem<NoteDisplayItem> selected = outlineTreeView.getSelectionModel()
+                .getSelectedItem();
+        UUID parentId;
+        if (selected != null && selected.getValue() != null) {
+            parentId = selected.getValue().getId();
+        } else {
+            parentId = viewModel.getBaseNoteId();
+        }
+        if (parentId != null) {
+            viewModel.createChildNote(parentId, "Untitled");
+        }
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -1,32 +1,167 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
 import java.util.Objects;
+import java.util.UUID;
 
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Note;
+import com.embervault.domain.TbxColor;
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 /**
  * ViewModel for the Map view tab.
  *
  * <p>Computes a tab title of the form "Map: &lt;note title&gt;" that updates
- * reactively when the underlying note title changes.</p>
+ * reactively when the underlying note title changes. Manages note display
+ * items for spatial rendering and supports creating child notes.</p>
  */
 public final class MapViewModel {
 
+    private static final double SCALE_X = 40.0;
+    private static final double SCALE_Y = 40.0;
+    private static final double DEFAULT_WIDTH = 6.0;
+    private static final double DEFAULT_HEIGHT = 4.0;
+    private static final String DEFAULT_COLOR_HEX = "#808080";
+
     private final ReadOnlyStringWrapper tabTitle = new ReadOnlyStringWrapper();
+    private final ObservableList<NoteDisplayItem> noteItems =
+            FXCollections.observableArrayList();
+    private final ObjectProperty<UUID> selectedNoteId =
+            new SimpleObjectProperty<>();
+    private final NoteService noteService;
+    private UUID baseNoteId;
 
     /**
      * Constructs a MapViewModel that derives its tab title from the given note title property.
+     *
+     * @param noteTitle   the observable note title
+     * @param noteService the note service for creating and querying notes
      */
-    public MapViewModel(StringProperty noteTitle) {
+    public MapViewModel(StringProperty noteTitle, NoteService noteService) {
         Objects.requireNonNull(noteTitle, "noteTitle must not be null");
+        this.noteService = Objects.requireNonNull(noteService,
+                "noteService must not be null");
         tabTitle.bind(Bindings.concat("Map: ", noteTitle));
     }
 
     /** Returns the tab title property. */
     public ReadOnlyStringProperty tabTitleProperty() {
         return tabTitle.getReadOnlyProperty();
+    }
+
+    /** Returns the observable list of note display items. */
+    public ObservableList<NoteDisplayItem> getNoteItems() {
+        return noteItems;
+    }
+
+    /** Returns the selected note id property. */
+    public ObjectProperty<UUID> selectedNoteIdProperty() {
+        return selectedNoteId;
+    }
+
+    /**
+     * Sets the base note (root container) whose children are displayed.
+     *
+     * @param noteId the base note id
+     */
+    public void setBaseNoteId(UUID noteId) {
+        this.baseNoteId = noteId;
+    }
+
+    /** Returns the base note id. */
+    public UUID getBaseNoteId() {
+        return baseNoteId;
+    }
+
+    /**
+     * Selects a note by id.
+     *
+     * @param noteId the note id to select, or null to clear selection
+     */
+    public void selectNote(UUID noteId) {
+        selectedNoteId.set(noteId);
+    }
+
+    /** Loads the children of the base note into the observable list. */
+    public void loadNotes() {
+        if (baseNoteId == null) {
+            noteItems.clear();
+            return;
+        }
+        noteItems.setAll(
+                noteService.getChildren(baseNoteId).stream()
+                        .map(MapViewModel::toDisplayItem)
+                        .toList());
+    }
+
+    /**
+     * Creates a new child note under the base note with the given title.
+     *
+     * @param title the title for the new note
+     * @return the display item for the created note
+     */
+    public NoteDisplayItem createChildNote(String title) {
+        Objects.requireNonNull(baseNoteId, "baseNoteId must be set before creating children");
+        Note child = noteService.createChildNote(baseNoteId, title);
+        NoteDisplayItem item = toDisplayItem(child);
+        noteItems.add(item);
+        return item;
+    }
+
+    /**
+     * Updates a note's position by setting its $Xpos and $Ypos attributes.
+     *
+     * @param noteId the note id
+     * @param xpos   the new x position
+     * @param ypos   the new y position
+     */
+    public void updateNotePosition(UUID noteId, double xpos, double ypos) {
+        noteService.getNote(noteId).ifPresent(note -> {
+            note.setAttribute("$Xpos", new AttributeValue.NumberValue(xpos / SCALE_X));
+            note.setAttribute("$Ypos", new AttributeValue.NumberValue(ypos / SCALE_Y));
+        });
+        // Update the display item in place
+        for (int i = 0; i < noteItems.size(); i++) {
+            NoteDisplayItem item = noteItems.get(i);
+            if (item.getId().equals(noteId)) {
+                noteItems.set(i, new NoteDisplayItem(
+                        item.getId(), item.getTitle(), item.getContent(),
+                        xpos, ypos,
+                        item.getWidth(), item.getHeight(),
+                        item.getColorHex(), item.isHasChildren()));
+                break;
+            }
+        }
+    }
+
+    private static NoteDisplayItem toDisplayItem(Note note) {
+        double xpos = note.getAttribute("$Xpos")
+                .map(v -> ((AttributeValue.NumberValue) v).value() * SCALE_X)
+                .orElse(0.0);
+        double ypos = note.getAttribute("$Ypos")
+                .map(v -> ((AttributeValue.NumberValue) v).value() * SCALE_Y)
+                .orElse(0.0);
+        double width = note.getAttribute("$Width")
+                .map(v -> ((AttributeValue.NumberValue) v).value() * SCALE_X)
+                .orElse(DEFAULT_WIDTH * SCALE_X);
+        double height = note.getAttribute("$Height")
+                .map(v -> ((AttributeValue.NumberValue) v).value() * SCALE_Y)
+                .orElse(DEFAULT_HEIGHT * SCALE_Y);
+        String colorHex = note.getAttribute("$Color")
+                .map(v -> ((AttributeValue.ColorValue) v).value())
+                .map(TbxColor::toHex)
+                .orElse(DEFAULT_COLOR_HEX);
+
+        return new NoteDisplayItem(
+                note.getId(), note.getTitle(), note.getContent(),
+                xpos, ypos, width, height, colorHex, note.hasChildren());
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -117,6 +117,24 @@ public final class MapViewModel {
     }
 
     /**
+     * Creates a new child note at the specified canvas position.
+     *
+     * @param title the title for the new note
+     * @param xpos  the x position on the canvas
+     * @param ypos  the y position on the canvas
+     * @return the display item for the created note
+     */
+    public NoteDisplayItem createChildNoteAt(String title, double xpos, double ypos) {
+        Objects.requireNonNull(baseNoteId, "baseNoteId must be set before creating children");
+        Note child = noteService.createChildNote(baseNoteId, title);
+        child.setAttribute("$Xpos", new AttributeValue.NumberValue(xpos / SCALE_X));
+        child.setAttribute("$Ypos", new AttributeValue.NumberValue(ypos / SCALE_Y));
+        NoteDisplayItem item = toDisplayItem(child);
+        noteItems.add(item);
+        return item;
+    }
+
+    /**
      * Updates a note's position by setting its $Xpos and $Ypos attributes.
      *
      * @param noteId the note id

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItem.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItem.java
@@ -14,14 +14,45 @@ public final class NoteDisplayItem {
     private final UUID id;
     private final String title;
     private final String content;
+    private final double xpos;
+    private final double ypos;
+    private final double width;
+    private final double height;
+    private final String colorHex;
+    private final boolean hasChildren;
 
     /**
      * Constructs a display item with the given id, title, and content.
      */
     public NoteDisplayItem(UUID id, String title, String content) {
+        this(id, title, content, 0, 0, 6, 4, "#808080", false);
+    }
+
+    /**
+     * Constructs a display item with full map and outline display data.
+     *
+     * @param id          the note id
+     * @param title       the note title
+     * @param content     the note content
+     * @param xpos        the x position
+     * @param ypos        the y position
+     * @param width       the width
+     * @param height      the height
+     * @param colorHex    the fill color as hex string
+     * @param hasChildren whether this note has children
+     */
+    public NoteDisplayItem(UUID id, String title, String content,
+            double xpos, double ypos, double width, double height,
+            String colorHex, boolean hasChildren) {
         this.id = Objects.requireNonNull(id, "id must not be null");
         this.title = Objects.requireNonNull(title, "title must not be null");
         this.content = Objects.requireNonNull(content, "content must not be null");
+        this.xpos = xpos;
+        this.ypos = ypos;
+        this.width = width;
+        this.height = height;
+        this.colorHex = Objects.requireNonNull(colorHex, "colorHex must not be null");
+        this.hasChildren = hasChildren;
     }
 
     /** Returns the note id. */
@@ -37,6 +68,36 @@ public final class NoteDisplayItem {
     /** Returns the content. */
     public String getContent() {
         return content;
+    }
+
+    /** Returns the x position for map rendering. */
+    public double getXpos() {
+        return xpos;
+    }
+
+    /** Returns the y position for map rendering. */
+    public double getYpos() {
+        return ypos;
+    }
+
+    /** Returns the width for map rendering. */
+    public double getWidth() {
+        return width;
+    }
+
+    /** Returns the height for map rendering. */
+    public double getHeight() {
+        return height;
+    }
+
+    /** Returns the fill color as a hex string (e.g., "#808080"). */
+    public String getColorHex() {
+        return colorHex;
+    }
+
+    /** Returns whether this note has children. */
+    public boolean isHasChildren() {
+        return hasChildren;
     }
 
     @Override

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -1,32 +1,139 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
 import java.util.Objects;
+import java.util.UUID;
 
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Note;
+import com.embervault.domain.TbxColor;
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 /**
  * ViewModel for the Outline view tab.
  *
  * <p>Computes a tab title of the form "Outline: &lt;note title&gt;" that updates
- * reactively when the underlying note title changes.</p>
+ * reactively when the underlying note title changes. Manages a tree structure
+ * of notes for hierarchical display.</p>
  */
 public final class OutlineViewModel {
 
     private final ReadOnlyStringWrapper tabTitle = new ReadOnlyStringWrapper();
+    private final ObservableList<NoteDisplayItem> rootItems =
+            FXCollections.observableArrayList();
+    private final ObjectProperty<UUID> selectedNoteId =
+            new SimpleObjectProperty<>();
+    private final NoteService noteService;
+    private UUID baseNoteId;
 
     /**
      * Constructs an OutlineViewModel that derives its tab title from the given note title property.
+     *
+     * @param noteTitle   the observable note title
+     * @param noteService the note service for creating and querying notes
      */
-    public OutlineViewModel(StringProperty noteTitle) {
+    public OutlineViewModel(StringProperty noteTitle, NoteService noteService) {
         Objects.requireNonNull(noteTitle, "noteTitle must not be null");
+        this.noteService = Objects.requireNonNull(noteService,
+                "noteService must not be null");
         tabTitle.bind(Bindings.concat("Outline: ", noteTitle));
     }
 
     /** Returns the tab title property. */
     public ReadOnlyStringProperty tabTitleProperty() {
         return tabTitle.getReadOnlyProperty();
+    }
+
+    /** Returns the observable list of root-level note display items. */
+    public ObservableList<NoteDisplayItem> getRootItems() {
+        return rootItems;
+    }
+
+    /** Returns the selected note id property. */
+    public ObjectProperty<UUID> selectedNoteIdProperty() {
+        return selectedNoteId;
+    }
+
+    /**
+     * Sets the base note (root container) whose children are displayed.
+     *
+     * @param noteId the base note id
+     */
+    public void setBaseNoteId(UUID noteId) {
+        this.baseNoteId = noteId;
+    }
+
+    /** Returns the base note id. */
+    public UUID getBaseNoteId() {
+        return baseNoteId;
+    }
+
+    /**
+     * Selects a note by id.
+     *
+     * @param noteId the note id to select, or null to clear selection
+     */
+    public void selectNote(UUID noteId) {
+        selectedNoteId.set(noteId);
+    }
+
+    /** Loads the children of the base note into the observable list. */
+    public void loadNotes() {
+        if (baseNoteId == null) {
+            rootItems.clear();
+            return;
+        }
+        rootItems.setAll(
+                noteService.getChildren(baseNoteId).stream()
+                        .map(OutlineViewModel::toDisplayItem)
+                        .toList());
+    }
+
+    /**
+     * Creates a new child note under the given parent with the given title.
+     *
+     * @param parentId the parent note id
+     * @param title    the title for the new note
+     * @return the display item for the created note
+     */
+    public NoteDisplayItem createChildNote(UUID parentId, String title) {
+        Note child = noteService.createChildNote(parentId, title);
+        NoteDisplayItem item = toDisplayItem(child);
+        // Add to root items if parent is the base note
+        if (parentId.equals(baseNoteId)) {
+            rootItems.add(item);
+        }
+        return item;
+    }
+
+    /**
+     * Returns the children of the given note as display items.
+     *
+     * @param parentId the parent note id
+     * @return the list of child display items
+     */
+    public ObservableList<NoteDisplayItem> getChildren(UUID parentId) {
+        return FXCollections.observableArrayList(
+                noteService.getChildren(parentId).stream()
+                        .map(OutlineViewModel::toDisplayItem)
+                        .toList());
+    }
+
+    private static NoteDisplayItem toDisplayItem(Note note) {
+        String colorHex = note.getAttribute("$Color")
+                .map(v -> ((AttributeValue.ColorValue) v).value())
+                .map(TbxColor::toHex)
+                .orElse("#808080");
+
+        return new NoteDisplayItem(
+                note.getId(), note.getTitle(), note.getContent(),
+                0, 0, 0, 0, colorHex, note.hasChildren());
     }
 }

--- a/src/main/java/com/embervault/adapter/out/persistence/InMemoryNoteRepository.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/InMemoryNoteRepository.java
@@ -34,6 +34,18 @@ public final class InMemoryNoteRepository implements NoteRepository {
     }
 
     @Override
+    public List<Note> findChildren(UUID parentId) {
+        Note parent = store.get(parentId);
+        if (parent == null) {
+            return List.of();
+        }
+        return parent.getChildIds().stream()
+                .map(store::get)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+    }
+
+    @Override
     public void delete(UUID id) {
         store.remove(id);
     }

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -4,10 +4,12 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 
 /**
@@ -17,14 +19,29 @@ import com.embervault.domain.Note;
  */
 public final class NoteServiceImpl implements NoteService {
 
+    private static final double MAX_XPOS = 500.0;
+    private static final double MAX_YPOS = 400.0;
+
     private final NoteRepository repository;
+    private final Random random;
 
     /**
      * Constructs a NoteServiceImpl backed by the given repository.
      */
     public NoteServiceImpl(NoteRepository repository) {
+        this(repository, new Random());
+    }
+
+    /**
+     * Constructs a NoteServiceImpl backed by the given repository and random source.
+     *
+     * @param repository the repository
+     * @param random     the random source for position generation
+     */
+    public NoteServiceImpl(NoteRepository repository, Random random) {
         this.repository = Objects.requireNonNull(repository,
                 "repository must not be null");
+        this.random = Objects.requireNonNull(random, "random must not be null");
     }
 
     @Override
@@ -50,6 +67,30 @@ public final class NoteServiceImpl implements NoteService {
                         "Note not found: " + id));
         note.update(title, content);
         return repository.save(note);
+    }
+
+    @Override
+    public Note createChildNote(UUID parentId, String title) {
+        Note parent = repository.findById(parentId)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Parent note not found: " + parentId));
+
+        Note child = Note.create(title, "");
+        child.setAttribute("$Xpos",
+                new AttributeValue.NumberValue(random.nextDouble() * MAX_XPOS));
+        child.setAttribute("$Ypos",
+                new AttributeValue.NumberValue(random.nextDouble() * MAX_YPOS));
+
+        repository.save(child);
+        parent.addChild(child.getId());
+        repository.save(parent);
+
+        return child;
+    }
+
+    @Override
+    public List<Note> getChildren(UUID parentId) {
+        return repository.findChildren(parentId);
     }
 
     @Override

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -19,8 +19,8 @@ import com.embervault.domain.Note;
  */
 public final class NoteServiceImpl implements NoteService {
 
-    private static final double MAX_XPOS = 500.0;
-    private static final double MAX_YPOS = 400.0;
+    private static final double MAX_XPOS = 12.0;
+    private static final double MAX_YPOS = 8.0;
 
     private final NoteRepository repository;
     private final Random random;

--- a/src/main/java/com/embervault/application/port/in/NoteService.java
+++ b/src/main/java/com/embervault/application/port/in/NoteService.java
@@ -32,6 +32,23 @@ public interface NoteService {
     Note updateNote(UUID id, String title, String content);
 
     /**
+     * Creates a new child note under the given parent.
+     *
+     * @param parentId the parent note id
+     * @param title    the title for the new note
+     * @return the newly created child note
+     */
+    Note createChildNote(UUID parentId, String title);
+
+    /**
+     * Returns the children of the note with the given id.
+     *
+     * @param parentId the parent note id
+     * @return the list of child notes
+     */
+    List<Note> getChildren(UUID parentId);
+
+    /**
      * Deletes the note with the given id.
      */
     void deleteNote(UUID id);

--- a/src/main/java/com/embervault/application/port/out/NoteRepository.java
+++ b/src/main/java/com/embervault/application/port/out/NoteRepository.java
@@ -27,6 +27,14 @@ public interface NoteRepository {
     List<Note> findAll();
 
     /**
+     * Returns the children of the note with the given parent id.
+     *
+     * @param parentId the parent note id
+     * @return the list of child notes
+     */
+    List<Note> findChildren(UUID parentId);
+
+    /**
      * Deletes the note with the given id.
      */
     void delete(UUID id);

--- a/src/main/java/com/embervault/domain/Note.java
+++ b/src/main/java/com/embervault/domain/Note.java
@@ -1,6 +1,9 @@
 package com.embervault.domain;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,6 +20,7 @@ public final class Note {
 
     private final UUID id;
     private final AttributeMap attributes;
+    private final List<UUID> childIds;
     private UUID prototypeId;
 
     /**
@@ -30,6 +34,7 @@ public final class Note {
         Objects.requireNonNull(attributes, "attributes must not be null");
         this.id = id;
         this.attributes = attributes;
+        this.childIds = new ArrayList<>();
     }
 
     /**
@@ -51,6 +56,7 @@ public final class Note {
         }
 
         this.id = id;
+        this.childIds = new ArrayList<>();
         this.attributes = new AttributeMap();
         this.attributes.set("$Name", new AttributeValue.StringValue(title));
         this.attributes.set("$Text", new AttributeValue.StringValue(content));
@@ -155,6 +161,43 @@ public final class Note {
      */
     public void setPrototypeId(UUID protoId) {
         this.prototypeId = protoId;
+    }
+
+    /**
+     * Adds a child note id to the end of the children list.
+     *
+     * @param childId the child note id
+     */
+    public void addChild(UUID childId) {
+        Objects.requireNonNull(childId, "childId must not be null");
+        childIds.add(childId);
+    }
+
+    /**
+     * Removes a child note id from the children list.
+     *
+     * @param childId the child note id
+     */
+    public void removeChild(UUID childId) {
+        childIds.remove(childId);
+    }
+
+    /**
+     * Returns an unmodifiable view of the child note ids.
+     *
+     * @return unmodifiable list of child ids
+     */
+    public List<UUID> getChildIds() {
+        return Collections.unmodifiableList(childIds);
+    }
+
+    /**
+     * Returns whether this note has any children.
+     *
+     * @return true if this note has children
+     */
+    public boolean hasChildren() {
+        return !childIds.isEmpty();
     }
 
     /**

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module com.embervault {
     requires javafx.controls;
     requires javafx.fxml;
+    requires org.slf4j;
 
     opens com.embervault to javafx.fxml;
     exports com.embervault;

--- a/src/main/resources/com/embervault/adapter/in/ui/view/MapView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/MapView.fxml
@@ -6,5 +6,6 @@
 <StackPane xmlns:fx="http://javafx.com/fxml"
            fx:controller="com.embervault.adapter.in.ui.view.MapViewController">
 
-    <Pane fx:id="mapCanvas" style="-fx-background-color: #F5F5F5;"/>
+    <Pane fx:id="mapCanvas" style="-fx-background-color: #F5F5F5;"
+          minWidth="400" minHeight="300"/>
 </StackPane>

--- a/src/main/resources/com/embervault/adapter/in/ui/view/MapView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/MapView.fxml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane xmlns:fx="http://javafx.com/fxml"
            fx:controller="com.embervault.adapter.in.ui.view.MapViewController">
-    <padding>
-        <Insets top="10" right="10" bottom="10" left="10"/>
-    </padding>
 
-    <Label fx:id="mapLabel" text="Map View" style="-fx-font-size: 18;"/>
+    <Pane fx:id="mapCanvas" style="-fx-background-color: #F5F5F5;"/>
 </StackPane>

--- a/src/main/resources/com/embervault/adapter/in/ui/view/OutlineView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/OutlineView.fxml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TreeView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox alignment="CENTER" xmlns:fx="http://javafx.com/fxml"
+<VBox xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.embervault.adapter.in.ui.view.OutlineViewController">
-    <padding>
-        <Insets top="10" right="10" bottom="10" left="10"/>
-    </padding>
 
-    <Label fx:id="outlineLabel" text="Outline View" style="-fx-font-size: 18;"/>
+    <TreeView fx:id="outlineTreeView" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
@@ -1,30 +1,48 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MapViewModelTest {
 
+    private MapViewModel viewModel;
+    private NoteService noteService;
+    private InMemoryNoteRepository repository;
+    private StringProperty noteTitle;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        noteTitle = new SimpleStringProperty("My Note");
+        viewModel = new MapViewModel(noteTitle, noteService);
+    }
+
     @Test
     @DisplayName("tabTitle reflects the note title with Map prefix")
     void tabTitle_shouldReflectNoteTitleWithMapPrefix() {
-        StringProperty noteTitle = new SimpleStringProperty("My Note");
-        MapViewModel viewModel = new MapViewModel(noteTitle);
-
         assertEquals("Map: My Note", viewModel.tabTitleProperty().get());
     }
 
     @Test
     @DisplayName("tabTitle updates when note title changes")
     void tabTitle_shouldUpdateWhenNoteTitleChanges() {
-        StringProperty noteTitle = new SimpleStringProperty("Original");
-        MapViewModel viewModel = new MapViewModel(noteTitle);
-
         noteTitle.set("Updated");
 
         assertEquals("Map: Updated", viewModel.tabTitleProperty().get());
@@ -34,6 +52,120 @@ class MapViewModelTest {
     @DisplayName("Constructor rejects null noteTitle")
     void constructor_shouldRejectNullNoteTitle() {
         assertThrows(NullPointerException.class,
-                () -> new MapViewModel(null));
+                () -> new MapViewModel(null, noteService));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null noteService")
+    void constructor_shouldRejectNullNoteService() {
+        assertThrows(NullPointerException.class,
+                () -> new MapViewModel(noteTitle, null));
+    }
+
+    @Test
+    @DisplayName("loadNotes() populates items from base note children")
+    void loadNotes_shouldPopulateFromBaseNoteChildren() {
+        Note parent = noteService.createNote("Parent", "");
+        noteService.createChildNote(parent.getId(), "Child1");
+        noteService.createChildNote(parent.getId(), "Child2");
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        assertEquals(2, viewModel.getNoteItems().size());
+        assertEquals("Child1", viewModel.getNoteItems().get(0).getTitle());
+        assertEquals("Child2", viewModel.getNoteItems().get(1).getTitle());
+    }
+
+    @Test
+    @DisplayName("loadNotes() clears items when baseNoteId is null")
+    void loadNotes_shouldClearWhenBaseNoteIdNull() {
+        viewModel.loadNotes();
+
+        assertTrue(viewModel.getNoteItems().isEmpty());
+    }
+
+    @Test
+    @DisplayName("createChildNote() adds item to list and returns it")
+    void createChildNote_shouldAddAndReturn() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+
+        NoteDisplayItem item = viewModel.createChildNote("New Child");
+
+        assertNotNull(item);
+        assertEquals("New Child", item.getTitle());
+        assertEquals(1, viewModel.getNoteItems().size());
+        assertEquals(item, viewModel.getNoteItems().get(0));
+    }
+
+    @Test
+    @DisplayName("createChildNote() sets position values on display item")
+    void createChildNote_shouldSetPosition() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+
+        NoteDisplayItem item = viewModel.createChildNote("Child");
+
+        // Positions should be set (scaled from attribute values)
+        assertTrue(item.getXpos() >= 0);
+        assertTrue(item.getYpos() >= 0);
+    }
+
+    @Test
+    @DisplayName("selectNote() sets selectedNoteId")
+    void selectNote_shouldSetSelectedNoteId() {
+        UUID noteId = UUID.randomUUID();
+
+        viewModel.selectNote(noteId);
+
+        assertEquals(noteId, viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("selectNote(null) clears selection")
+    void selectNote_null_shouldClearSelection() {
+        viewModel.selectNote(UUID.randomUUID());
+
+        viewModel.selectNote(null);
+
+        assertNull(viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("updateNotePosition() updates display item position")
+    void updateNotePosition_shouldUpdateDisplayItem() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        NoteDisplayItem item = viewModel.createChildNote("Child");
+
+        viewModel.updateNotePosition(item.getId(), 100.0, 200.0);
+
+        NoteDisplayItem updated = viewModel.getNoteItems().get(0);
+        assertEquals(100.0, updated.getXpos(), 0.01);
+        assertEquals(200.0, updated.getYpos(), 0.01);
+    }
+
+    @Test
+    @DisplayName("setBaseNoteId and getBaseNoteId work correctly")
+    void baseNoteId_shouldBeSettableAndGettable() {
+        UUID id = UUID.randomUUID();
+        viewModel.setBaseNoteId(id);
+
+        assertEquals(id, viewModel.getBaseNoteId());
+    }
+
+    @Test
+    @DisplayName("loadNotes() includes color hex from note attributes")
+    void loadNotes_shouldIncludeColorHex() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.createChildNote("Child");
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getNoteItems().get(0);
+        assertNotNull(item.getColorHex());
+        assertFalse(item.getColorHex().isEmpty());
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -1,30 +1,48 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.ObservableList;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class OutlineViewModelTest {
 
+    private OutlineViewModel viewModel;
+    private NoteService noteService;
+    private InMemoryNoteRepository repository;
+    private StringProperty noteTitle;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        noteTitle = new SimpleStringProperty("My Note");
+        viewModel = new OutlineViewModel(noteTitle, noteService);
+    }
+
     @Test
     @DisplayName("tabTitle reflects the note title with Outline prefix")
     void tabTitle_shouldReflectNoteTitleWithOutlinePrefix() {
-        StringProperty noteTitle = new SimpleStringProperty("My Note");
-        OutlineViewModel viewModel = new OutlineViewModel(noteTitle);
-
         assertEquals("Outline: My Note", viewModel.tabTitleProperty().get());
     }
 
     @Test
     @DisplayName("tabTitle updates when note title changes")
     void tabTitle_shouldUpdateWhenNoteTitleChanges() {
-        StringProperty noteTitle = new SimpleStringProperty("Original");
-        OutlineViewModel viewModel = new OutlineViewModel(noteTitle);
-
         noteTitle.set("Updated");
 
         assertEquals("Outline: Updated", viewModel.tabTitleProperty().get());
@@ -34,6 +52,107 @@ class OutlineViewModelTest {
     @DisplayName("Constructor rejects null noteTitle")
     void constructor_shouldRejectNullNoteTitle() {
         assertThrows(NullPointerException.class,
-                () -> new OutlineViewModel(null));
+                () -> new OutlineViewModel(null, noteService));
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null noteService")
+    void constructor_shouldRejectNullNoteService() {
+        assertThrows(NullPointerException.class,
+                () -> new OutlineViewModel(noteTitle, null));
+    }
+
+    @Test
+    @DisplayName("loadNotes() populates root items from base note children")
+    void loadNotes_shouldPopulateRootItems() {
+        Note parent = noteService.createNote("Parent", "");
+        noteService.createChildNote(parent.getId(), "Child1");
+        noteService.createChildNote(parent.getId(), "Child2");
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        assertEquals(2, viewModel.getRootItems().size());
+        assertEquals("Child1", viewModel.getRootItems().get(0).getTitle());
+        assertEquals("Child2", viewModel.getRootItems().get(1).getTitle());
+    }
+
+    @Test
+    @DisplayName("loadNotes() clears items when baseNoteId is null")
+    void loadNotes_shouldClearWhenBaseNoteIdNull() {
+        viewModel.loadNotes();
+
+        assertTrue(viewModel.getRootItems().isEmpty());
+    }
+
+    @Test
+    @DisplayName("createChildNote() under base note adds to root items")
+    void createChildNote_underBaseNote_shouldAddToRootItems() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+
+        NoteDisplayItem item = viewModel.createChildNote(parent.getId(), "New Child");
+
+        assertNotNull(item);
+        assertEquals("New Child", item.getTitle());
+        assertEquals(1, viewModel.getRootItems().size());
+    }
+
+    @Test
+    @DisplayName("createChildNote() under non-base note does not add to root items")
+    void createChildNote_underNonBaseNote_shouldNotAddToRootItems() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        viewModel.setBaseNoteId(parent.getId());
+
+        NoteDisplayItem grandchild = viewModel.createChildNote(child.getId(), "Grandchild");
+
+        assertNotNull(grandchild);
+        assertEquals("Grandchild", grandchild.getTitle());
+        // Grandchild should not appear in root items since its parent is not the base note
+        assertTrue(viewModel.getRootItems().isEmpty());
+    }
+
+    @Test
+    @DisplayName("selectNote() sets selectedNoteId")
+    void selectNote_shouldSetSelectedNoteId() {
+        UUID noteId = UUID.randomUUID();
+
+        viewModel.selectNote(noteId);
+
+        assertEquals(noteId, viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("selectNote(null) clears selection")
+    void selectNote_null_shouldClearSelection() {
+        viewModel.selectNote(UUID.randomUUID());
+
+        viewModel.selectNote(null);
+
+        assertNull(viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("getChildren() returns display items for child notes")
+    void getChildren_shouldReturnChildDisplayItems() {
+        Note parent = noteService.createNote("Parent", "");
+        noteService.createChildNote(parent.getId(), "Child1");
+        noteService.createChildNote(parent.getId(), "Child2");
+
+        ObservableList<NoteDisplayItem> children = viewModel.getChildren(parent.getId());
+
+        assertEquals(2, children.size());
+        assertEquals("Child1", children.get(0).getTitle());
+        assertEquals("Child2", children.get(1).getTitle());
+    }
+
+    @Test
+    @DisplayName("setBaseNoteId and getBaseNoteId work correctly")
+    void baseNoteId_shouldBeSettableAndGettable() {
+        UUID id = UUID.randomUUID();
+        viewModel.setBaseNoteId(id);
+
+        assertEquals(id, viewModel.getBaseNoteId());
     }
 }

--- a/src/test/java/com/embervault/adapter/out/persistence/InMemoryNoteRepositoryTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/InMemoryNoteRepositoryTest.java
@@ -96,4 +96,44 @@ class InMemoryNoteRepositoryTest {
         assertEquals("New", found.getTitle());
         assertEquals("New content", found.getContent());
     }
+
+    @Test
+    @DisplayName("findChildren() returns children of a parent note")
+    void findChildren_shouldReturnChildren() {
+        Note parent = Note.create("Parent", "");
+        Note child1 = Note.create("Child1", "");
+        Note child2 = Note.create("Child2", "");
+
+        parent.addChild(child1.getId());
+        parent.addChild(child2.getId());
+
+        repository.save(parent);
+        repository.save(child1);
+        repository.save(child2);
+
+        List<Note> children = repository.findChildren(parent.getId());
+
+        assertEquals(2, children.size());
+        assertEquals(child1, children.get(0));
+        assertEquals(child2, children.get(1));
+    }
+
+    @Test
+    @DisplayName("findChildren() returns empty list for unknown parent")
+    void findChildren_shouldReturnEmptyForUnknownParent() {
+        List<Note> children = repository.findChildren(UUID.randomUUID());
+
+        assertTrue(children.isEmpty());
+    }
+
+    @Test
+    @DisplayName("findChildren() returns empty list for parent with no children")
+    void findChildren_shouldReturnEmptyForParentWithNoChildren() {
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
+
+        List<Note> children = repository.findChildren(parent.getId());
+
+        assertTrue(children.isEmpty());
+    }
 }

--- a/src/test/java/com/embervault/application/NoteServiceImplTest.java
+++ b/src/test/java/com/embervault/application/NoteServiceImplTest.java
@@ -8,10 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -95,5 +97,73 @@ class NoteServiceImplTest {
         service.deleteNote(created.getId());
 
         assertTrue(service.getNote(created.getId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("createChildNote() creates a child and links to parent")
+    void createChildNote_shouldCreateAndLink() {
+        Note parent = service.createNote("Parent", "");
+
+        Note child = service.createChildNote(parent.getId(), "Child");
+
+        assertNotNull(child);
+        assertEquals("Child", child.getTitle());
+        assertTrue(repository.findById(child.getId()).isPresent());
+
+        Note updatedParent = repository.findById(parent.getId()).orElseThrow();
+        assertTrue(updatedParent.getChildIds().contains(child.getId()));
+    }
+
+    @Test
+    @DisplayName("createChildNote() sets random Xpos and Ypos")
+    void createChildNote_shouldSetRandomPosition() {
+        // Use a seeded random for deterministic test
+        Random seeded = new Random(42L);
+        NoteService seededService = new NoteServiceImpl(repository, seeded);
+
+        Note parent = seededService.createNote("Parent", "");
+        Note child = seededService.createChildNote(parent.getId(), "Child");
+
+        Optional<AttributeValue> xpos = child.getAttribute("$Xpos");
+        Optional<AttributeValue> ypos = child.getAttribute("$Ypos");
+
+        assertTrue(xpos.isPresent());
+        assertTrue(ypos.isPresent());
+
+        double x = ((AttributeValue.NumberValue) xpos.get()).value();
+        double y = ((AttributeValue.NumberValue) ypos.get()).value();
+        assertTrue(x >= 0 && x <= 500, "Xpos should be 0-500, was " + x);
+        assertTrue(y >= 0 && y <= 400, "Ypos should be 0-400, was " + y);
+    }
+
+    @Test
+    @DisplayName("createChildNote() throws when parent does not exist")
+    void createChildNote_shouldThrowForMissingParent() {
+        assertThrows(NoSuchElementException.class,
+                () -> service.createChildNote(UUID.randomUUID(), "Child"));
+    }
+
+    @Test
+    @DisplayName("getChildren() returns children of a parent note")
+    void getChildren_shouldReturnChildren() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+        Note child2 = service.createChildNote(parent.getId(), "Child2");
+
+        List<Note> children = service.getChildren(parent.getId());
+
+        assertEquals(2, children.size());
+        assertEquals(child1, children.get(0));
+        assertEquals(child2, children.get(1));
+    }
+
+    @Test
+    @DisplayName("getChildren() returns empty for note with no children")
+    void getChildren_shouldReturnEmptyForNoChildren() {
+        Note parent = service.createNote("Parent", "");
+
+        List<Note> children = service.getChildren(parent.getId());
+
+        assertTrue(children.isEmpty());
     }
 }

--- a/src/test/java/com/embervault/domain/NoteTest.java
+++ b/src/test/java/com/embervault/domain/NoteTest.java
@@ -1,12 +1,14 @@
 package com.embervault.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -187,5 +189,94 @@ class NoteTest {
 
         assertTrue(str.contains(note.getId().toString()));
         assertTrue(str.contains("Test"));
+    }
+
+    // --- Child note tests ---
+
+    @Test
+    @DisplayName("new note has no children")
+    void newNote_shouldHaveNoChildren() {
+        Note note = Note.create("Title", "Content");
+
+        assertTrue(note.getChildIds().isEmpty());
+        assertFalse(note.hasChildren());
+    }
+
+    @Test
+    @DisplayName("addChild() adds a child id to the list")
+    void addChild_shouldAddChildId() {
+        Note note = Note.create("Parent", "");
+        UUID childId = UUID.randomUUID();
+
+        note.addChild(childId);
+
+        assertEquals(1, note.getChildIds().size());
+        assertEquals(childId, note.getChildIds().get(0));
+        assertTrue(note.hasChildren());
+    }
+
+    @Test
+    @DisplayName("addChild() preserves order")
+    void addChild_shouldPreserveOrder() {
+        Note note = Note.create("Parent", "");
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+
+        note.addChild(first);
+        note.addChild(second);
+
+        assertEquals(List.of(first, second), note.getChildIds());
+    }
+
+    @Test
+    @DisplayName("addChild() rejects null")
+    void addChild_shouldRejectNull() {
+        Note note = Note.create("Parent", "");
+
+        assertThrows(NullPointerException.class, () -> note.addChild(null));
+    }
+
+    @Test
+    @DisplayName("removeChild() removes a child id")
+    void removeChild_shouldRemoveChildId() {
+        Note note = Note.create("Parent", "");
+        UUID childId = UUID.randomUUID();
+        note.addChild(childId);
+
+        note.removeChild(childId);
+
+        assertTrue(note.getChildIds().isEmpty());
+        assertFalse(note.hasChildren());
+    }
+
+    @Test
+    @DisplayName("removeChild() is safe for unknown ids")
+    void removeChild_shouldBeSafeForUnknownId() {
+        Note note = Note.create("Parent", "");
+
+        note.removeChild(UUID.randomUUID());
+
+        assertTrue(note.getChildIds().isEmpty());
+    }
+
+    @Test
+    @DisplayName("getChildIds() returns unmodifiable list")
+    void getChildIds_shouldReturnUnmodifiableList() {
+        Note note = Note.create("Parent", "");
+        note.addChild(UUID.randomUUID());
+
+        List<UUID> children = note.getChildIds();
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> children.add(UUID.randomUUID()));
+    }
+
+    @Test
+    @DisplayName("Note created with AttributeMap constructor has empty children")
+    void attributeMapConstructor_shouldHaveEmptyChildren() {
+        Note note = new Note(UUID.randomUUID(), new AttributeMap());
+
+        assertTrue(note.getChildIds().isEmpty());
+        assertFalse(note.hasChildren());
     }
 }


### PR DESCRIPTION
## Summary
- Add parent-child relationships to `Note` entity with ordered child ID list (`addChild`, `removeChild`, `getChildIds`, `hasChildren`)
- Add `createChildNote(parentId, title)` to `NoteService` with random `$Xpos`/`$Ypos` for map placement
- Add `findChildren(parentId)` to `NoteRepository` and `InMemoryNoteRepository`
- Map view renders child notes as draggable, selectable colored rectangles positioned spatially
- Outline view renders child notes as a `TreeView` hierarchy with expand/collapse disclosure triangles
- Both views stay synchronized via shared `NoteService` and observable list listeners
- `NoteDisplayItem` extended with position, size, color, and children metadata for view rendering

## Test plan
- [x] 254 tests pass (35 new tests added, all 219 existing tests still pass)
- [x] Checkstyle clean (0 violations)
- [x] JaCoCo coverage thresholds met (80% line and branch)
- [x] ArchUnit architecture rules pass (domain isolation, ViewModel/View separation)
- [ ] Manual: create child note via Return key in Map view
- [ ] Manual: create child note via double-click on Map background
- [ ] Manual: create child note via Return key in Outline view
- [ ] Manual: drag note rectangles in Map view to reposition
- [ ] Manual: verify both views synchronize when a note is created

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)