### PR TITLE
Fix Map and Outline view sync with shared refresh callback

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -82,25 +82,14 @@ public class App extends Application {
         OutlineViewController outlineController = outlineLoader.getController();
         outlineController.initViewModel(outlineViewModel);
 
-        // Synchronize: when map creates a note, refresh outline and vice versa.
-        // Use a flag to prevent infinite listener loops.
-        final boolean[] syncing = {false};
-        mapViewModel.getNoteItems().addListener(
-                (javafx.collections.ListChangeListener<Object>) change -> {
-                    if (!syncing[0]) {
-                        syncing[0] = true;
-                        outlineViewModel.loadNotes();
-                        syncing[0] = false;
-                    }
-                });
-        outlineViewModel.getRootItems().addListener(
-                (javafx.collections.ListChangeListener<Object>) change -> {
-                    if (!syncing[0]) {
-                        syncing[0] = true;
-                        mapViewModel.loadNotes();
-                        syncing[0] = false;
-                    }
-                });
+        // Synchronize: any mutation in either view triggers both to reload
+        // from the shared NoteService/Repository.
+        Runnable refreshAll = () -> {
+            mapViewModel.loadNotes();
+            outlineViewModel.loadNotes();
+        };
+        mapViewModel.setOnDataChanged(refreshAll);
+        outlineViewModel.setOnDataChanged(refreshAll);
 
         // Wrap each view with a title label
         Label mapLabel = new Label();

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -47,6 +47,7 @@ public final class MapViewModel {
     private final StringProperty rootNoteTitle;
     private final Deque<UUID> navigationHistory = new ArrayDeque<>();
     private UUID baseNoteId;
+    private Runnable onDataChanged;
 
     /**
      * Constructs a MapViewModel that derives its tab title from the given note title property.
@@ -66,6 +67,21 @@ public final class MapViewModel {
                 updateTabTitle(newVal);
             }
         });
+    }
+
+    /**
+     * Sets a callback to be invoked after any mutation operation.
+     *
+     * @param callback the callback to invoke, or null to clear
+     */
+    public void setOnDataChanged(Runnable callback) {
+        this.onDataChanged = callback;
+    }
+
+    private void notifyDataChanged() {
+        if (onDataChanged != null) {
+            onDataChanged.run();
+        }
     }
 
     /** Returns the tab title property. */
@@ -129,6 +145,7 @@ public final class MapViewModel {
         Note child = noteService.createChildNote(baseNoteId, title);
         NoteDisplayItem item = toDisplayItem(child);
         noteItems.add(item);
+        notifyDataChanged();
         return item;
     }
 
@@ -147,6 +164,7 @@ public final class MapViewModel {
         child.setAttribute("$Ypos", new AttributeValue.NumberValue(ypos / SCALE_Y));
         NoteDisplayItem item = toDisplayItem(child);
         noteItems.add(item);
+        notifyDataChanged();
         return item;
     }
 
@@ -178,6 +196,7 @@ public final class MapViewModel {
                 break;
             }
         }
+        notifyDataChanged();
         return true;
     }
 
@@ -193,6 +212,7 @@ public final class MapViewModel {
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
+        notifyDataChanged();
     }
 
     /**
@@ -211,6 +231,7 @@ public final class MapViewModel {
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();
+        notifyDataChanged();
     }
 
     private void updateTabTitle(String title) {
@@ -241,6 +262,7 @@ public final class MapViewModel {
                 break;
             }
         }
+        notifyDataChanged();
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -42,6 +42,7 @@ public final class OutlineViewModel {
     private final StringProperty rootNoteTitle;
     private final Deque<UUID> navigationHistory = new ArrayDeque<>();
     private UUID baseNoteId;
+    private Runnable onDataChanged;
 
     /**
      * Constructs an OutlineViewModel that derives its tab title from the given note title property.
@@ -61,6 +62,21 @@ public final class OutlineViewModel {
                 updateTabTitle(newVal);
             }
         });
+    }
+
+    /**
+     * Sets a callback to be invoked after any mutation operation.
+     *
+     * @param callback the callback to invoke, or null to clear
+     */
+    public void setOnDataChanged(Runnable callback) {
+        this.onDataChanged = callback;
+    }
+
+    private void notifyDataChanged() {
+        if (onDataChanged != null) {
+            onDataChanged.run();
+        }
     }
 
     /** Returns the tab title property. */
@@ -127,6 +143,7 @@ public final class OutlineViewModel {
         if (parentId.equals(baseNoteId)) {
             rootItems.add(item);
         }
+        notifyDataChanged();
         return item;
     }
 
@@ -141,6 +158,7 @@ public final class OutlineViewModel {
         Note sibling = noteService.createSiblingNote(siblingId, title);
         NoteDisplayItem item = toDisplayItem(sibling);
         loadNotes();
+        notifyDataChanged();
         return item;
     }
 
@@ -152,6 +170,7 @@ public final class OutlineViewModel {
     public void indentNote(UUID noteId) {
         noteService.indentNote(noteId);
         loadNotes();
+        notifyDataChanged();
     }
 
     /**
@@ -162,6 +181,7 @@ public final class OutlineViewModel {
     public void outdentNote(UUID noteId) {
         noteService.outdentNote(noteId);
         loadNotes();
+        notifyDataChanged();
     }
 
     /**
@@ -187,6 +207,7 @@ public final class OutlineViewModel {
                 break;
             }
         }
+        notifyDataChanged();
         return true;
     }
 
@@ -207,6 +228,7 @@ public final class OutlineViewModel {
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
+        notifyDataChanged();
     }
 
     /**
@@ -225,6 +247,7 @@ public final class OutlineViewModel {
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();
+        notifyDataChanged();
     }
 
     /**

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ViewSyncTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ViewSyncTest.java
@@ -1,0 +1,190 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that MapViewModel and OutlineViewModel stay in sync when they
+ * share the same NoteService and are wired with an onDataChanged callback.
+ */
+class ViewSyncTest {
+
+    private MapViewModel mapViewModel;
+    private OutlineViewModel outlineViewModel;
+    private NoteService noteService;
+    private InMemoryNoteRepository repository;
+    private Note root;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        StringProperty noteTitle = new SimpleStringProperty("Root");
+
+        mapViewModel = new MapViewModel(noteTitle, noteService);
+        outlineViewModel = new OutlineViewModel(noteTitle, noteService);
+
+        root = noteService.createNote("Root", "");
+        mapViewModel.setBaseNoteId(root.getId());
+        outlineViewModel.setBaseNoteId(root.getId());
+
+        // Wire the shared refresh callback (same pattern as App.java)
+        Runnable refreshAll = () -> {
+            mapViewModel.loadNotes();
+            outlineViewModel.loadNotes();
+        };
+        mapViewModel.setOnDataChanged(refreshAll);
+        outlineViewModel.setOnDataChanged(refreshAll);
+
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+    }
+
+    @Test
+    @DisplayName("Creating a note in Outline refreshes Map view")
+    void createInOutline_shouldRefreshMap() {
+        outlineViewModel.createChildNote(root.getId(), "New Note");
+
+        assertEquals(1, mapViewModel.getNoteItems().size());
+        assertEquals("New Note", mapViewModel.getNoteItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Creating a note in Map refreshes Outline view")
+    void createInMap_shouldRefreshOutline() {
+        mapViewModel.createChildNote("New Note");
+
+        assertEquals(1, outlineViewModel.getRootItems().size());
+        assertEquals("New Note", outlineViewModel.getRootItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Renaming a note in Outline refreshes Map view")
+    void renameInOutline_shouldRefreshMap() {
+        Note child = noteService.createChildNote(root.getId(), "Original");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        outlineViewModel.renameNote(child.getId(), "Renamed");
+
+        assertEquals("Renamed", mapViewModel.getNoteItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Renaming a note in Map refreshes Outline view")
+    void renameInMap_shouldRefreshOutline() {
+        Note child = noteService.createChildNote(root.getId(), "Original");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        mapViewModel.renameNote(child.getId(), "Renamed");
+
+        assertEquals("Renamed", outlineViewModel.getRootItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Indenting a note in Outline refreshes Map view with hasChildren")
+    void indentInOutline_shouldRefreshMapWithHasChildren() {
+        noteService.createChildNote(root.getId(), "Child1");
+        Note child2 = noteService.createChildNote(root.getId(), "Child2");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        outlineViewModel.indentNote(child2.getId());
+
+        // Map should show only Child1 and it should have children
+        assertEquals(1, mapViewModel.getNoteItems().size());
+        assertEquals("Child1", mapViewModel.getNoteItems().get(0).getTitle());
+        assertTrue(mapViewModel.getNoteItems().get(0).isHasChildren());
+    }
+
+    @Test
+    @DisplayName("Outdenting a note in Outline refreshes Map view")
+    void outdentInOutline_shouldRefreshMap() {
+        Note child1 = noteService.createChildNote(root.getId(), "Child1");
+        noteService.createChildNote(child1.getId(), "Grandchild");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        outlineViewModel.outdentNote(
+                noteService.getChildren(child1.getId()).get(0).getId());
+
+        // Map should now show Child1 and Grandchild at root level
+        assertEquals(2, mapViewModel.getNoteItems().size());
+    }
+
+    @Test
+    @DisplayName("Creating a sibling in Outline refreshes Map view")
+    void createSiblingInOutline_shouldRefreshMap() {
+        Note child1 = noteService.createChildNote(root.getId(), "Child1");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        outlineViewModel.createSiblingNote(child1.getId(), "Sibling");
+
+        assertEquals(2, mapViewModel.getNoteItems().size());
+    }
+
+    @Test
+    @DisplayName("Drill-down in Map refreshes Outline to same level")
+    void drillDownInMap_shouldNotifyDataChanged() {
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        mapViewModel.drillDown(child.getId());
+
+        // After drillDown, the callback fires, reloading both.
+        // Map should show grandchild, outline should still show root's children.
+        assertEquals(1, mapViewModel.getNoteItems().size());
+        assertEquals("Grandchild", mapViewModel.getNoteItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Navigate back in Map refreshes views")
+    void navigateBackInMap_shouldNotifyDataChanged() {
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+        mapViewModel.drillDown(child.getId());
+
+        mapViewModel.navigateBack();
+
+        assertEquals(1, mapViewModel.getNoteItems().size());
+        assertEquals("Child", mapViewModel.getNoteItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("updateNotePosition in Map notifies data changed")
+    void updatePositionInMap_shouldNotifyDataChanged() {
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        mapViewModel.updateNotePosition(child.getId(), 100.0, 200.0);
+
+        // Position update triggers refresh; map should still have the item
+        assertEquals(1, mapViewModel.getNoteItems().size());
+    }
+
+    @Test
+    @DisplayName("createChildNoteAt in Map notifies data changed and refreshes Outline")
+    void createChildNoteAtInMap_shouldRefreshOutline() {
+        mapViewModel.createChildNoteAt("Placed Note", 50.0, 75.0);
+
+        assertEquals(1, outlineViewModel.getRootItems().size());
+        assertEquals("Placed Note", outlineViewModel.getRootItems().get(0).getTitle());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the fragile cross-listener sync mechanism (`syncing` flag + `ListChangeListener`) with an `onDataChanged` callback pattern
- Both `MapViewModel` and `OutlineViewModel` call `notifyDataChanged()` after every mutation (create, rename, indent, outdent, createSibling, drillDown, navigateBack, updatePosition)
- `App.java` wires a single `refreshAll` callback that reloads both views from the shared `NoteService`
- `loadNotes()` does NOT trigger the callback, preventing infinite loops

## Test plan
- [x] 11 new tests in `ViewSyncTest` covering cross-view sync for all mutation operations
- [x] All 326 tests pass
- [x] Checkstyle: 0 violations
- [x] JaCoCo: all coverage checks met
- [x] ArchUnit: ViewModels do not reference javafx.scene classes (Runnable is java.lang)
- [x] `mvnw verify` passes cleanly

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)