### PR TITLE
Fix map view z-order reset after drag

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -295,7 +295,6 @@ public final class MapViewModel {
                 break;
             }
         }
-        notifyDataChanged();
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {


### PR DESCRIPTION
## Summary
- Remove `notifyDataChanged()` call from `MapViewModel.updateNotePosition()` so dragging a note no longer triggers `renderAllNotes()`, which was resetting z-order
- `notePane.toFront()` on `mousePressed` was already in place (from PR #73), so clicked/dragged notes stay on top after release

## Root cause
`updateNotePosition()` called `notifyDataChanged()` → `refreshAll` → `loadNotes()` → ObservableList change → `renderAllNotes()` cleared and recreated all canvas children in default order, undoing any `toFront()` call.

Position updates are purely cosmetic — the drag handler already moves the node visually, and the method persists coordinates via the note service. No cross-view notification is needed.

## Test plan
- [ ] Click a note overlapping another → it renders on top and stays there
- [ ] Drag a note → it stays on top during and after the drag
- [ ] Create, rename, delete notes → other views still sync correctly
- [ ] `./mvnw verify` passes (346 tests, 0 checkstyle violations, coverage met)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)