### PR TITLE
Map UX: bring dragged note to front, Enter creates sibling

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -2,11 +2,13 @@ package com.embervault.adapter.in.ui.view;
 
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
@@ -171,6 +173,7 @@ public class MapViewController {
         textBox.setClip(clip);
 
         StackPane notePane = new StackPane(rect, textBox);
+        notePane.setUserData(item.getId());
         notePane.setAlignment(Pos.TOP_LEFT);
         notePane.setLayoutX(item.getXpos());
         notePane.setLayoutY(item.getYpos());
@@ -244,8 +247,21 @@ public class MapViewController {
             }
         };
 
-        // Commit on Enter
-        textField.setOnAction(e -> commitEdit.run());
+        // Commit on Enter, then create sibling and start editing it
+        textField.setOnAction(e -> {
+            commitEdit.run();
+            NoteDisplayItem newItem = viewModel.createSiblingNote(
+                    item.getId(), "");
+            Platform.runLater(() -> {
+                for (Node child : mapCanvas.getChildren()) {
+                    if (child instanceof StackPane sp
+                            && newItem.getId().equals(sp.getUserData())) {
+                        startInlineEditOnNode(sp, newItem);
+                        break;
+                    }
+                }
+            });
+        });
 
         // Cancel on Escape
         textField.setOnKeyPressed(e -> {
@@ -264,6 +280,17 @@ public class MapViewController {
     }
 
     /**
+     * Starts inline editing on a note pane found by ID after a re-render.
+     */
+    private void startInlineEditOnNode(StackPane notePane,
+            NoteDisplayItem item) {
+        VBox textBox = (VBox) notePane.getChildren().get(1);
+        Label titleLabel = (Label) textBox.getChildren().get(0);
+        Rectangle rect = (Rectangle) notePane.getChildren().get(0);
+        startInlineEdit(notePane, titleLabel, rect, item);
+    }
+
+    /**
      * Installs drag handlers on the note pane while allowing click events to
      * propagate to children (title label, rectangle).
      *
@@ -279,6 +306,7 @@ public class MapViewController {
             dragDelta[0] = notePane.getLayoutX() - event.getSceneX();
             dragDelta[1] = notePane.getLayoutY() - event.getSceneY();
             dragging[0] = false;
+            notePane.toFront();
             viewModel.selectNote(item.getId());
             highlightSelected(notePane);
             // Do NOT consume – let the event reach child click handlers
@@ -305,7 +333,7 @@ public class MapViewController {
     }
 
     private void highlightSelected(StackPane selected) {
-        for (javafx.scene.Node child : mapCanvas.getChildren()) {
+        for (Node child : mapCanvas.getChildren()) {
             if (child instanceof StackPane sp && !sp.getChildren().isEmpty()
                     && sp.getChildren().get(0) instanceof Rectangle r) {
                 r.setStrokeWidth(NORMAL_BORDER_WIDTH);

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -168,6 +168,39 @@ public final class MapViewModel {
         return item;
     }
 
+    /**
+     * Creates a new sibling note after the given sibling, positioned slightly below it.
+     *
+     * @param siblingId the id of the note to create a sibling after
+     * @param title     the title for the new note (may be empty for rapid entry)
+     * @return the display item for the created note
+     */
+    public NoteDisplayItem createSiblingNote(UUID siblingId, String title) {
+        Note sibling = noteService.createSiblingNote(siblingId, title);
+        // Position the new note near the original sibling
+        NoteDisplayItem siblingItem = findItemById(siblingId);
+        if (siblingItem != null) {
+            double offsetY = siblingItem.getYpos() + siblingItem.getHeight() + 20;
+            sibling.setAttribute("$Xpos",
+                    new AttributeValue.NumberValue(siblingItem.getXpos() / SCALE_X));
+            sibling.setAttribute("$Ypos",
+                    new AttributeValue.NumberValue(offsetY / SCALE_Y));
+        }
+        NoteDisplayItem item = toDisplayItem(sibling);
+        noteItems.add(item);
+        notifyDataChanged();
+        return item;
+    }
+
+    private NoteDisplayItem findItemById(UUID noteId) {
+        for (NoteDisplayItem item : noteItems) {
+            if (item.getId().equals(noteId)) {
+                return item;
+            }
+        }
+        return null;
+    }
+
     /** Returns the canNavigateBack property. */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
         return canNavigateBack;

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
@@ -223,6 +223,69 @@ class MapViewModelTest {
     }
 
     @Test
+    @DisplayName("createSiblingNote() delegates to service and adds item to list")
+    void createSiblingNote_shouldDelegateAndAddItem() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        NoteDisplayItem existing = viewModel.createChildNote("First");
+
+        NoteDisplayItem sibling = viewModel.createSiblingNote(
+                existing.getId(), "Second");
+
+        assertNotNull(sibling);
+        assertEquals("Second", sibling.getTitle());
+        assertEquals(2, viewModel.getNoteItems().size());
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() positions new note near the original sibling")
+    void createSiblingNote_shouldPositionNearSibling() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        NoteDisplayItem existing = viewModel.createChildNote("First");
+        viewModel.updateNotePosition(existing.getId(), 100.0, 50.0);
+        // Re-fetch the updated item after position change
+        NoteDisplayItem updated = viewModel.getNoteItems().get(0);
+
+        NoteDisplayItem sibling = viewModel.createSiblingNote(
+                updated.getId(), "Second");
+
+        // New note should share the sibling's x position
+        assertEquals(100.0, sibling.getXpos(), 0.01);
+        // New note should be offset below the sibling
+        assertTrue(sibling.getYpos() > updated.getYpos(),
+                "Sibling should be positioned below the original note");
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() notifies data changed")
+    void createSiblingNote_shouldNotifyDataChanged() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        NoteDisplayItem existing = viewModel.createChildNote("First");
+        boolean[] notified = {false};
+        viewModel.setOnDataChanged(() -> notified[0] = true);
+
+        viewModel.createSiblingNote(existing.getId(), "Second");
+
+        assertTrue(notified[0]);
+    }
+
+    @Test
+    @DisplayName("createSiblingNote() with empty title creates note")
+    void createSiblingNote_withEmptyTitle_shouldCreateNote() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        NoteDisplayItem existing = viewModel.createChildNote("First");
+
+        NoteDisplayItem sibling = viewModel.createSiblingNote(
+                existing.getId(), "");
+
+        assertNotNull(sibling);
+        assertEquals(2, viewModel.getNoteItems().size());
+    }
+
+    @Test
     @DisplayName("drillDown() changes baseNoteId and reloads children")
     void drillDown_shouldChangeBaseAndReload() {
         Note root = noteService.createNote("Root", "");


### PR DESCRIPTION
## Summary
- **#71**: Call `notePane.toFront()` in the `mousePressed` handler so dragged notes render above all other notes in the Map view
- **#72**: Pressing Enter during inline title edit now commits the edit, creates a sibling note positioned below the current note, and immediately starts editing the new note's title for rapid sequential entry
- Added `MapViewModel.createSiblingNote()` which delegates to `NoteService.createSiblingNote()` and positions the new note near the original
- Store note ID via `setUserData()` on each note pane to enable finding nodes after re-render

Closes #71
Closes #72

## Test plan
- [x] 4 new tests for `MapViewModel.createSiblingNote()` (delegation, positioning, data-changed notification, empty title)
- [x] All 330 tests pass
- [x] Checkstyle clean (0 violations)
- [x] JaCoCo coverage checks met
- [ ] Manual: drag a note and verify it appears on top of other notes
- [ ] Manual: double-click title, type, press Enter — verify sibling is created and editing starts on it
- [ ] Manual: press Escape during edit — verify no sibling is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)