### PR TITLE
Outline view: backspace on empty title deletes note and selects previous

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -301,6 +301,21 @@ public class OutlineViewController {
                     refreshAndEdit(currentItem.getId());
                 }
                 event.consume();
+            } else if (event.getCode() == KeyCode.BACK_SPACE
+                    && textField.getText().isEmpty()) {
+                UUID noteId = getItem().getId();
+                if (!viewModel.hasChildren(noteId)) {
+                    UUID previousId = viewModel.getPreviousNoteId(noteId);
+                    editing = false;
+                    setText(null);
+                    setGraphic(null);
+                    textField = null;
+                    viewModel.deleteNote(noteId);
+                    if (previousId != null) {
+                        refreshAndEdit(previousId);
+                    }
+                }
+                event.consume();
             } else if (event.getCode() == KeyCode.ESCAPE) {
                 escapeCancelled = true;
                 cancelInlineEdit();

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -251,6 +251,43 @@ public final class OutlineViewModel {
     }
 
     /**
+     * Returns whether the note with the given id has any children.
+     *
+     * @param noteId the note id
+     * @return true if the note has children
+     */
+    public boolean hasChildren(UUID noteId) {
+        return noteService.hasChildren(noteId);
+    }
+
+    /**
+     * Returns the id of the previous note in outline order, or null if none.
+     *
+     * @param noteId the note id
+     * @return the previous note id, or null
+     */
+    public UUID getPreviousNoteId(UUID noteId) {
+        return noteService.getPreviousInOutline(noteId)
+                .map(Note::getId)
+                .orElse(null);
+    }
+
+    /**
+     * Deletes a leaf note and reloads the tree.
+     *
+     * @param noteId the note id to delete
+     * @return true if the note was deleted, false if it has children or does not exist
+     */
+    public boolean deleteNote(UUID noteId) {
+        boolean deleted = noteService.deleteNoteIfLeaf(noteId);
+        if (deleted) {
+            loadNotes();
+            notifyDataChanged();
+        }
+        return deleted;
+    }
+
+    /**
      * Returns the children of the given note as display items.
      *
      * @param parentId the parent note id

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -299,6 +299,66 @@ public final class NoteServiceImpl implements NoteService {
         repository.delete(id);
     }
 
+    @Override
+    public Optional<Note> getPreviousInOutline(UUID noteId) {
+        Note note = repository.findById(noteId)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Note not found: " + noteId));
+
+        String containerId = note.getAttribute("$Container")
+                .filter(v -> v instanceof AttributeValue.StringValue)
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .orElse(null);
+
+        if (containerId == null) {
+            return Optional.empty();
+        }
+
+        UUID parentId = UUID.fromString(containerId);
+        double noteOrder = note.getAttribute("$OutlineOrder")
+                .filter(v -> v instanceof AttributeValue.NumberValue)
+                .map(v -> ((AttributeValue.NumberValue) v).value())
+                .orElse(0.0);
+
+        // Find the sibling with the next-lower outline order
+        List<Note> siblings = repository.findChildren(parentId);
+        Note previousSibling = null;
+        double bestOrder = Double.NEGATIVE_INFINITY;
+        for (Note s : siblings) {
+            if (s.getId().equals(noteId)) {
+                continue;
+            }
+            double order = s.getAttribute("$OutlineOrder")
+                    .filter(v -> v instanceof AttributeValue.NumberValue)
+                    .map(v -> ((AttributeValue.NumberValue) v).value())
+                    .orElse(0.0);
+            if (order < noteOrder && order > bestOrder) {
+                bestOrder = order;
+                previousSibling = s;
+            }
+        }
+
+        if (previousSibling != null) {
+            return Optional.of(previousSibling);
+        }
+
+        // No previous sibling — return the parent note
+        return repository.findById(parentId);
+    }
+
+    @Override
+    public boolean deleteNoteIfLeaf(UUID noteId) {
+        Optional<Note> noteOpt = repository.findById(noteId);
+        if (noteOpt.isEmpty()) {
+            return false;
+        }
+        if (hasChildren(noteId)) {
+            return false;
+        }
+        repository.delete(noteId);
+        return true;
+    }
+
     /**
      * Creates a note allowing an empty title by using the AttributeMap constructor.
      */

--- a/src/main/java/com/embervault/application/port/in/NoteService.java
+++ b/src/main/java/com/embervault/application/port/in/NoteService.java
@@ -112,4 +112,25 @@ public interface NoteService {
      * Deletes the note with the given id.
      */
     void deleteNote(UUID id);
+
+    /**
+     * Returns the previous note in outline order for the given note.
+     *
+     * <p>The previous note is the sibling with the next-lower {@code $OutlineOrder}
+     * within the same {@code $Container}. If no previous sibling exists, the parent
+     * note (the {@code $Container} note) is returned. If there is no parent,
+     * {@code Optional.empty()} is returned.</p>
+     *
+     * @param noteId the note id
+     * @return the previous note, or empty if none
+     */
+    Optional<Note> getPreviousInOutline(UUID noteId);
+
+    /**
+     * Deletes the note only if it is a leaf (has no children).
+     *
+     * @param noteId the note id
+     * @return true if the note was deleted, false if it has children or does not exist
+     */
+    boolean deleteNoteIfLeaf(UUID noteId);
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -459,4 +459,108 @@ class OutlineViewModelTest {
         assertEquals("Parent", viewModel.getRootItems().get(0).getTitle());
         assertEquals("Child", viewModel.getRootItems().get(1).getTitle());
     }
+
+    // --- hasChildren tests ---
+
+    @Test
+    @DisplayName("hasChildren() returns true when note has children")
+    void hasChildren_shouldReturnTrue() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+
+        assertTrue(viewModel.hasChildren(child.getId()));
+    }
+
+    @Test
+    @DisplayName("hasChildren() returns false when note has no children")
+    void hasChildren_shouldReturnFalse() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+
+        assertFalse(viewModel.hasChildren(child.getId()));
+    }
+
+    // --- getPreviousNoteId tests ---
+
+    @Test
+    @DisplayName("getPreviousNoteId() returns previous sibling id")
+    void getPreviousNoteId_shouldReturnPreviousSiblingId() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child1 = noteService.createChildNote(parent.getId(), "Child1");
+        Note child2 = noteService.createChildNote(parent.getId(), "Child2");
+
+        UUID previousId = viewModel.getPreviousNoteId(child2.getId());
+
+        assertEquals(child1.getId(), previousId);
+    }
+
+    @Test
+    @DisplayName("getPreviousNoteId() returns parent id when first child")
+    void getPreviousNoteId_shouldReturnParentIdWhenFirstChild() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+
+        UUID previousId = viewModel.getPreviousNoteId(child.getId());
+
+        assertEquals(parent.getId(), previousId);
+    }
+
+    @Test
+    @DisplayName("getPreviousNoteId() returns null when no previous")
+    void getPreviousNoteId_shouldReturnNullWhenNoPrevious() {
+        Note root = noteService.createNote("Root", "");
+
+        UUID previousId = viewModel.getPreviousNoteId(root.getId());
+
+        assertNull(previousId);
+    }
+
+    // --- deleteNote tests ---
+
+    @Test
+    @DisplayName("deleteNote() deletes leaf note and reloads tree")
+    void deleteNote_shouldDeleteLeafAndReload() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        noteService.createChildNote(parent.getId(), "Child1");
+        Note child2 = noteService.createChildNote(parent.getId(), "Child2");
+        viewModel.loadNotes();
+
+        boolean result = viewModel.deleteNote(child2.getId());
+
+        assertTrue(result);
+        assertEquals(1, viewModel.getRootItems().size());
+        assertEquals("Child1", viewModel.getRootItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("deleteNote() does not delete note with children")
+    void deleteNote_shouldNotDeleteNoteWithChildren() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        viewModel.loadNotes();
+
+        boolean result = viewModel.deleteNote(child.getId());
+
+        assertFalse(result);
+        assertEquals(1, viewModel.getRootItems().size());
+    }
+
+    @Test
+    @DisplayName("deleteNote() notifies data changed on success")
+    void deleteNote_shouldNotifyDataChanged() {
+        Note parent = noteService.createNote("Parent", "");
+        viewModel.setBaseNoteId(parent.getId());
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        viewModel.loadNotes();
+        boolean[] notified = {false};
+        viewModel.setOnDataChanged(() -> notified[0] = true);
+
+        viewModel.deleteNote(child.getId());
+
+        assertTrue(notified[0]);
+    }
 }

--- a/src/test/java/com/embervault/application/NoteServiceImplTest.java
+++ b/src/test/java/com/embervault/application/NoteServiceImplTest.java
@@ -502,4 +502,97 @@ class NoteServiceImplTest {
         assertThrows(NoSuchElementException.class,
                 () -> service.outdentNote(UUID.randomUUID()));
     }
+
+    // --- getPreviousInOutline tests ---
+
+    @Test
+    @DisplayName("getPreviousInOutline() returns previous sibling")
+    void getPreviousInOutline_shouldReturnPreviousSibling() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+        Note child2 = service.createChildNote(parent.getId(), "Child2");
+
+        Optional<Note> previous = service.getPreviousInOutline(child2.getId());
+
+        assertTrue(previous.isPresent());
+        assertEquals(child1.getId(), previous.get().getId());
+    }
+
+    @Test
+    @DisplayName("getPreviousInOutline() returns parent when note is first child")
+    void getPreviousInOutline_shouldReturnParentWhenFirstChild() {
+        Note parent = service.createNote("Parent", "");
+        Note child = service.createChildNote(parent.getId(), "Child");
+
+        Optional<Note> previous = service.getPreviousInOutline(child.getId());
+
+        assertTrue(previous.isPresent());
+        assertEquals(parent.getId(), previous.get().getId());
+    }
+
+    @Test
+    @DisplayName("getPreviousInOutline() returns empty when note has no container")
+    void getPreviousInOutline_shouldReturnEmptyWhenNoContainer() {
+        Note root = service.createNote("Root", "");
+
+        Optional<Note> previous = service.getPreviousInOutline(root.getId());
+
+        assertTrue(previous.isEmpty());
+    }
+
+    @Test
+    @DisplayName("getPreviousInOutline() returns correct sibling among many")
+    void getPreviousInOutline_shouldReturnCorrectSiblingAmongMany() {
+        Note parent = service.createNote("Parent", "");
+        Note child1 = service.createChildNote(parent.getId(), "Child1");
+        Note child2 = service.createChildNote(parent.getId(), "Child2");
+        Note child3 = service.createChildNote(parent.getId(), "Child3");
+
+        Optional<Note> previous = service.getPreviousInOutline(child3.getId());
+
+        assertTrue(previous.isPresent());
+        assertEquals(child2.getId(), previous.get().getId());
+    }
+
+    @Test
+    @DisplayName("getPreviousInOutline() throws when note does not exist")
+    void getPreviousInOutline_shouldThrowForMissingNote() {
+        assertThrows(NoSuchElementException.class,
+                () -> service.getPreviousInOutline(UUID.randomUUID()));
+    }
+
+    // --- deleteNoteIfLeaf tests ---
+
+    @Test
+    @DisplayName("deleteNoteIfLeaf() deletes leaf note and returns true")
+    void deleteNoteIfLeaf_shouldDeleteLeafNote() {
+        Note parent = service.createNote("Parent", "");
+        Note child = service.createChildNote(parent.getId(), "Child");
+
+        boolean result = service.deleteNoteIfLeaf(child.getId());
+
+        assertTrue(result);
+        assertTrue(service.getNote(child.getId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("deleteNoteIfLeaf() does not delete note with children and returns false")
+    void deleteNoteIfLeaf_shouldNotDeleteNoteWithChildren() {
+        Note parent = service.createNote("Parent", "");
+        Note child = service.createChildNote(parent.getId(), "Child");
+        service.createChildNote(child.getId(), "Grandchild");
+
+        boolean result = service.deleteNoteIfLeaf(child.getId());
+
+        assertFalse(result);
+        assertTrue(service.getNote(child.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("deleteNoteIfLeaf() returns false when note does not exist")
+    void deleteNoteIfLeaf_shouldReturnFalseForMissingNote() {
+        boolean result = service.deleteNoteIfLeaf(UUID.randomUUID());
+
+        assertFalse(result);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `getPreviousInOutline(UUID)` and `deleteNoteIfLeaf(UUID)` to `NoteService` — finds the previous sibling (or parent) in outline order, and safely deletes only leaf notes
- Add `hasChildren()`, `getPreviousNoteId()`, and `deleteNote()` to `OutlineViewModel` — delegates to the new service methods with tree reload
- Handle `Backspace` on empty title in `OutlineNoteTreeCell` — deletes the leaf note and moves focus/editing to the previous note with cursor at end of title

## Test plan
- [x] `getPreviousInOutline()` returns previous sibling when one exists
- [x] `getPreviousInOutline()` returns parent when note is first child
- [x] `getPreviousInOutline()` returns empty when note has no container
- [x] `getPreviousInOutline()` picks correct sibling among many
- [x] `deleteNoteIfLeaf()` deletes leaf and returns true
- [x] `deleteNoteIfLeaf()` refuses to delete note with children
- [x] `deleteNoteIfLeaf()` returns false for missing note
- [x] ViewModel `hasChildren()`, `getPreviousNoteId()`, `deleteNote()` all tested
- [x] All 342 tests pass, checkstyle clean, coverage met

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)