### PR TITLE
Refine title editing and navigation in Map and Outline views

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -215,9 +215,13 @@ public class MapViewController {
             }
         });
 
-        // Cancel on focus lost
+        // Commit on focus lost (same as pressing Enter)
         textField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
             if (!isFocused && notePane.getChildren().contains(textField)) {
+                String newTitle = textField.getText().trim();
+                if (!newTitle.isEmpty() && viewModel.renameNote(item.getId(), newTitle)) {
+                    titleLabel.setText(newTitle);
+                }
                 notePane.getChildren().remove(textField);
                 if (!notePane.getChildren().contains(titleLabel)) {
                     notePane.getChildren().add(titleLabel);

--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -6,6 +6,7 @@ import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
@@ -14,22 +15,27 @@ import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.VBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * FXML controller for the Outline view.
  *
- * <p>Renders notes as a hierarchical tree. Notes are selectable.
- * New child notes can be created by pressing Return.</p>
+ * <p>Renders notes as a hierarchical tree. Single-clicking an already-selected
+ * note starts inline editing. Double-clicking drills down into a note.
+ * Focus lost on the edit field commits the change; Escape cancels.</p>
  */
 public class OutlineViewController {
 
     private static final Logger LOG = LoggerFactory.getLogger(OutlineViewController.class);
 
     @FXML private TreeView<NoteDisplayItem> outlineTreeView;
+    @FXML private VBox outlineRoot;
 
     private OutlineViewModel viewModel;
+    private Button backButton;
 
     /**
      * Injects the ViewModel and binds UI controls to its properties.
@@ -37,11 +43,19 @@ public class OutlineViewController {
     public void initViewModel(OutlineViewModel viewModel) {
         this.viewModel = viewModel;
 
-        // Enable editing on the tree view
-        outlineTreeView.setEditable(true);
+        // Back navigation button
+        backButton = new Button("\u2190 Back");
+        backButton.setVisible(false);
+        backButton.setOnAction(e -> viewModel.navigateBack());
+        viewModel.canNavigateBackProperty().addListener(
+                (obs, oldVal, newVal) -> backButton.setVisible(newVal));
+        outlineRoot.getChildren().add(0, backButton);
 
-        // Set up cell factory with editable support
-        outlineTreeView.setCellFactory(tv -> new EditableNoteTreeCell());
+        // Do NOT use TreeView's built-in edit mode
+        outlineTreeView.setEditable(false);
+
+        // Set up cell factory with custom click handling
+        outlineTreeView.setCellFactory(tv -> new ClickToEditNoteTreeCell());
 
         // Load initial data
         viewModel.loadNotes();
@@ -61,10 +75,14 @@ public class OutlineViewController {
                     }
                 });
 
-        // Return key to create new child note under selected
+        // Key handling: Enter creates child, Escape navigates back
         outlineTreeView.setOnKeyPressed(event -> {
             if (event.getCode() == KeyCode.ENTER) {
                 createChildUnderSelected();
+                event.consume();
+            } else if (event.getCode() == KeyCode.ESCAPE
+                    && viewModel.canNavigateBackProperty().get()) {
+                viewModel.navigateBack();
                 event.consume();
             }
         });
@@ -130,30 +148,55 @@ public class OutlineViewController {
     }
 
     /**
-     * Custom TreeCell that supports inline editing of note titles.
+     * Custom TreeCell that uses single-click on a selected item to edit,
+     * and double-click to drill down. Focus lost on the edit field commits changes.
      */
-    private final class EditableNoteTreeCell extends TreeCell<NoteDisplayItem> {
+    private final class ClickToEditNoteTreeCell extends TreeCell<NoteDisplayItem> {
 
         private TextField textField;
+        private boolean editing;
 
-        @Override
-        public void startEdit() {
-            super.startEdit();
+        ClickToEditNoteTreeCell() {
+            setOnMouseClicked(event -> {
+                if (event.getButton() != MouseButton.PRIMARY || isEmpty() || getItem() == null) {
+                    return;
+                }
+
+                if (event.getClickCount() == 2) {
+                    // Double-click -> drill down
+                    viewModel.drillDown(getItem().getId());
+                    event.consume();
+                } else if (event.getClickCount() == 1 && isSelected() && !editing) {
+                    // Single click on already-selected item -> start editing
+                    startInlineEdit();
+                    event.consume();
+                }
+            });
+        }
+
+        private void startInlineEdit() {
             if (getItem() == null) {
                 return;
             }
+            editing = true;
             textField = new TextField(getItem().getTitle());
             textField.selectAll();
-            textField.setOnAction(e -> commitEdit(getItem()));
+
+            // Commit on Enter
+            textField.setOnAction(e -> commitInlineEdit());
+
+            // Cancel on Escape
             textField.setOnKeyPressed(e -> {
                 if (e.getCode() == KeyCode.ESCAPE) {
-                    cancelEdit();
+                    cancelInlineEdit();
                     e.consume();
                 }
             });
+
+            // Commit on focus lost
             textField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-                if (!isFocused) {
-                    cancelEdit();
+                if (!isFocused && editing) {
+                    commitInlineEdit();
                 }
             });
 
@@ -162,24 +205,35 @@ public class OutlineViewController {
             textField.requestFocus();
         }
 
-        @Override
-        public void commitEdit(NoteDisplayItem item) {
-            String newTitle = textField.getText().trim();
-            if (!newTitle.isEmpty()) {
-                viewModel.renameNote(item.getId(), newTitle);
+        private void commitInlineEdit() {
+            if (!editing) {
+                return;
             }
-            super.commitEdit(item);
-            setText(item.getTitle());
+            editing = false;
+            NoteDisplayItem item = getItem();
+            if (item != null && textField != null) {
+                String newTitle = textField.getText().trim();
+                if (!newTitle.isEmpty()) {
+                    viewModel.renameNote(item.getId(), newTitle);
+                }
+            }
+            if (item != null) {
+                setText(item.getTitle());
+            }
             setGraphic(null);
+            textField = null;
         }
 
-        @Override
-        public void cancelEdit() {
-            super.cancelEdit();
+        private void cancelInlineEdit() {
+            if (!editing) {
+                return;
+            }
+            editing = false;
             if (getItem() != null) {
                 setText(getItem().getTitle());
             }
             setGraphic(null);
+            textField = null;
         }
 
         @Override
@@ -188,7 +242,8 @@ public class OutlineViewController {
             if (empty || item == null) {
                 setText(null);
                 setGraphic(null);
-            } else if (isEditing()) {
+                editing = false;
+            } else if (editing && textField != null) {
                 setText(null);
                 setGraphic(textField);
             } else {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -1,5 +1,7 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -7,10 +9,12 @@ import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 import com.embervault.domain.TbxColor;
-import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
@@ -21,7 +25,7 @@ import javafx.collections.ObservableList;
  *
  * <p>Computes a tab title of the form "Outline: &lt;note title&gt;" that updates
  * reactively when the underlying note title changes. Manages a tree structure
- * of notes for hierarchical display.</p>
+ * of notes for hierarchical display and supports drill-down navigation.</p>
  */
 public final class OutlineViewModel {
 
@@ -30,7 +34,11 @@ public final class OutlineViewModel {
             FXCollections.observableArrayList();
     private final ObjectProperty<UUID> selectedNoteId =
             new SimpleObjectProperty<>();
+    private final BooleanProperty canNavigateBack =
+            new SimpleBooleanProperty(false);
     private final NoteService noteService;
+    private final StringProperty rootNoteTitle;
+    private final Deque<UUID> navigationHistory = new ArrayDeque<>();
     private UUID baseNoteId;
 
     /**
@@ -43,7 +51,14 @@ public final class OutlineViewModel {
         Objects.requireNonNull(noteTitle, "noteTitle must not be null");
         this.noteService = Objects.requireNonNull(noteService,
                 "noteService must not be null");
-        tabTitle.bind(Bindings.concat("Outline: ", noteTitle));
+        this.rootNoteTitle = noteTitle;
+        updateTabTitle(noteTitle.get());
+        // When the root note title changes and we're at the root level, update tab title
+        noteTitle.addListener((obs, oldVal, newVal) -> {
+            if (navigationHistory.isEmpty()) {
+                updateTabTitle(newVal);
+            }
+        });
     }
 
     /** Returns the tab title property. */
@@ -139,6 +154,43 @@ public final class OutlineViewModel {
         return true;
     }
 
+    /** Returns the canNavigateBack property. */
+    public ReadOnlyBooleanProperty canNavigateBackProperty() {
+        return canNavigateBack;
+    }
+
+    /**
+     * Drills down into a child note, making it the new base note.
+     *
+     * @param noteId the note id to drill into
+     */
+    public void drillDown(UUID noteId) {
+        navigationHistory.push(baseNoteId);
+        canNavigateBack.set(true);
+        baseNoteId = noteId;
+        noteService.getNote(noteId).ifPresent(note ->
+                updateTabTitle(note.getTitle()));
+        loadNotes();
+    }
+
+    /**
+     * Navigates back to the previous base note.
+     */
+    public void navigateBack() {
+        if (navigationHistory.isEmpty()) {
+            return;
+        }
+        baseNoteId = navigationHistory.pop();
+        canNavigateBack.set(!navigationHistory.isEmpty());
+        if (navigationHistory.isEmpty()) {
+            updateTabTitle(rootNoteTitle.get());
+        } else {
+            noteService.getNote(baseNoteId).ifPresent(note ->
+                    updateTabTitle(note.getTitle()));
+        }
+        loadNotes();
+    }
+
     /**
      * Returns the children of the given note as display items.
      *
@@ -150,6 +202,10 @@ public final class OutlineViewModel {
                 noteService.getChildren(parentId).stream()
                         .map(this::toDisplayItem)
                         .toList());
+    }
+
+    private void updateTabTitle(String title) {
+        tabTitle.set("Outline: " + title);
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {

--- a/src/main/resources/com/embervault/adapter/in/ui/view/OutlineView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/OutlineView.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TreeView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns:fx="http://javafx.com/fxml"
+<VBox fx:id="outlineRoot" xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.embervault.adapter.in.ui.view.OutlineViewController">
 
     <TreeView fx:id="outlineTreeView" VBox.vgrow="ALWAYS"/>

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -194,4 +194,163 @@ class OutlineViewModelTest {
 
         assertFalse(result);
     }
+
+    // --- Drill-down navigation tests ---
+
+    @Test
+    @DisplayName("drillDown() changes baseNoteId and reloads children")
+    void drillDown_shouldChangeBaseAndReload() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        assertEquals(child.getId(), viewModel.getBaseNoteId());
+        assertEquals(1, viewModel.getRootItems().size());
+        assertEquals("Grandchild", viewModel.getRootItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("drillDown() updates tab title to drilled-down note")
+    void drillDown_shouldUpdateTabTitle() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        assertEquals("Outline: Child", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("navigateBack() returns to previous base note")
+    void navigateBack_shouldReturnToPreviousBase() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        viewModel.navigateBack();
+
+        assertEquals(root.getId(), viewModel.getBaseNoteId());
+        assertEquals(1, viewModel.getRootItems().size());
+        assertEquals("Child", viewModel.getRootItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("navigateBack() restores tab title to root note title")
+    void navigateBack_shouldRestoreTabTitle() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        viewModel.navigateBack();
+
+        assertEquals("Outline: My Note", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("canNavigateBack() is false initially")
+    void canNavigateBack_shouldBeFalseInitially() {
+        assertFalse(viewModel.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("canNavigateBack() is true after drillDown")
+    void canNavigateBack_shouldBeTrueAfterDrillDown() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        assertTrue(viewModel.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("canNavigateBack() is false after navigating back to root")
+    void canNavigateBack_shouldBeFalseAfterBack() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        viewModel.navigateBack();
+
+        assertFalse(viewModel.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("navigateBack() does nothing when history is empty")
+    void navigateBack_shouldDoNothingWhenHistoryEmpty() {
+        Note root = noteService.createNote("Root", "");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.navigateBack();
+
+        assertEquals(root.getId(), viewModel.getBaseNoteId());
+    }
+
+    @Test
+    @DisplayName("multiple drillDown and navigateBack traverses stack correctly")
+    void drillDown_multipleLevels_shouldTraverseStackCorrectly() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        Note grandchild = noteService.createChildNote(child.getId(), "Grandchild");
+        noteService.createChildNote(grandchild.getId(), "GreatGrandchild");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+        viewModel.drillDown(grandchild.getId());
+
+        assertEquals(grandchild.getId(), viewModel.getBaseNoteId());
+        assertEquals("Outline: Grandchild", viewModel.tabTitleProperty().get());
+        assertTrue(viewModel.canNavigateBackProperty().get());
+
+        viewModel.navigateBack();
+
+        assertEquals(child.getId(), viewModel.getBaseNoteId());
+        assertEquals("Outline: Child", viewModel.tabTitleProperty().get());
+        assertTrue(viewModel.canNavigateBackProperty().get());
+
+        viewModel.navigateBack();
+
+        assertEquals(root.getId(), viewModel.getBaseNoteId());
+        assertEquals("Outline: My Note", viewModel.tabTitleProperty().get());
+        assertFalse(viewModel.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("tabTitle does not update from rootNoteTitle when drilled down")
+    void tabTitle_shouldNotUpdateFromRootNoteTitleWhenDrilledDown() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        noteTitle.set("Changed Root Title");
+
+        assertEquals("Outline: Child", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("tabTitle updates from rootNoteTitle when at root level")
+    void tabTitle_shouldUpdateFromRootNoteTitleWhenAtRootLevel() {
+        noteTitle.set("New Root Title");
+
+        assertEquals("Outline: New Root Title", viewModel.tabTitleProperty().get());
+    }
 }


### PR DESCRIPTION
## Summary
- **Map view**: Focus-lost on inline title edit now commits the change (was canceling), matching Enter behavior
- **Outline view**: Rewritten interaction model -- single-click on already-selected note starts Finder-style inline rename, double-click drills down into note's children, focus-lost commits edits, Escape cancels
- **OutlineViewModel**: Added `drillDown()`, `navigateBack()`, and `canNavigateBackProperty()` with navigation stack and dynamic tab title updates (mirroring MapViewModel)
- **Outline view**: Added back-navigation button and Escape-key to navigate back when drilled down

## Test plan
- [x] 10 new OutlineViewModel drill-down tests (drill-down changes base, updates tab title, navigate-back restores state, multi-level stack traversal, tab title isolation when drilled down)
- [x] All 285 existing tests pass
- [x] Checkstyle: 0 violations
- [x] JaCoCo: all coverage checks met
- [x] ArchUnit: architecture rules pass

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)