### PR TITLE
Add badge support to notes displayed across all views

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -459,6 +459,18 @@ public class App extends Application {
         stampService.createStamp("Color:blue", "$Color=blue");
         stampService.createStamp("Mark Done", "$Checked=true");
         stampService.createStamp("Mark Undone", "$Checked=false");
+
+        // Badge stamps
+        stampService.createStamp("Badge:star", "$Badge=star");
+        stampService.createStamp("Badge:flag", "$Badge=flag");
+        stampService.createStamp("Badge:check", "$Badge=check");
+        stampService.createStamp("Badge:warning", "$Badge=warning");
+        stampService.createStamp("Badge:book", "$Badge=book");
+        stampService.createStamp("Badge:person", "$Badge=person");
+        stampService.createStamp("Badge:idea", "$Badge=idea");
+        stampService.createStamp("Badge:heart", "$Badge=heart");
+        stampService.createStamp("Badge:pin", "$Badge=pin");
+        stampService.createStamp("Badge:fire", "$Badge=fire");
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
@@ -215,7 +215,9 @@ public class HyperbolicViewController {
             // Label (only if node is large enough)
             if (node.displayRadius() >= SMALL_NODE_THRESHOLD) {
                 String title = noteTitle(node.noteId());
-                Label label = new Label(title);
+                String badge = noteBadge(node.noteId());
+                String labelText = badge.isEmpty() ? title : badge + " " + title;
+                Label label = new Label(labelText);
                 label.setFont(Font.font("System", FontWeight.BOLD, LABEL_FONT_SIZE));
                 label.setTextFill(Color.WHITE);
                 label.setMouseTransparent(true);
@@ -226,7 +228,9 @@ public class HyperbolicViewController {
             } else {
                 // Tooltip for small nodes
                 String title = noteTitle(node.noteId());
-                Tooltip.install(circle, new Tooltip(title));
+                String badge = noteBadge(node.noteId());
+                String tipText = badge.isEmpty() ? title : badge + " " + title;
+                Tooltip.install(circle, new Tooltip(tipText));
             }
         }
 
@@ -260,14 +264,11 @@ public class HyperbolicViewController {
     }
 
     private String noteTitle(UUID noteId) {
-        return viewModel.getNodes().stream()
-                .filter(n -> n.noteId().equals(noteId))
-                .findFirst()
-                .map(n -> {
-                    // Try to get the note title from NoteService via ViewModel
-                    // For now, use the noteId as a fallback
-                    return noteId.toString().substring(0, 8);
-                })
-                .orElse("");
+        String title = viewModel.getNoteTitle(noteId);
+        return title.isEmpty() ? noteId.toString().substring(0, 8) : title;
+    }
+
+    private String noteBadge(UUID noteId) {
+        return viewModel.getNoteBadge(noteId);
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -173,6 +173,18 @@ public class MapViewController {
         textBox.setClip(clip);
 
         StackPane notePane = new StackPane(rect, textBox);
+
+        // Badge label in top-right corner
+        String badge = item.getBadge();
+        if (badge != null && !badge.isEmpty()) {
+            Label badgeLabel = new Label(badge);
+            badgeLabel.setFont(Font.font("System", TITLE_FONT_SIZE));
+            badgeLabel.setMouseTransparent(true);
+            badgeLabel.setPadding(new Insets(2, 4, 0, 0));
+            StackPane.setAlignment(badgeLabel, Pos.TOP_RIGHT);
+            notePane.getChildren().add(badgeLabel);
+        }
+
         notePane.setUserData(item.getId());
         notePane.setAlignment(Pos.TOP_LEFT);
         notePane.setLayoutX(item.getXpos());

--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -336,7 +336,7 @@ public class OutlineViewController {
                 }
             }
             if (item != null) {
-                setText(item.getTitle());
+                setText(badgedTitle(item));
             }
             setGraphic(null);
             textField = null;
@@ -348,10 +348,18 @@ public class OutlineViewController {
             }
             editing = false;
             if (getItem() != null) {
-                setText(getItem().getTitle());
+                setText(badgedTitle(getItem()));
             }
             setGraphic(null);
             textField = null;
+        }
+
+        private String badgedTitle(NoteDisplayItem item) {
+            String badge = item.getBadge();
+            if (badge != null && !badge.isEmpty()) {
+                return badge + " " + item.getTitle();
+            }
+            return item.getTitle();
         }
 
         @Override
@@ -370,7 +378,7 @@ public class OutlineViewController {
                 setText(null);
                 setGraphic(textField);
             } else {
-                setText(item.getTitle());
+                setText(badgedTitle(item));
                 setGraphic(null);
             }
         }

--- a/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
@@ -167,6 +167,18 @@ public class TreemapViewController {
 
         Rectangle clip = new Rectangle(rectWidth, rectHeight);
         StackPane notePane = new StackPane(rect, titleLabel);
+
+        // Badge in top-right corner if space permits
+        String badge = item.getBadge();
+        if (badge != null && !badge.isEmpty() && rectWidth > 30 && rectHeight > 20) {
+            Label badgeLabel = new Label(badge);
+            badgeLabel.setFont(Font.font("System", TITLE_FONT_SIZE));
+            badgeLabel.setMouseTransparent(true);
+            badgeLabel.setPadding(new Insets(2, 4, 0, 0));
+            StackPane.setAlignment(badgeLabel, Pos.TOP_RIGHT);
+            notePane.getChildren().add(badgeLabel);
+        }
+
         notePane.setClip(clip);
         notePane.setUserData(item.getId());
         notePane.setAlignment(Pos.CENTER);

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
@@ -13,6 +13,7 @@ import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeSchemaRegistry;
 import com.embervault.domain.AttributeType;
 import com.embervault.domain.AttributeValue;
+import com.embervault.domain.BadgeRegistry;
 import com.embervault.domain.Note;
 import com.embervault.domain.TbxColor;
 import javafx.beans.property.ObjectProperty;
@@ -216,10 +217,14 @@ public final class AttributeBrowserViewModel {
                 .map(v -> ((AttributeValue.ColorValue) v).value())
                 .map(TbxColor::toHex)
                 .orElse(DEFAULT_COLOR_HEX);
+        String badge = note.getAttribute("$Badge")
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .flatMap(BadgeRegistry::getBadgeSymbol)
+                .orElse("");
 
         return new NoteDisplayItem(
                 note.getId(), note.getTitle(), note.getContent(),
                 0, 0, 0, 0, colorHex,
-                noteService.hasChildren(note.getId()));
+                noteService.hasChildren(note.getId()), badge);
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
@@ -13,6 +13,8 @@ import java.util.UUID;
 
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.BadgeRegistry;
 import com.embervault.domain.Link;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -188,6 +190,33 @@ public final class HyperbolicViewModel {
     /** Returns the canNavigateBack property. */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
         return canNavigateBack;
+    }
+
+    /**
+     * Returns the title of the note with the given id, or an empty string.
+     *
+     * @param noteId the note id
+     * @return the note title, or empty string if not found
+     */
+    public String getNoteTitle(UUID noteId) {
+        return noteService.getNote(noteId)
+                .map(note -> note.getTitle())
+                .orElse("");
+    }
+
+    /**
+     * Returns the badge Unicode symbol for the note with the given id,
+     * or an empty string if no badge is set.
+     *
+     * @param noteId the note id
+     * @return the badge symbol, or empty string
+     */
+    public String getNoteBadge(UUID noteId) {
+        return noteService.getNote(noteId)
+                .flatMap(note -> note.getAttribute("$Badge"))
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .flatMap(BadgeRegistry::getBadgeSymbol)
+                .orElse("");
     }
 
     private void computeLayout() {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeValue;
+import com.embervault.domain.BadgeRegistry;
 import com.embervault.domain.Note;
 import com.embervault.domain.TbxColor;
 import javafx.beans.property.BooleanProperty;
@@ -225,7 +226,8 @@ public final class MapViewModel {
                         item.getId(), newTitle, item.getContent(),
                         item.getXpos(), item.getYpos(),
                         item.getWidth(), item.getHeight(),
-                        item.getColorHex(), item.isHasChildren()));
+                        item.getColorHex(), item.isHasChildren(),
+                        item.getBadge()));
                 break;
             }
         }
@@ -291,7 +293,8 @@ public final class MapViewModel {
                         item.getId(), item.getTitle(), item.getContent(),
                         xpos, ypos,
                         item.getWidth(), item.getHeight(),
-                        item.getColorHex(), item.isHasChildren()));
+                        item.getColorHex(), item.isHasChildren(),
+                        item.getBadge()));
                 break;
             }
         }
@@ -314,10 +317,18 @@ public final class MapViewModel {
                 .map(v -> ((AttributeValue.ColorValue) v).value())
                 .map(TbxColor::toHex)
                 .orElse(DEFAULT_COLOR_HEX);
+        String badge = resolveBadge(note);
 
         return new NoteDisplayItem(
                 note.getId(), note.getTitle(), note.getContent(),
                 xpos, ypos, width, height, colorHex,
-                noteService.hasChildren(note.getId()));
+                noteService.hasChildren(note.getId()), badge);
+    }
+
+    private static String resolveBadge(Note note) {
+        return note.getAttribute("$Badge")
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .flatMap(BadgeRegistry::getBadgeSymbol)
+                .orElse("");
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItem.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItem.java
@@ -20,12 +20,13 @@ public final class NoteDisplayItem {
     private final double height;
     private final String colorHex;
     private final boolean hasChildren;
+    private final String badge;
 
     /**
      * Constructs a display item with the given id, title, and content.
      */
     public NoteDisplayItem(UUID id, String title, String content) {
-        this(id, title, content, 0, 0, 6, 4, "#808080", false);
+        this(id, title, content, 0, 0, 6, 4, "#808080", false, "");
     }
 
     /**
@@ -44,6 +45,27 @@ public final class NoteDisplayItem {
     public NoteDisplayItem(UUID id, String title, String content,
             double xpos, double ypos, double width, double height,
             String colorHex, boolean hasChildren) {
+        this(id, title, content, xpos, ypos, width, height, colorHex,
+                hasChildren, "");
+    }
+
+    /**
+     * Constructs a display item with full map, outline, and badge data.
+     *
+     * @param id          the note id
+     * @param title       the note title
+     * @param content     the note content
+     * @param xpos        the x position
+     * @param ypos        the y position
+     * @param width       the width
+     * @param height      the height
+     * @param colorHex    the fill color as hex string
+     * @param hasChildren whether this note has children
+     * @param badge       the badge Unicode symbol, or empty string if none
+     */
+    public NoteDisplayItem(UUID id, String title, String content,
+            double xpos, double ypos, double width, double height,
+            String colorHex, boolean hasChildren, String badge) {
         this.id = Objects.requireNonNull(id, "id must not be null");
         this.title = Objects.requireNonNull(title, "title must not be null");
         this.content = Objects.requireNonNull(content, "content must not be null");
@@ -53,6 +75,7 @@ public final class NoteDisplayItem {
         this.height = height;
         this.colorHex = Objects.requireNonNull(colorHex, "colorHex must not be null");
         this.hasChildren = hasChildren;
+        this.badge = Objects.requireNonNull(badge, "badge must not be null");
     }
 
     /** Returns the note id. */
@@ -98,6 +121,11 @@ public final class NoteDisplayItem {
     /** Returns whether this note has children. */
     public boolean isHasChildren() {
         return hasChildren;
+    }
+
+    /** Returns the badge Unicode symbol, or empty string if no badge. */
+    public String getBadge() {
+        return badge;
     }
 
     @Override

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeValue;
+import com.embervault.domain.BadgeRegistry;
 import com.embervault.domain.Note;
 import com.embervault.domain.TbxColor;
 import javafx.beans.property.BooleanProperty;
@@ -203,7 +204,8 @@ public final class OutlineViewModel {
                         item.getId(), newTitle, item.getContent(),
                         item.getXpos(), item.getYpos(),
                         item.getWidth(), item.getHeight(),
-                        item.getColorHex(), item.isHasChildren()));
+                        item.getColorHex(), item.isHasChildren(),
+                        item.getBadge()));
                 break;
             }
         }
@@ -309,10 +311,18 @@ public final class OutlineViewModel {
                 .map(v -> ((AttributeValue.ColorValue) v).value())
                 .map(TbxColor::toHex)
                 .orElse("#808080");
+        String badge = resolveBadge(note);
 
         return new NoteDisplayItem(
                 note.getId(), note.getTitle(), note.getContent(),
                 0, 0, 0, 0, colorHex,
-                noteService.hasChildren(note.getId()));
+                noteService.hasChildren(note.getId()), badge);
+    }
+
+    private static String resolveBadge(Note note) {
+        return note.getAttribute("$Badge")
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .flatMap(BadgeRegistry::getBadgeSymbol)
+                .orElse("");
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeValue;
+import com.embervault.domain.BadgeRegistry;
 import com.embervault.domain.Note;
 import com.embervault.domain.TbxColor;
 import javafx.beans.property.BooleanProperty;
@@ -210,10 +211,18 @@ public final class TreemapViewModel {
                 .map(v -> ((AttributeValue.ColorValue) v).value())
                 .map(TbxColor::toHex)
                 .orElse(DEFAULT_COLOR_HEX);
+        String badge = resolveBadge(note);
 
         return new NoteDisplayItem(
                 note.getId(), note.getTitle(), note.getContent(),
                 0, 0, 0, 0, colorHex,
-                noteService.hasChildren(note.getId()));
+                noteService.hasChildren(note.getId()), badge);
+    }
+
+    private static String resolveBadge(Note note) {
+        return note.getAttribute("$Badge")
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .flatMap(BadgeRegistry::getBadgeSymbol)
+                .orElse("");
     }
 }

--- a/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
+++ b/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
@@ -124,6 +124,7 @@ public final class AttributeSchemaRegistry {
         systemAttr("$DisplayedAttributes", AttributeType.SET,
                 new AttributeValue.SetValue(Set.of()));
         systemAttr("$Flags", AttributeType.SET, new AttributeValue.SetValue(Set.of()));
+        systemAttr("$Badge", AttributeType.STRING, new AttributeValue.StringValue(""));
     }
 
     private void systemAttr(String name, AttributeType type, AttributeValue defaultValue) {

--- a/src/main/java/com/embervault/domain/BadgeRegistry.java
+++ b/src/main/java/com/embervault/domain/BadgeRegistry.java
@@ -1,0 +1,57 @@
+package com.embervault.domain;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Registry of badge names and their corresponding Unicode symbols.
+ *
+ * <p>Provides a static mapping from human-readable badge names (e.g., "star")
+ * to Unicode emoji symbols (e.g., "\u2B50"). Used by ViewModels to resolve
+ * the {@code $Badge} attribute into a displayable symbol.</p>
+ */
+public final class BadgeRegistry {
+
+    private static final Map<String, String> BADGES = new LinkedHashMap<>();
+
+    static {
+        BADGES.put("star", "\u2B50");
+        BADGES.put("flag", "\uD83D\uDEA9");
+        BADGES.put("check", "\u2705");
+        BADGES.put("warning", "\u26A0\uFE0F");
+        BADGES.put("book", "\uD83D\uDCD6");
+        BADGES.put("person", "\uD83D\uDC64");
+        BADGES.put("idea", "\uD83D\uDCA1");
+        BADGES.put("heart", "\u2764\uFE0F");
+        BADGES.put("pin", "\uD83D\uDCCC");
+        BADGES.put("fire", "\uD83D\uDD25");
+    }
+
+    private BadgeRegistry() {
+        // utility class
+    }
+
+    /**
+     * Returns the Unicode symbol for the given badge name.
+     *
+     * @param name the badge name (e.g., "star"), or null
+     * @return an optional containing the symbol, or empty if unknown
+     */
+    public static Optional<String> getBadgeSymbol(String name) {
+        if (name == null || name.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(BADGES.get(name));
+    }
+
+    /**
+     * Returns an unmodifiable list of all registered badge names.
+     *
+     * @return the list of badge names
+     */
+    public static List<String> getAllBadgeNames() {
+        return List.copyOf(BADGES.keySet());
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelTest.java
@@ -15,6 +15,7 @@ import com.embervault.application.LinkServiceImpl;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -290,5 +291,55 @@ class HyperbolicViewModelTest {
         assertNotNull(viewModel.getNodes());
         assertFalse(viewModel.getNodes().isEmpty());
         assertEquals(n1.getId(), viewModel.getNodes().get(0).noteId());
+    }
+
+    @Test
+    @DisplayName("getNoteBadge() returns badge symbol when $Badge is set")
+    void getNoteBadge_shouldReturnSymbolWhenSet() {
+        Note note = noteService.createNote("N1", "");
+        note.setAttribute("$Badge", new AttributeValue.StringValue("star"));
+
+        String badge = viewModel.getNoteBadge(note.getId());
+
+        assertEquals("\u2B50", badge);
+    }
+
+    @Test
+    @DisplayName("getNoteBadge() returns empty when $Badge not set")
+    void getNoteBadge_shouldReturnEmptyWhenNotSet() {
+        Note note = noteService.createNote("N1", "");
+
+        String badge = viewModel.getNoteBadge(note.getId());
+
+        assertEquals("", badge);
+    }
+
+    @Test
+    @DisplayName("getNoteBadge() returns empty for unknown badge name")
+    void getNoteBadge_shouldReturnEmptyForUnknownName() {
+        Note note = noteService.createNote("N1", "");
+        note.setAttribute("$Badge", new AttributeValue.StringValue("nonexistent"));
+
+        String badge = viewModel.getNoteBadge(note.getId());
+
+        assertEquals("", badge);
+    }
+
+    @Test
+    @DisplayName("getNoteTitle() returns note title")
+    void getNoteTitle_shouldReturnTitle() {
+        Note note = noteService.createNote("My Title", "");
+
+        String title = viewModel.getNoteTitle(note.getId());
+
+        assertEquals("My Title", title);
+    }
+
+    @Test
+    @DisplayName("getNoteTitle() returns empty for nonexistent note")
+    void getNoteTitle_shouldReturnEmptyForNonexistent() {
+        String title = viewModel.getNoteTitle(UUID.randomUUID());
+
+        assertEquals("", title);
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -377,5 +378,46 @@ class MapViewModelTest {
         viewModel.navigateBack();
 
         assertFalse(viewModel.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("toDisplayItem() resolves badge from $Badge attribute")
+    void toDisplayItem_shouldResolveBadgeFromAttribute() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        child.setAttribute("$Badge", new AttributeValue.StringValue("star"));
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getNoteItems().get(0);
+        assertEquals("\u2B50", item.getBadge());
+    }
+
+    @Test
+    @DisplayName("toDisplayItem() returns empty badge when $Badge not set")
+    void toDisplayItem_shouldReturnEmptyBadgeWhenNotSet() {
+        Note parent = noteService.createNote("Parent", "");
+        noteService.createChildNote(parent.getId(), "Child");
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getNoteItems().get(0);
+        assertEquals("", item.getBadge());
+    }
+
+    @Test
+    @DisplayName("toDisplayItem() returns empty badge for unknown badge name")
+    void toDisplayItem_shouldReturnEmptyBadgeForUnknown() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        child.setAttribute("$Badge", new AttributeValue.StringValue("nonexistent"));
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getNoteItems().get(0);
+        assertEquals("", item.getBadge());
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItemTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/NoteDisplayItemTest.java
@@ -110,4 +110,41 @@ class NoteDisplayItemTest {
 
         assertEquals(a.hashCode(), b.hashCode());
     }
+
+    @Test
+    @DisplayName("simple constructor defaults badge to empty string")
+    void simpleConstructor_shouldDefaultBadgeToEmpty() {
+        NoteDisplayItem item = new NoteDisplayItem(
+                UUID.randomUUID(), "Title", "Content");
+
+        assertEquals("", item.getBadge());
+    }
+
+    @Test
+    @DisplayName("nine-arg constructor defaults badge to empty string")
+    void nineArgConstructor_shouldDefaultBadgeToEmpty() {
+        NoteDisplayItem item = new NoteDisplayItem(
+                UUID.randomUUID(), "Title", "Content",
+                0, 0, 6, 4, "#808080", false);
+
+        assertEquals("", item.getBadge());
+    }
+
+    @Test
+    @DisplayName("full constructor stores badge symbol")
+    void fullConstructor_shouldStoreBadge() {
+        NoteDisplayItem item = new NoteDisplayItem(
+                UUID.randomUUID(), "Title", "Content",
+                0, 0, 6, 4, "#808080", false, "\u2B50");
+
+        assertEquals("\u2B50", item.getBadge());
+    }
+
+    @Test
+    @DisplayName("full constructor rejects null badge")
+    void fullConstructor_shouldRejectNullBadge() {
+        assertThrows(NullPointerException.class,
+                () -> new NoteDisplayItem(UUID.randomUUID(), "Title", "Content",
+                        0, 0, 6, 4, "#808080", false, null));
+    }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -562,5 +563,32 @@ class OutlineViewModelTest {
         viewModel.deleteNote(child.getId());
 
         assertTrue(notified[0]);
+    }
+
+    @Test
+    @DisplayName("toDisplayItem() resolves badge from $Badge attribute")
+    void toDisplayItem_shouldResolveBadge() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        child.setAttribute("$Badge", new AttributeValue.StringValue("flag"));
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getRootItems().get(0);
+        assertEquals("\uD83D\uDEA9", item.getBadge());
+    }
+
+    @Test
+    @DisplayName("toDisplayItem() returns empty badge when $Badge not set")
+    void toDisplayItem_shouldReturnEmptyBadgeWhenNotSet() {
+        Note parent = noteService.createNote("Parent", "");
+        noteService.createChildNote(parent.getId(), "Child");
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getRootItems().get(0);
+        assertEquals("", item.getBadge());
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModelTest.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -411,5 +412,32 @@ class TreemapViewModelTest {
 
         // Should not throw
         viewModel.createChildNote("Test");
+    }
+
+    @Test
+    @DisplayName("toDisplayItem() resolves badge from $Badge attribute")
+    void toDisplayItem_shouldResolveBadge() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child = noteService.createChildNote(parent.getId(), "Child");
+        child.setAttribute("$Badge", new AttributeValue.StringValue("check"));
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getNoteItems().get(0);
+        assertEquals("\u2705", item.getBadge());
+    }
+
+    @Test
+    @DisplayName("toDisplayItem() returns empty badge when $Badge not set")
+    void toDisplayItem_shouldReturnEmptyBadgeWhenNotSet() {
+        Note parent = noteService.createNote("Parent", "");
+        noteService.createChildNote(parent.getId(), "Child");
+        viewModel.setBaseNoteId(parent.getId());
+
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.getNoteItems().get(0);
+        assertEquals("", item.getBadge());
     }
 }

--- a/src/test/java/com/embervault/domain/BadgeRegistryTest.java
+++ b/src/test/java/com/embervault/domain/BadgeRegistryTest.java
@@ -1,0 +1,169 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BadgeRegistryTest {
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns star symbol for 'star'")
+    void getBadgeSymbol_shouldReturnStarSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("star");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\u2B50", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns flag symbol for 'flag'")
+    void getBadgeSymbol_shouldReturnFlagSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("flag");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\uD83D\uDEA9", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns check symbol for 'check'")
+    void getBadgeSymbol_shouldReturnCheckSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("check");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\u2705", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns warning symbol for 'warning'")
+    void getBadgeSymbol_shouldReturnWarningSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("warning");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\u26A0\uFE0F", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns book symbol for 'book'")
+    void getBadgeSymbol_shouldReturnBookSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("book");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\uD83D\uDCD6", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns person symbol for 'person'")
+    void getBadgeSymbol_shouldReturnPersonSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("person");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\uD83D\uDC64", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns idea symbol for 'idea'")
+    void getBadgeSymbol_shouldReturnIdeaSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("idea");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\uD83D\uDCA1", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns heart symbol for 'heart'")
+    void getBadgeSymbol_shouldReturnHeartSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("heart");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\u2764\uFE0F", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns pin symbol for 'pin'")
+    void getBadgeSymbol_shouldReturnPinSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("pin");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\uD83D\uDCCC", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns fire symbol for 'fire'")
+    void getBadgeSymbol_shouldReturnFireSymbol() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("fire");
+
+        assertTrue(symbol.isPresent());
+        assertEquals("\uD83D\uDD25", symbol.get());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns empty for unknown badge name")
+    void getBadgeSymbol_shouldReturnEmptyForUnknown() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("nonexistent");
+
+        assertFalse(symbol.isPresent());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns empty for null badge name")
+    void getBadgeSymbol_shouldReturnEmptyForNull() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol(null);
+
+        assertFalse(symbol.isPresent());
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() returns empty for empty string")
+    void getBadgeSymbol_shouldReturnEmptyForEmptyString() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("");
+
+        assertFalse(symbol.isPresent());
+    }
+
+    @Test
+    @DisplayName("getAllBadgeNames() returns all built-in badge names")
+    void getAllBadgeNames_shouldReturnAllBuiltInNames() {
+        List<String> names = BadgeRegistry.getAllBadgeNames();
+
+        assertEquals(10, names.size());
+        assertTrue(names.contains("star"));
+        assertTrue(names.contains("flag"));
+        assertTrue(names.contains("check"));
+        assertTrue(names.contains("warning"));
+        assertTrue(names.contains("book"));
+        assertTrue(names.contains("person"));
+        assertTrue(names.contains("idea"));
+        assertTrue(names.contains("heart"));
+        assertTrue(names.contains("pin"));
+        assertTrue(names.contains("fire"));
+    }
+
+    @Test
+    @DisplayName("getAllBadgeNames() returns an unmodifiable list")
+    void getAllBadgeNames_shouldReturnUnmodifiableList() {
+        List<String> names = BadgeRegistry.getAllBadgeNames();
+
+        try {
+            names.add("custom");
+            // Should not reach here
+            assertFalse(true, "Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException expected) {
+            // expected
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    @DisplayName("getBadgeSymbol() is case-sensitive")
+    void getBadgeSymbol_shouldBeCaseSensitive() {
+        Optional<String> symbol = BadgeRegistry.getBadgeSymbol("Star");
+
+        assertFalse(symbol.isPresent());
+    }
+}


### PR DESCRIPTION
## Summary
- Create `BadgeRegistry` in `com.embervault.domain` with 10 built-in badges (star, flag, check, warning, book, person, idea, heart, pin, fire) mapped to Unicode symbols
- Add `badge` field to `NoteDisplayItem` populated from `$Badge` attribute via `BadgeRegistry` in all ViewModels
- Render badges in all views: top-right corner label (Map/Treemap), prepended text (Outline), next to node label (Hyperbolic), and in Attribute Browser
- Register `$Badge` as a system attribute and add 10 built-in badge stamps

## Test plan
- [x] `BadgeRegistryTest` covers all 10 built-in badges, unknown/null/empty lookups, unmodifiable list, case sensitivity
- [x] `NoteDisplayItemTest` covers badge field in all constructors, null rejection
- [x] `MapViewModelTest` covers badge resolution from `$Badge` attribute, empty when not set, empty for unknown name
- [x] `OutlineViewModelTest` covers badge resolution
- [x] `TreemapViewModelTest` covers badge resolution
- [x] `HyperbolicViewModelTest` covers `getNoteBadge()` and `getNoteTitle()` methods
- [x] All 584 tests pass, 0 checkstyle violations, coverage checks met

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)