### PR TITLE
Add descriptive tab titles with truncated note names

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -19,6 +19,7 @@ import javafx.beans.property.StringProperty;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
@@ -27,6 +28,8 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,8 +102,21 @@ public class App extends Application {
                     }
                 });
 
+        // Wrap each view with a title label
+        Label mapLabel = new Label();
+        mapLabel.textProperty().bind(mapViewModel.tabTitleProperty());
+        mapLabel.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
+        VBox mapContainer = new VBox(mapLabel, mapView);
+        VBox.setVgrow(mapView, Priority.ALWAYS);
+
+        Label outlineLabel = new Label();
+        outlineLabel.textProperty().bind(outlineViewModel.tabTitleProperty());
+        outlineLabel.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
+        VBox outlineContainer = new VBox(outlineLabel, outlineView);
+        VBox.setVgrow(outlineView, Priority.ALWAYS);
+
         // SplitPane with Map on left, Outline on right
-        SplitPane splitPane = new SplitPane(mapView, outlineView);
+        SplitPane splitPane = new SplitPane(mapContainer, outlineContainer);
         splitPane.setDividerPositions(0.5);
 
         // Menu bar

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -29,6 +29,7 @@ import javafx.collections.ObservableList;
  */
 public final class MapViewModel {
 
+    private static final int MAX_TITLE_LENGTH = 20;
     private static final double SCALE_X = 40.0;
     private static final double SCALE_Y = 40.0;
     private static final double DEFAULT_WIDTH = 6.0;
@@ -213,7 +214,7 @@ public final class MapViewModel {
     }
 
     private void updateTabTitle(String title) {
-        tabTitle.set("Map: " + title);
+        tabTitle.set("Map: " + TextUtils.truncate(title, MAX_TITLE_LENGTH));
     }
 
     /**

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -29,6 +29,8 @@ import javafx.collections.ObservableList;
  */
 public final class OutlineViewModel {
 
+    private static final int MAX_TITLE_LENGTH = 20;
+
     private final ReadOnlyStringWrapper tabTitle = new ReadOnlyStringWrapper();
     private final ObservableList<NoteDisplayItem> rootItems =
             FXCollections.observableArrayList();
@@ -205,7 +207,7 @@ public final class OutlineViewModel {
     }
 
     private void updateTabTitle(String title) {
-        tabTitle.set("Outline: " + title);
+        tabTitle.set("Outline: " + TextUtils.truncate(title, MAX_TITLE_LENGTH));
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TextUtils.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TextUtils.java
@@ -1,0 +1,25 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+/**
+ * Text utility methods for the viewmodel layer.
+ */
+final class TextUtils {
+
+    private TextUtils() {
+        // utility class
+    }
+
+    /**
+     * Truncates text to the given maximum length, appending an ellipsis if truncated.
+     *
+     * @param text      the text to truncate, may be null
+     * @param maxLength the maximum number of characters before truncation
+     * @return the truncated text with ellipsis, or the original text if within limit
+     */
+    static String truncate(String text, int maxLength) {
+        if (text == null || text.length() <= maxLength) {
+            return text;
+        }
+        return text.substring(0, maxLength) + "\u2026";
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
@@ -49,6 +49,22 @@ class MapViewModelTest {
     }
 
     @Test
+    @DisplayName("tabTitle truncates long note titles to 20 characters with ellipsis")
+    void tabTitle_shouldTruncateLongTitles() {
+        noteTitle.set("Welcome to EmberVault Application");
+
+        assertEquals("Map: Welcome to EmberVaul\u2026", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("tabTitle does not truncate titles at exactly 20 characters")
+    void tabTitle_shouldNotTruncateExactly20Chars() {
+        noteTitle.set("12345678901234567890"); // exactly 20 chars
+
+        assertEquals("Map: 12345678901234567890", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
     @DisplayName("Constructor rejects null noteTitle")
     void constructor_shouldRejectNullNoteTitle() {
         assertThrows(NullPointerException.class,
@@ -233,6 +249,21 @@ class MapViewModelTest {
         viewModel.drillDown(child.getId());
 
         assertEquals("Map: Child", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("drillDown() truncates long drilled-down note title")
+    void drillDown_shouldTruncateLongDrilledDownTitle() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(),
+                "A Very Long Child Note Title Here");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        assertEquals("Map: A Very Long Child No\u2026",
+                viewModel.tabTitleProperty().get());
     }
 
     @Test

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -50,6 +50,24 @@ class OutlineViewModelTest {
     }
 
     @Test
+    @DisplayName("tabTitle truncates long note titles to 20 characters with ellipsis")
+    void tabTitle_shouldTruncateLongTitles() {
+        noteTitle.set("Welcome to EmberVault Application");
+
+        assertEquals("Outline: Welcome to EmberVaul\u2026",
+                viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("tabTitle does not truncate titles at exactly 20 characters")
+    void tabTitle_shouldNotTruncateExactly20Chars() {
+        noteTitle.set("12345678901234567890"); // exactly 20 chars
+
+        assertEquals("Outline: 12345678901234567890",
+                viewModel.tabTitleProperty().get());
+    }
+
+    @Test
     @DisplayName("Constructor rejects null noteTitle")
     void constructor_shouldRejectNullNoteTitle() {
         assertThrows(NullPointerException.class,
@@ -224,6 +242,21 @@ class OutlineViewModelTest {
         viewModel.drillDown(child.getId());
 
         assertEquals("Outline: Child", viewModel.tabTitleProperty().get());
+    }
+
+    @Test
+    @DisplayName("drillDown() truncates long drilled-down note title")
+    void drillDown_shouldTruncateLongDrilledDownTitle() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(),
+                "A Very Long Child Note Title Here");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        assertEquals("Outline: A Very Long Child No\u2026",
+                viewModel.tabTitleProperty().get());
     }
 
     @Test

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/TextUtilsTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/TextUtilsTest.java
@@ -1,0 +1,48 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TextUtilsTest {
+
+    @Test
+    @DisplayName("truncate returns null for null input")
+    void truncate_shouldReturnNullForNullInput() {
+        assertNull(TextUtils.truncate(null, 20));
+    }
+
+    @Test
+    @DisplayName("truncate returns empty string unchanged")
+    void truncate_shouldReturnEmptyStringUnchanged() {
+        assertEquals("", TextUtils.truncate("", 20));
+    }
+
+    @Test
+    @DisplayName("truncate returns short string unchanged")
+    void truncate_shouldReturnShortStringUnchanged() {
+        assertEquals("Hello", TextUtils.truncate("Hello", 20));
+    }
+
+    @Test
+    @DisplayName("truncate returns exact-length string unchanged")
+    void truncate_shouldReturnExactLengthStringUnchanged() {
+        String text = "12345678901234567890"; // exactly 20 chars
+        assertEquals(text, TextUtils.truncate(text, 20));
+    }
+
+    @Test
+    @DisplayName("truncate appends ellipsis when over max length")
+    void truncate_shouldAppendEllipsisWhenOverMaxLength() {
+        String text = "123456789012345678901"; // 21 chars
+        assertEquals("12345678901234567890\u2026", TextUtils.truncate(text, 20));
+    }
+
+    @Test
+    @DisplayName("truncate works with max length of 1")
+    void truncate_shouldWorkWithMaxLengthOfOne() {
+        assertEquals("a\u2026", TextUtils.truncate("abc", 1));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TextUtils.truncate()` utility that truncates text to a max length with Unicode ellipsis
- Update `MapViewModel` and `OutlineViewModel` to format tab titles as "Map: <title>" / "Outline: <title>" with note names truncated to 20 characters
- Display tab title labels above each view pane in the SplitPane (in `App.java`)
- Titles update reactively on rename and drill-down navigation

## Test plan
- [x] TextUtils: null, empty, short, exact-length, and over-length truncation tests
- [x] MapViewModel: truncated title tests for initial, update, exact-20, and drill-down scenarios
- [x] OutlineViewModel: truncated title tests for initial, update, exact-20, and drill-down scenarios
- [x] All 297 tests pass, checkstyle clean, JaCoCo coverage met, ArchUnit passes

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)