### PR TITLE
Outline view: single-click edit, Enter sibling, Tab indent/outdent

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -15,6 +16,7 @@ import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.VBox;
 import org.slf4j.Logger;
@@ -23,8 +25,9 @@ import org.slf4j.LoggerFactory;
 /**
  * FXML controller for the Outline view.
  *
- * <p>Renders notes as a hierarchical tree. Single-clicking an already-selected
- * note starts inline editing. Double-clicking drills down into a note.
+ * <p>Renders notes as a hierarchical tree. Single-clicking any note
+ * immediately starts inline editing. Double-clicking drills down into a note.
+ * Enter creates a new sibling, Tab indents, Shift+Tab outdents.
  * Focus lost on the edit field commits the change; Escape cancels.</p>
  */
 public class OutlineViewController {
@@ -55,7 +58,7 @@ public class OutlineViewController {
         outlineTreeView.setEditable(false);
 
         // Set up cell factory with custom click handling
-        outlineTreeView.setCellFactory(tv -> new ClickToEditNoteTreeCell());
+        outlineTreeView.setCellFactory(tv -> new OutlineNoteTreeCell());
 
         // Load initial data
         viewModel.loadNotes();
@@ -75,12 +78,12 @@ public class OutlineViewController {
                     }
                 });
 
-        // Key handling: Enter creates child, Escape navigates back
+        // Event filter to intercept Tab/Shift+Tab before TreeView handles them
+        outlineTreeView.addEventFilter(KeyEvent.KEY_PRESSED, this::handleTreeKeyFilter);
+
+        // Key handling: Escape navigates back
         outlineTreeView.setOnKeyPressed(event -> {
-            if (event.getCode() == KeyCode.ENTER) {
-                createChildUnderSelected();
-                event.consume();
-            } else if (event.getCode() == KeyCode.ESCAPE
+            if (event.getCode() == KeyCode.ESCAPE
                     && viewModel.canNavigateBackProperty().get()) {
                 viewModel.navigateBack();
                 event.consume();
@@ -94,6 +97,23 @@ public class OutlineViewController {
     /** Returns the associated ViewModel. */
     public OutlineViewModel getViewModel() {
         return viewModel;
+    }
+
+    private void handleTreeKeyFilter(KeyEvent event) {
+        if (event.getCode() == KeyCode.TAB) {
+            TreeItem<NoteDisplayItem> selected = outlineTreeView.getSelectionModel()
+                    .getSelectedItem();
+            if (selected != null && selected.getValue() != null) {
+                UUID noteId = selected.getValue().getId();
+                if (event.isShiftDown()) {
+                    viewModel.outdentNote(noteId);
+                } else {
+                    viewModel.indentNote(noteId);
+                }
+                refreshAndEdit(noteId);
+                event.consume();
+            }
+        }
     }
 
     private ContextMenu createContextMenu() {
@@ -148,17 +168,73 @@ public class OutlineViewController {
     }
 
     /**
-     * Custom TreeCell that uses single-click on a selected item to edit,
-     * and double-click to drill down. Focus lost on the edit field commits changes.
+     * Rebuilds the tree, selects the given note, and starts editing it.
      */
-    private final class ClickToEditNoteTreeCell extends TreeCell<NoteDisplayItem> {
+    private void refreshAndEdit(UUID noteIdToSelect) {
+        TreeItem<NoteDisplayItem> target = findTreeItem(
+                outlineTreeView.getRoot(), noteIdToSelect);
+        if (target != null) {
+            outlineTreeView.getSelectionModel().select(target);
+            // Use Platform.runLater so the tree has settled before we trigger edit
+            Platform.runLater(() -> {
+                int row = outlineTreeView.getRow(target);
+                if (row >= 0) {
+                    OutlineNoteTreeCell cell = findCellForItem(target);
+                    if (cell != null) {
+                        cell.startInlineEdit();
+                    }
+                }
+            });
+        }
+    }
+
+    private TreeItem<NoteDisplayItem> findTreeItem(TreeItem<NoteDisplayItem> root,
+            UUID noteId) {
+        if (root == null || noteId == null) {
+            return null;
+        }
+        if (root.getValue() != null && noteId.equals(root.getValue().getId())) {
+            return root;
+        }
+        for (TreeItem<NoteDisplayItem> child : root.getChildren()) {
+            TreeItem<NoteDisplayItem> found = findTreeItem(child, noteId);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutlineNoteTreeCell findCellForItem(TreeItem<NoteDisplayItem> target) {
+        int row = outlineTreeView.getRow(target);
+        if (row < 0) {
+            return null;
+        }
+        // Look up the cell via the TreeView's lookup mechanism
+        for (var node : outlineTreeView.lookupAll(".tree-cell")) {
+            if (node instanceof OutlineNoteTreeCell cell
+                    && cell.getTreeItem() == target) {
+                return cell;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Custom TreeCell that starts editing on single click.
+     * Enter creates a sibling, Tab/Shift+Tab indent/outdent,
+     * Escape cancels, focus lost commits.
+     */
+    private final class OutlineNoteTreeCell extends TreeCell<NoteDisplayItem> {
 
         private TextField textField;
         private boolean editing;
 
-        ClickToEditNoteTreeCell() {
+        OutlineNoteTreeCell() {
             setOnMouseClicked(event -> {
-                if (event.getButton() != MouseButton.PRIMARY || isEmpty() || getItem() == null) {
+                if (event.getButton() != MouseButton.PRIMARY
+                        || isEmpty() || getItem() == null) {
                     return;
                 }
 
@@ -166,15 +242,15 @@ public class OutlineViewController {
                     // Double-click -> drill down
                     viewModel.drillDown(getItem().getId());
                     event.consume();
-                } else if (event.getClickCount() == 1 && isSelected() && !editing) {
-                    // Single click on already-selected item -> start editing
+                } else if (event.getClickCount() == 1 && !editing) {
+                    // Single click -> immediate edit
                     startInlineEdit();
                     event.consume();
                 }
             });
         }
 
-        private void startInlineEdit() {
+        void startInlineEdit() {
             if (getItem() == null) {
                 return;
             }
@@ -182,16 +258,8 @@ public class OutlineViewController {
             textField = new TextField(getItem().getTitle());
             textField.selectAll();
 
-            // Commit on Enter
-            textField.setOnAction(e -> commitInlineEdit());
-
-            // Cancel on Escape
-            textField.setOnKeyPressed(e -> {
-                if (e.getCode() == KeyCode.ESCAPE) {
-                    cancelInlineEdit();
-                    e.consume();
-                }
-            });
+            // Key handling on the text field
+            textField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleEditKeyPress);
 
             // Commit on focus lost
             textField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
@@ -203,6 +271,34 @@ public class OutlineViewController {
             setText(null);
             setGraphic(textField);
             textField.requestFocus();
+        }
+
+        private void handleEditKeyPress(KeyEvent event) {
+            if (event.getCode() == KeyCode.ENTER) {
+                NoteDisplayItem currentItem = getItem();
+                commitInlineEdit();
+                if (currentItem != null) {
+                    NoteDisplayItem newItem = viewModel.createSiblingNote(
+                            currentItem.getId(), "");
+                    refreshAndEdit(newItem.getId());
+                }
+                event.consume();
+            } else if (event.getCode() == KeyCode.TAB) {
+                NoteDisplayItem currentItem = getItem();
+                commitInlineEdit();
+                if (currentItem != null) {
+                    if (event.isShiftDown()) {
+                        viewModel.outdentNote(currentItem.getId());
+                    } else {
+                        viewModel.indentNote(currentItem.getId());
+                    }
+                    refreshAndEdit(currentItem.getId());
+                }
+                event.consume();
+            } else if (event.getCode() == KeyCode.ESCAPE) {
+                cancelInlineEdit();
+                event.consume();
+            }
         }
 
         private void commitInlineEdit() {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -131,6 +131,40 @@ public final class OutlineViewModel {
     }
 
     /**
+     * Creates a new sibling note directly after the given sibling and reloads the tree.
+     *
+     * @param siblingId the sibling note id
+     * @param title     the title for the new note (may be empty)
+     * @return the display item for the created note
+     */
+    public NoteDisplayItem createSiblingNote(UUID siblingId, String title) {
+        Note sibling = noteService.createSiblingNote(siblingId, title);
+        NoteDisplayItem item = toDisplayItem(sibling);
+        loadNotes();
+        return item;
+    }
+
+    /**
+     * Indents a note (makes it a child of the note above) and reloads the tree.
+     *
+     * @param noteId the note id to indent
+     */
+    public void indentNote(UUID noteId) {
+        noteService.indentNote(noteId);
+        loadNotes();
+    }
+
+    /**
+     * Outdents a note (moves it up one level) and reloads the tree.
+     *
+     * @param noteId the note id to outdent
+     */
+    public void outdentNote(UUID noteId) {
+        noteService.outdentNote(noteId);
+        loadNotes();
+    }
+
+    /**
      * Renames a note, updating the display item in the root items list if present.
      *
      * @param noteId   the note id

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -1,5 +1,6 @@
 package com.embervault.application;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -9,6 +10,7 @@ import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.AttributeMap;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 
@@ -132,7 +134,185 @@ public final class NoteServiceImpl implements NoteService {
     }
 
     @Override
+    public Note createSiblingNote(UUID siblingId, String title) {
+        Note sibling = repository.findById(siblingId)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Sibling note not found: " + siblingId));
+
+        String containerId = sibling.getAttribute("$Container")
+                .filter(v -> v instanceof AttributeValue.StringValue)
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Sibling has no $Container: " + siblingId));
+
+        double siblingOrder = sibling.getAttribute("$OutlineOrder")
+                .filter(v -> v instanceof AttributeValue.NumberValue)
+                .map(v -> ((AttributeValue.NumberValue) v).value())
+                .orElse(0.0);
+
+        UUID parentId = UUID.fromString(containerId);
+
+        // Bump order of all siblings after this one
+        List<Note> siblings = repository.findChildren(parentId);
+        for (Note s : siblings) {
+            double order = s.getAttribute("$OutlineOrder")
+                    .filter(v -> v instanceof AttributeValue.NumberValue)
+                    .map(v -> ((AttributeValue.NumberValue) v).value())
+                    .orElse(0.0);
+            if (order > siblingOrder) {
+                s.setAttribute("$OutlineOrder",
+                        new AttributeValue.NumberValue(order + 1));
+                repository.save(s);
+            }
+        }
+
+        // Create the new note (use AttributeMap constructor to allow empty titles)
+        Note newNote = createNoteWithTitle(title);
+        newNote.setAttribute("$Container",
+                new AttributeValue.StringValue(containerId));
+        newNote.setAttribute("$OutlineOrder",
+                new AttributeValue.NumberValue(siblingOrder + 1));
+        newNote.setAttribute("$Xpos",
+                new AttributeValue.NumberValue(random.nextDouble() * MAX_XPOS));
+        newNote.setAttribute("$Ypos",
+                new AttributeValue.NumberValue(random.nextDouble() * MAX_YPOS));
+
+        return repository.save(newNote);
+    }
+
+    @Override
+    public Note indentNote(UUID noteId) {
+        Note note = repository.findById(noteId)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Note not found: " + noteId));
+
+        String containerId = note.getAttribute("$Container")
+                .filter(v -> v instanceof AttributeValue.StringValue)
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .orElse(null);
+
+        if (containerId == null) {
+            return note;
+        }
+
+        UUID parentId = UUID.fromString(containerId);
+        double noteOrder = note.getAttribute("$OutlineOrder")
+                .filter(v -> v instanceof AttributeValue.NumberValue)
+                .map(v -> ((AttributeValue.NumberValue) v).value())
+                .orElse(0.0);
+
+        // Find the note directly above (sibling with the next-lower order)
+        List<Note> siblings = repository.findChildren(parentId);
+        Note noteAbove = null;
+        double bestOrder = -1;
+        for (Note s : siblings) {
+            if (s.getId().equals(noteId)) {
+                continue;
+            }
+            double order = s.getAttribute("$OutlineOrder")
+                    .filter(v -> v instanceof AttributeValue.NumberValue)
+                    .map(v -> ((AttributeValue.NumberValue) v).value())
+                    .orElse(0.0);
+            if (order < noteOrder && order > bestOrder) {
+                bestOrder = order;
+                noteAbove = s;
+            }
+        }
+
+        if (noteAbove == null) {
+            return note;
+        }
+
+        // Move note to be a child of noteAbove
+        int newOrder = repository.findChildren(noteAbove.getId()).size();
+        note.setAttribute("$Container",
+                new AttributeValue.StringValue(noteAbove.getId().toString()));
+        note.setAttribute("$OutlineOrder",
+                new AttributeValue.NumberValue(newOrder));
+
+        return repository.save(note);
+    }
+
+    @Override
+    public Note outdentNote(UUID noteId) {
+        Note note = repository.findById(noteId)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Note not found: " + noteId));
+
+        String containerId = note.getAttribute("$Container")
+                .filter(v -> v instanceof AttributeValue.StringValue)
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .orElse(null);
+
+        if (containerId == null) {
+            return note;
+        }
+
+        UUID parentId = UUID.fromString(containerId);
+        Note parent = repository.findById(parentId).orElse(null);
+        if (parent == null) {
+            return note;
+        }
+
+        String grandparentContainerId = parent.getAttribute("$Container")
+                .filter(v -> v instanceof AttributeValue.StringValue)
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .orElse(null);
+
+        if (grandparentContainerId == null) {
+            return note;
+        }
+
+        UUID grandparentId = UUID.fromString(grandparentContainerId);
+
+        // Find parent's order in grandparent's children
+        double parentOrder = parent.getAttribute("$OutlineOrder")
+                .filter(v -> v instanceof AttributeValue.NumberValue)
+                .map(v -> ((AttributeValue.NumberValue) v).value())
+                .orElse(0.0);
+
+        // Bump order of grandparent's children that come after parent
+        List<Note> grandparentChildren = repository.findChildren(grandparentId);
+        for (Note gc : grandparentChildren) {
+            double order = gc.getAttribute("$OutlineOrder")
+                    .filter(v -> v instanceof AttributeValue.NumberValue)
+                    .map(v -> ((AttributeValue.NumberValue) v).value())
+                    .orElse(0.0);
+            if (order > parentOrder) {
+                gc.setAttribute("$OutlineOrder",
+                        new AttributeValue.NumberValue(order + 1));
+                repository.save(gc);
+            }
+        }
+
+        // Move note to grandparent, positioned just after parent
+        note.setAttribute("$Container",
+                new AttributeValue.StringValue(grandparentContainerId));
+        note.setAttribute("$OutlineOrder",
+                new AttributeValue.NumberValue(parentOrder + 1));
+
+        return repository.save(note);
+    }
+
+    @Override
     public void deleteNote(UUID id) {
         repository.delete(id);
+    }
+
+    /**
+     * Creates a note allowing an empty title by using the AttributeMap constructor.
+     */
+    private Note createNoteWithTitle(String title) {
+        if (title != null && !title.isBlank()) {
+            return Note.create(title, "");
+        }
+        Instant now = Instant.now();
+        AttributeMap attrs = new AttributeMap();
+        attrs.set("$Name", new AttributeValue.StringValue(
+                title == null ? "" : title));
+        attrs.set("$Text", new AttributeValue.StringValue(""));
+        attrs.set("$Created", new AttributeValue.DateValue(now));
+        attrs.set("$Modified", new AttributeValue.DateValue(now));
+        return new Note(UUID.randomUUID(), attrs);
     }
 }

--- a/src/main/java/com/embervault/application/port/in/NoteService.java
+++ b/src/main/java/com/embervault/application/port/in/NoteService.java
@@ -75,6 +75,40 @@ public interface NoteService {
     Note renameNote(UUID noteId, String newTitle);
 
     /**
+     * Creates a new sibling note directly after the given sibling in outline order.
+     *
+     * <p>The new note will have the same {@code $Container} as the sibling.
+     * Subsequent siblings have their {@code $OutlineOrder} incremented to make room.</p>
+     *
+     * @param siblingId the id of the note to create a sibling after
+     * @param title     the title for the new note (may be empty for rapid entry)
+     * @return the newly created sibling note
+     */
+    Note createSiblingNote(UUID siblingId, String title);
+
+    /**
+     * Indents a note by making it a child of the note directly above it in outline order.
+     *
+     * <p>If the note is the first child (no note above), it is returned unchanged.</p>
+     *
+     * @param noteId the id of the note to indent
+     * @return the updated note
+     */
+    Note indentNote(UUID noteId);
+
+    /**
+     * Outdents a note by moving it to be a sibling of its current parent.
+     *
+     * <p>The note is placed just after its old parent in the grandparent's children.
+     * If the note has no parent or the parent has no grandparent, the note is returned
+     * unchanged.</p>
+     *
+     * @param noteId the id of the note to outdent
+     * @return the updated note
+     */
+    Note outdentNote(UUID noteId);
+
+    /**
      * Deletes the note with the given id.
      */
     void deleteNote(UUID id);

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -386,4 +386,77 @@ class OutlineViewModelTest {
 
         assertEquals("Outline: New Root Title", viewModel.tabTitleProperty().get());
     }
+
+    // --- createSiblingNote tests ---
+
+    @Test
+    @DisplayName("createSiblingNote() creates sibling and reloads tree")
+    void createSiblingNote_shouldCreateSiblingAndReload() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        Note child1 = noteService.createChildNote(parent.getId(), "Child1");
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.createSiblingNote(child1.getId(), "Sibling");
+
+        assertNotNull(item);
+        assertEquals("Sibling", item.getTitle());
+        // Root items should be reloaded
+        assertEquals(2, viewModel.getRootItems().size());
+        assertEquals("Child1", viewModel.getRootItems().get(0).getTitle());
+        assertEquals("Sibling", viewModel.getRootItems().get(1).getTitle());
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() with empty title creates note with empty title")
+    void createSiblingNote_emptyTitle_shouldWork() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        Note child1 = noteService.createChildNote(parent.getId(), "Child1");
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.createSiblingNote(child1.getId(), "");
+
+        assertNotNull(item);
+        assertEquals("", item.getTitle());
+    }
+
+    // --- indentNote tests ---
+
+    @Test
+    @DisplayName("indentNote() indents note and reloads tree")
+    void indentNote_shouldIndentAndReload() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        noteService.createChildNote(parent.getId(), "Child1");
+        Note child2 = noteService.createChildNote(parent.getId(), "Child2");
+        viewModel.loadNotes();
+
+        viewModel.indentNote(child2.getId());
+
+        // Only Child1 should remain at root level
+        assertEquals(1, viewModel.getRootItems().size());
+        assertEquals("Child1", viewModel.getRootItems().get(0).getTitle());
+        // Child1 should now have children
+        assertTrue(viewModel.getRootItems().get(0).isHasChildren());
+    }
+
+    // --- outdentNote tests ---
+
+    @Test
+    @DisplayName("outdentNote() outdents note and reloads tree")
+    void outdentNote_shouldOutdentAndReload() {
+        Note root = noteService.createNote("Root", "");
+        Note parent = noteService.createChildNote(root.getId(), "Parent");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.outdentNote(child.getId());
+
+        // Root should now have Parent and Child
+        assertEquals(2, viewModel.getRootItems().size());
+        assertEquals("Parent", viewModel.getRootItems().get(0).getTitle());
+        assertEquals("Child", viewModel.getRootItems().get(1).getTitle());
+    }
 }

--- a/src/test/java/com/embervault/application/NoteServiceImplTest.java
+++ b/src/test/java/com/embervault/application/NoteServiceImplTest.java
@@ -288,4 +288,218 @@ class NoteServiceImplTest {
         assertThrows(IllegalArgumentException.class,
                 () -> service.renameNote(note.getId(), "   "));
     }
+
+    // --- createSiblingNote tests ---
+
+    @Test
+    @DisplayName("createSiblingNote() creates a note with same parent as sibling")
+    void createSiblingNote_shouldCreateWithSameParent() {
+        Note parent = service.createNote("Parent", "");
+        Note sibling = service.createChildNote(parent.getId(), "Sibling");
+
+        Note newNote = service.createSiblingNote(sibling.getId(), "New");
+
+        assertNotNull(newNote);
+        assertEquals("New", newNote.getTitle());
+        String container = ((AttributeValue.StringValue)
+                newNote.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(parent.getId().toString(), container);
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() places new note after sibling in outline order")
+    void createSiblingNote_shouldPlaceAfterSibling() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+        service.createChildNote(parent.getId(), "Child2");
+
+        Note newNote = service.createSiblingNote(child1.getId(), "Between");
+
+        double order = ((AttributeValue.NumberValue)
+                newNote.getAttribute("$OutlineOrder").orElseThrow()).value();
+        assertEquals(1.0, order);
+
+        // Child2's order should have been bumped to 2
+        List<Note> children = service.getChildren(parent.getId());
+        assertEquals(3, children.size());
+        assertEquals("Child1", children.get(0).getTitle());
+        assertEquals("Between", children.get(1).getTitle());
+        assertEquals("Child2", children.get(2).getTitle());
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() at end of list does not need to bump orders")
+    void createSiblingNote_atEnd_shouldAppend() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+        Note child2 = service.createChildNote(parent.getId(), "Child2");
+
+        Note newNote = service.createSiblingNote(child2.getId(), "Last");
+
+        List<Note> children = service.getChildren(parent.getId());
+        assertEquals(3, children.size());
+        assertEquals("Child1", children.get(0).getTitle());
+        assertEquals("Child2", children.get(1).getTitle());
+        assertEquals("Last", children.get(2).getTitle());
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() with empty title creates note with empty title")
+    void createSiblingNote_emptyTitle_shouldCreateWithEmptyTitle() {
+        Note parent = service.createNote("Parent", "");
+        Note sibling = service.createChildNote(parent.getId(), "Sibling");
+
+        Note newNote = service.createSiblingNote(sibling.getId(), "");
+
+        assertEquals("", newNote.getTitle());
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() throws when sibling does not exist")
+    void createSiblingNote_shouldThrowForMissingSibling() {
+        assertThrows(NoSuchElementException.class,
+                () -> service.createSiblingNote(UUID.randomUUID(), "Title"));
+    }
+
+    // --- indentNote tests ---
+
+    @Test
+    @DisplayName("indentNote() moves note to be child of note above")
+    void indentNote_shouldMoveUnderNoteAbove() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+        Note child2 = service.createChildNote(parent.getId(), "Child2");
+
+        Note indented = service.indentNote(child2.getId());
+
+        // child2 should now be a child of child1
+        String container = ((AttributeValue.StringValue)
+                indented.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(child1.getId().toString(), container);
+
+        // parent should only have child1 now
+        List<Note> parentChildren = service.getChildren(parent.getId());
+        assertEquals(1, parentChildren.size());
+        assertEquals("Child1", parentChildren.get(0).getTitle());
+
+        // child1 should have child2 as its child
+        List<Note> child1Children = service.getChildren(child1.getId());
+        assertEquals(1, child1Children.size());
+        assertEquals("Child2", child1Children.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("indentNote() returns unchanged when note is first child (no note above)")
+    void indentNote_shouldReturnUnchangedWhenFirst() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+
+        Note result = service.indentNote(child1.getId());
+
+        // Should remain under parent
+        String container = ((AttributeValue.StringValue)
+                result.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(parent.getId().toString(), container);
+    }
+
+    @Test
+    @DisplayName("indentNote() appends to end of target's existing children")
+    void indentNote_shouldAppendToExistingChildren() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+        service.createChildNote(child1.getId(), "ExistingGrandchild");
+        Note child2 = service.createChildNote(parent.getId(), "Child2");
+
+        service.indentNote(child2.getId());
+
+        List<Note> child1Children = service.getChildren(child1.getId());
+        assertEquals(2, child1Children.size());
+        assertEquals("ExistingGrandchild", child1Children.get(0).getTitle());
+        assertEquals("Child2", child1Children.get(1).getTitle());
+    }
+
+    @Test
+    @DisplayName("indentNote() throws when note does not exist")
+    void indentNote_shouldThrowForMissingNote() {
+        assertThrows(NoSuchElementException.class,
+                () -> service.indentNote(UUID.randomUUID()));
+    }
+
+    // --- outdentNote tests ---
+
+    @Test
+    @DisplayName("outdentNote() moves note to be sibling of parent")
+    void outdentNote_shouldMoveToGrandparent() {
+        Note root = service.createNote("Root", "");
+        Note parent = service.createChildNote(root.getId(), "Parent");
+        Note child = service.createChildNote(parent.getId(), "Child");
+
+        Note outdented = service.outdentNote(child.getId());
+
+        // child should now be under root
+        String container = ((AttributeValue.StringValue)
+                outdented.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(root.getId().toString(), container);
+
+        // parent should have no children
+        assertTrue(service.getChildren(parent.getId()).isEmpty());
+
+        // root should have parent and child
+        List<Note> rootChildren = service.getChildren(root.getId());
+        assertEquals(2, rootChildren.size());
+    }
+
+    @Test
+    @DisplayName("outdentNote() places note just after old parent in grandparent's children")
+    void outdentNote_shouldPlaceAfterOldParent() {
+        Note root = service.createNote("Root", "");
+        Note parent = service.createChildNote(root.getId(), "Parent");
+        service.createChildNote(root.getId(), "Uncle");
+        Note child = service.createChildNote(parent.getId(), "Child");
+
+        service.outdentNote(child.getId());
+
+        List<Note> rootChildren = service.getChildren(root.getId());
+        assertEquals(3, rootChildren.size());
+        assertEquals("Parent", rootChildren.get(0).getTitle());
+        assertEquals("Child", rootChildren.get(1).getTitle());
+        assertEquals("Uncle", rootChildren.get(2).getTitle());
+    }
+
+    @Test
+    @DisplayName("outdentNote() returns unchanged when note has no parent ($Container)")
+    void outdentNote_shouldReturnUnchangedWhenNoParent() {
+        Note root = service.createNote("Root", "");
+
+        Note result = service.outdentNote(root.getId());
+
+        assertEquals(root.getId(), result.getId());
+        // Should still have no $Container
+        assertTrue(result.getAttribute("$Container").isEmpty());
+    }
+
+    @Test
+    @DisplayName("outdentNote() returns unchanged when parent has no grandparent")
+    void outdentNote_shouldReturnUnchangedWhenParentIsTopLevel() {
+        Note topLevel = service.createNote("TopLevel", "");
+        Note child = service.createChildNote(topLevel.getId(), "Child");
+
+        // topLevel has no $Container, so child can't outdent further
+        // Actually, topLevel has no $Container, but child's parent is topLevel.
+        // The outdent should check if the parent (topLevel) has a $Container.
+        // Since topLevel doesn't, child is already at the shallowest indentable level.
+        Note result = service.outdentNote(child.getId());
+
+        // Should remain under topLevel
+        String container = ((AttributeValue.StringValue)
+                result.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(topLevel.getId().toString(), container);
+    }
+
+    @Test
+    @DisplayName("outdentNote() throws when note does not exist")
+    void outdentNote_shouldThrowForMissingNote() {
+        assertThrows(NoSuchElementException.class,
+                () -> service.outdentNote(UUID.randomUUID()));
+    }
 }


### PR DESCRIPTION
## Summary

- Add outliner interaction model for rapid note entry: single-click starts editing, Enter creates sibling, Tab indents, Shift+Tab outdents
- Implement three new service-layer operations (`createSiblingNote`, `indentNote`, `outdentNote`) with full TDD test coverage
- Rewrite `OutlineViewController` TreeCell to support immediate single-click editing and keyboard-driven outline manipulation

## Test plan

- [x] 315 tests pass (`./mvnw verify`)
- [x] Checkstyle: 0 violations
- [x] JaCoCo: all coverage checks met
- [x] ArchUnit: all architecture rules pass
- [ ] Manual: single-click a note title and verify immediate edit mode
- [ ] Manual: type a title, press Enter, verify new sibling appears in edit mode below
- [ ] Manual: press Tab during edit, verify note indents under the note above
- [ ] Manual: press Shift+Tab during edit, verify note outdents to parent level
- [ ] Manual: press Escape during edit, verify edit is cancelled

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)