### PR TITLE
Fix outline view: commit edit on focus loss

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -230,6 +230,7 @@ public class OutlineViewController {
 
         private TextField textField;
         private boolean editing;
+        private boolean escapeCancelled;
 
         OutlineNoteTreeCell() {
             setOnMouseClicked(event -> {
@@ -255,16 +256,21 @@ public class OutlineViewController {
                 return;
             }
             editing = true;
+            escapeCancelled = false;
             textField = new TextField(getItem().getTitle());
             textField.selectAll();
 
             // Key handling on the text field
             textField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleEditKeyPress);
 
-            // Commit on focus lost
+            // Focus lost: commit unless Escape was pressed
             textField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
                 if (!isFocused && editing) {
-                    commitInlineEdit();
+                    if (escapeCancelled) {
+                        cancelInlineEdit();
+                    } else {
+                        commitInlineEdit();
+                    }
                 }
             });
 
@@ -296,6 +302,7 @@ public class OutlineViewController {
                 }
                 event.consume();
             } else if (event.getCode() == KeyCode.ESCAPE) {
+                escapeCancelled = true;
                 cancelInlineEdit();
                 event.consume();
             }
@@ -336,9 +343,14 @@ public class OutlineViewController {
         protected void updateItem(NoteDisplayItem item, boolean empty) {
             super.updateItem(item, empty);
             if (empty || item == null) {
+                // Cell recycled — commit any in-progress edit before clearing
+                if (editing && textField != null && !escapeCancelled) {
+                    commitInlineEdit();
+                }
                 setText(null);
                 setGraphic(null);
                 editing = false;
+                escapeCancelled = false;
             } else if (editing && textField != null) {
                 setText(null);
                 setGraphic(textField);


### PR DESCRIPTION
## Summary
- Add `escapeCancelled` boolean flag to `OutlineNoteTreeCell` to distinguish Escape-triggered focus loss from click-away focus loss
- Focus lost on the TextField now commits the edit (saves the trimmed title via `viewModel.renameNote()`) unless Escape was pressed
- Commit in-progress edits in `updateItem()` when the cell is recycled (handles the case where clicking another note causes cell reuse before the focus-lost listener fires)
- Empty/blank titles are still reverted to the original (no save)

## Test plan
- [ ] Edit a note title, click another note -- first note's edit is saved, second note is selected
- [ ] Edit a note title, click empty space -- edit is saved
- [ ] Edit a note title, press Escape -- edit is canceled (reverted)
- [ ] Edit a note title, press Enter -- edit is saved and sibling is created
- [ ] Edit a note title to blank, click away -- reverts to original title
- [ ] `mvn verify` passes (315 tests, checkstyle, coverage)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)