### PR TITLE
Add Find/Search across all notes

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -10,6 +10,7 @@ import com.embervault.adapter.in.ui.view.HyperbolicViewController;
 import com.embervault.adapter.in.ui.view.MapViewController;
 import com.embervault.adapter.in.ui.view.NoteEditorViewController;
 import com.embervault.adapter.in.ui.view.OutlineViewController;
+import com.embervault.adapter.in.ui.view.SearchViewController;
 import com.embervault.adapter.in.ui.view.StampEditorViewController;
 import com.embervault.adapter.in.ui.view.TreemapViewController;
 import com.embervault.adapter.in.ui.viewmodel.AttributeBrowserViewModel;
@@ -17,6 +18,7 @@ import com.embervault.adapter.in.ui.viewmodel.HyperbolicViewModel;
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.NoteEditorViewModel;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
 import com.embervault.adapter.in.ui.viewmodel.StampEditorViewModel;
 import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
@@ -38,6 +40,7 @@ import com.embervault.domain.Project;
 import com.embervault.domain.Stamp;
 import javafx.application.Application;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXMLLoader;
@@ -178,6 +181,21 @@ public class App extends Application {
         browserViewModel.selectedNoteIdProperty().addListener(
                 (obs, oldVal, newVal) -> editorViewModel.setNote(newVal));
 
+        SearchViewModel searchViewModel = new SearchViewModel(noteService);
+        FXMLLoader searchLoader = new FXMLLoader(getClass().getResource(
+                "/com/embervault/adapter/in/ui/view/SearchView.fxml"));
+        Parent searchView = searchLoader.load();
+        SearchViewController searchController =
+                searchLoader.getController();
+        searchController.initViewModel(searchViewModel);
+        searchViewModel.selectedNoteIdProperty().addListener(
+                (obs, oldVal, newVal) -> {
+                    if (newVal != null) {
+                        mapViewModel.selectNote(newVal);
+                        outlineViewModel.selectNote(newVal);
+                    }
+                });
+
         // Synchronize: any mutation in any view triggers all to reload
         // from the shared NoteService/Repository.
         Runnable refreshAll = () -> {
@@ -197,41 +215,18 @@ public class App extends Application {
         hyperbolicViewModel.setOnDataChanged(refreshAll);
 
         // Wrap each view with a title label
-        Label mapLabel = new Label();
-        mapLabel.textProperty().bind(mapViewModel.tabTitleProperty());
-        mapLabel.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
-        VBox mapContainer = new VBox(mapLabel, mapView);
-        VBox.setVgrow(mapView, Priority.ALWAYS);
-
-        Label outlineLabel = new Label();
-        outlineLabel.textProperty().bind(
-                outlineViewModel.tabTitleProperty());
-        outlineLabel.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
-        VBox outlineContainer = new VBox(outlineLabel, outlineView);
-        VBox.setVgrow(outlineView, Priority.ALWAYS);
-
-        Label treemapLabel = new Label();
-        treemapLabel.textProperty().bind(
-                treemapViewModel.tabTitleProperty());
-        treemapLabel.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
-        VBox treemapContainer = new VBox(treemapLabel, treemapView);
-        VBox.setVgrow(treemapView, Priority.ALWAYS);
-
-        Label hyperbolicLabel = new Label();
-        hyperbolicLabel.textProperty().bind(
-                hyperbolicViewModel.tabTitleProperty());
-        hyperbolicLabel.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
-        VBox hyperbolicContainer = new VBox(
-                hyperbolicLabel, hyperbolicView);
-        VBox.setVgrow(hyperbolicView, Priority.ALWAYS);
+        VBox mapContainer = wrapWithLabel(
+                mapViewModel.tabTitleProperty(), mapView);
+        VBox outlineContainer = wrapWithLabel(
+                outlineViewModel.tabTitleProperty(), outlineView);
+        VBox treemapContainer = wrapWithLabel(
+                treemapViewModel.tabTitleProperty(), treemapView);
+        VBox hyperbolicContainer = wrapWithLabel(
+                hyperbolicViewModel.tabTitleProperty(), hyperbolicView);
 
         // Browser + Editor combined pane
-        Label browserLabel = new Label();
-        browserLabel.textProperty().bind(
-                browserViewModel.tabTitleProperty());
-        browserLabel.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
-        VBox browserContainer = new VBox(browserLabel, browserView);
-        VBox.setVgrow(browserView, Priority.ALWAYS);
+        VBox browserContainer = wrapWithLabel(
+                browserViewModel.tabTitleProperty(), browserView);
 
         VBox editorContainer = new VBox(editorView);
         VBox.setVgrow(editorView, Priority.ALWAYS);
@@ -251,11 +246,14 @@ public class App extends Application {
                 browserEditorPane, hyperbolicContainer,
                 hyperbolicViewModel, project, stampService,
                 mapViewModel.selectedNoteIdProperty(),
-                refreshAll, stage);
+                refreshAll, stage, searchViewModel);
 
-        // BorderPane: menu bar on top, split pane in center
+        // Top area: menu bar + search bar
+        VBox topArea = new VBox(menuBar, searchView);
+
+        // BorderPane: top area on top, split pane in center
         BorderPane root = new BorderPane();
-        root.setTop(menuBar);
+        root.setTop(topArea);
         root.setCenter(splitPane);
 
         Scene scene = new Scene(root, 1024, 768);
@@ -275,7 +273,8 @@ public class App extends Application {
             StampService stampService,
             ObjectProperty<UUID> selectedNoteId,
             Runnable refreshAll,
-            Stage ownerStage) {
+            Stage ownerStage,
+            SearchViewModel searchViewModel) {
         // Note menu
         MenuItem createNote = new MenuItem("Create Note");
         createNote.setAccelerator(
@@ -347,8 +346,18 @@ public class App extends Application {
         viewMenu.getItems().addAll(mapViewItem, outlineViewItem,
                 treemapViewItem, hyperbolicViewItem, browserViewItem);
 
+        // Edit menu
+        MenuItem findItem = new MenuItem("Find");
+        findItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.F,
+                        KeyCombination.SHORTCUT_DOWN));
+        findItem.setOnAction(e -> searchViewModel.toggleVisible());
+
+        Menu editMenu = new Menu("Edit");
+        editMenu.getItems().add(findItem);
+
         MenuBar menuBar = new MenuBar(
-                noteMenu, stampsMenu, viewMenu);
+                noteMenu, editMenu, stampsMenu, viewMenu);
         menuBar.setUseSystemMenuBar(true);
         return menuBar;
     }
@@ -451,6 +460,17 @@ public class App extends Application {
         // Rebuild stamps menu after editor closes
         buildStampsMenu(stampsMenu, stampService, selectedNoteId,
                 refreshAll, ownerStage);
+    }
+
+    private static VBox wrapWithLabel(
+            ReadOnlyStringProperty titleProp,
+            Parent view) {
+        Label label = new Label();
+        label.textProperty().bind(titleProp);
+        label.setStyle("-fx-font-weight: bold; -fx-padding: 4 8;");
+        VBox container = new VBox(label, view);
+        VBox.setVgrow(view, Priority.ALWAYS);
+        return container;
     }
 
     private void populateBuiltInStamps(StampService stampService) {

--- a/src/main/java/com/embervault/adapter/in/ui/view/SearchViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/SearchViewController.java
@@ -1,0 +1,120 @@
+package com.embervault.adapter.in.ui.view;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
+import javafx.collections.ListChangeListener;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.VBox;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FXML controller for the search bar.
+ *
+ * <p>Binds to a {@link SearchViewModel} and triggers search on each keystroke.
+ * Escape closes the bar, Enter selects the first result, and clicking a result
+ * selects it in the active view.</p>
+ */
+public class SearchViewController {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(SearchViewController.class);
+
+    @FXML private VBox searchRoot;
+    @FXML private TextField searchField;
+    @FXML private Button closeButton;
+    @FXML private ListView<NoteDisplayItem> resultsList;
+
+    private SearchViewModel viewModel;
+
+    /**
+     * Injects the ViewModel and binds UI controls to its properties.
+     *
+     * @param viewModel the search view model
+     */
+    public void initViewModel(SearchViewModel viewModel) {
+        this.viewModel = viewModel;
+
+        // Bind visibility
+        searchRoot.visibleProperty().bind(viewModel.visibleProperty());
+        searchRoot.managedProperty().bind(viewModel.visibleProperty());
+
+        // Bind search field text to query
+        searchField.textProperty().bindBidirectional(
+                viewModel.queryProperty());
+
+        // Search on each keystroke
+        searchField.textProperty().addListener(
+                (obs, oldVal, newVal) -> {
+                    LOG.debug("Search query changed: {}", newVal);
+                    viewModel.search(newVal);
+                });
+
+        // Enter selects first result
+        searchField.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER
+                    && !viewModel.getResults().isEmpty()) {
+                NoteDisplayItem first = viewModel.getResults().get(0);
+                viewModel.selectResult(first.getId());
+            } else if (event.getCode() == KeyCode.ESCAPE) {
+                viewModel.hide();
+            }
+        });
+
+        // Bind results list
+        resultsList.setItems(viewModel.getResults());
+
+        // Custom cell factory for result display
+        resultsList.setCellFactory(lv -> new ListCell<>() {
+            @Override
+            protected void updateItem(NoteDisplayItem item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(null);
+                    setGraphic(null);
+                } else {
+                    String badge = item.getBadge().isEmpty()
+                            ? "" : item.getBadge() + " ";
+                    setText(badge + item.getTitle());
+                }
+            }
+        });
+
+        // Click result to select
+        resultsList.setOnMouseClicked(event -> {
+            NoteDisplayItem selected = resultsList.getSelectionModel()
+                    .getSelectedItem();
+            if (selected != null) {
+                viewModel.selectResult(selected.getId());
+            }
+        });
+
+        // Hide results list when empty
+        viewModel.getResults().addListener(
+                (ListChangeListener<NoteDisplayItem>) change -> {
+                    boolean hasResults = !viewModel.getResults().isEmpty();
+                    resultsList.setVisible(hasResults);
+                    resultsList.setManaged(hasResults);
+                });
+        resultsList.setVisible(false);
+        resultsList.setManaged(false);
+
+        // When search bar becomes visible, focus the text field
+        viewModel.visibleProperty().addListener((obs, oldVal, newVal) -> {
+            if (Boolean.TRUE.equals(newVal)) {
+                searchField.requestFocus();
+            }
+        });
+    }
+
+    /** Handles the close button click. */
+    @FXML
+    private void handleClose() {
+        viewModel.hide();
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModel.java
@@ -1,0 +1,100 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * ViewModel for the search bar.
+ *
+ * <p>Manages the search query, results list, visibility state, and
+ * result selection. Delegates searching to {@link NoteService#searchNotes}.</p>
+ */
+public final class SearchViewModel {
+
+    private final StringProperty query = new SimpleStringProperty("");
+    private final ObservableList<NoteDisplayItem> results =
+            FXCollections.observableArrayList();
+    private final BooleanProperty visible = new SimpleBooleanProperty(false);
+    private final ObjectProperty<UUID> selectedNoteId =
+            new SimpleObjectProperty<>();
+    private final NoteService noteService;
+
+    /**
+     * Constructs a SearchViewModel backed by the given NoteService.
+     *
+     * @param noteService the note service for searching
+     */
+    public SearchViewModel(NoteService noteService) {
+        this.noteService = Objects.requireNonNull(noteService,
+                "noteService must not be null");
+    }
+
+    /** Returns the query property bound to the search text field. */
+    public StringProperty queryProperty() {
+        return query;
+    }
+
+    /** Returns the observable list of search results. */
+    public ObservableList<NoteDisplayItem> getResults() {
+        return results;
+    }
+
+    /** Returns the visibility property for the search bar. */
+    public BooleanProperty visibleProperty() {
+        return visible;
+    }
+
+    /** Returns the selected note id property. */
+    public ObjectProperty<UUID> selectedNoteIdProperty() {
+        return selectedNoteId;
+    }
+
+    /**
+     * Searches notes matching the given query and updates the results list.
+     *
+     * @param searchQuery the search query
+     */
+    public void search(String searchQuery) {
+        results.setAll(
+                noteService.searchNotes(searchQuery).stream()
+                        .map(this::toDisplayItem)
+                        .toList());
+    }
+
+    /**
+     * Selects a search result by note id.
+     *
+     * @param noteId the note id to select, or null to clear
+     */
+    public void selectResult(UUID noteId) {
+        selectedNoteId.set(noteId);
+    }
+
+    /** Toggles the search bar visibility. */
+    public void toggleVisible() {
+        visible.set(!visible.get());
+    }
+
+    /** Hides the search bar and clears query and results. */
+    public void hide() {
+        visible.set(false);
+        query.set("");
+        results.clear();
+    }
+
+    private NoteDisplayItem toDisplayItem(Note note) {
+        return new NoteDisplayItem(
+                note.getId(), note.getTitle(), note.getContent());
+    }
+}

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -1,7 +1,9 @@
 package com.embervault.application;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -357,6 +359,39 @@ public final class NoteServiceImpl implements NoteService {
         }
         repository.delete(noteId);
         return true;
+    }
+
+    @Override
+    public List<Note> searchNotes(String query) {
+        if (query == null || query.isBlank()) {
+            return List.of();
+        }
+        String lowerQuery = query.toLowerCase(Locale.ROOT);
+        List<Note> allNotes = repository.findAll();
+
+        List<Note> titleMatches = new ArrayList<>();
+        List<Note> textOnlyMatches = new ArrayList<>();
+
+        for (Note note : allNotes) {
+            boolean titleMatch = note.getTitle()
+                    .toLowerCase(Locale.ROOT)
+                    .contains(lowerQuery);
+            boolean textMatch = note.getContent()
+                    .toLowerCase(Locale.ROOT)
+                    .contains(lowerQuery);
+
+            if (titleMatch) {
+                titleMatches.add(note);
+            } else if (textMatch) {
+                textOnlyMatches.add(note);
+            }
+        }
+
+        List<Note> results = new ArrayList<>(
+                titleMatches.size() + textOnlyMatches.size());
+        results.addAll(titleMatches);
+        results.addAll(textOnlyMatches);
+        return results;
     }
 
     /**

--- a/src/main/java/com/embervault/application/port/in/NoteService.java
+++ b/src/main/java/com/embervault/application/port/in/NoteService.java
@@ -133,4 +133,16 @@ public interface NoteService {
      * @return true if the note was deleted, false if it has children or does not exist
      */
     boolean deleteNoteIfLeaf(UUID noteId);
+
+    /**
+     * Searches all notes by case-insensitive substring matching on $Name and $Text.
+     *
+     * <p>Returns notes whose title or content contain the query string.
+     * Title matches appear before text-only matches. Returns an empty list
+     * if the query is null, empty, or blank.</p>
+     *
+     * @param query the search query
+     * @return matching notes ordered by relevance (title matches first)
+     */
+    List<Note> searchNotes(String query);
 }

--- a/src/main/resources/com/embervault/adapter/in/ui/view/SearchView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/SearchView.fxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Priority?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox fx:id="searchRoot" xmlns:fx="http://javafx.com/fxml"
+      fx:controller="com.embervault.adapter.in.ui.view.SearchViewController"
+      spacing="2">
+
+    <HBox spacing="4" alignment="CENTER_LEFT" style="-fx-padding: 4 8;">
+        <TextField fx:id="searchField" promptText="Search notes..."
+                   HBox.hgrow="ALWAYS"/>
+        <Button fx:id="closeButton" text="X" onAction="#handleClose"/>
+    </HBox>
+
+    <ListView fx:id="resultsList" maxHeight="200"/>
+</VBox>

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModelTest.java
@@ -1,0 +1,173 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SearchViewModelTest {
+
+    private SearchViewModel viewModel;
+    private NoteService noteService;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        viewModel = new SearchViewModel(noteService);
+    }
+
+    @Test
+    @DisplayName("queryProperty() is initially empty")
+    void queryProperty_shouldBeInitiallyEmpty() {
+        assertEquals("", viewModel.queryProperty().get());
+    }
+
+    @Test
+    @DisplayName("resultsProperty() is initially empty")
+    void resultsProperty_shouldBeInitiallyEmpty() {
+        assertTrue(viewModel.getResults().isEmpty());
+    }
+
+    @Test
+    @DisplayName("visibleProperty() is initially false")
+    void visibleProperty_shouldBeInitiallyFalse() {
+        assertFalse(viewModel.visibleProperty().get());
+    }
+
+    @Test
+    @DisplayName("search() populates results from NoteService")
+    void search_shouldPopulateResults() {
+        noteService.createNote("Meeting notes", "Important stuff");
+        noteService.createNote("Shopping list", "Eggs, milk");
+
+        viewModel.search("meeting");
+
+        assertEquals(1, viewModel.getResults().size());
+        assertEquals("Meeting notes", viewModel.getResults().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("search() clears previous results")
+    void search_shouldClearPreviousResults() {
+        noteService.createNote("Alpha", "");
+        noteService.createNote("Beta", "");
+
+        viewModel.search("alpha");
+        assertEquals(1, viewModel.getResults().size());
+
+        viewModel.search("beta");
+        assertEquals(1, viewModel.getResults().size());
+        assertEquals("Beta", viewModel.getResults().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("search() with blank query clears results")
+    void search_shouldClearResultsForBlankQuery() {
+        noteService.createNote("Alpha", "");
+
+        viewModel.search("alpha");
+        assertEquals(1, viewModel.getResults().size());
+
+        viewModel.search("");
+        assertTrue(viewModel.getResults().isEmpty());
+    }
+
+    @Test
+    @DisplayName("search() orders title matches before text matches")
+    void search_shouldOrderTitleMatchesFirst() {
+        noteService.createNote("Unrelated title", "Contains meeting in text");
+        noteService.createNote("Meeting agenda", "Some content");
+
+        viewModel.search("meeting");
+
+        assertEquals(2, viewModel.getResults().size());
+        assertEquals("Meeting agenda", viewModel.getResults().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("selectResult() sets selectedNoteIdProperty")
+    void selectResult_shouldSetSelectedNoteId() {
+        UUID noteId = UUID.randomUUID();
+
+        viewModel.selectResult(noteId);
+
+        assertEquals(noteId, viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("selectResult(null) clears selection")
+    void selectResult_null_shouldClearSelection() {
+        viewModel.selectResult(UUID.randomUUID());
+
+        viewModel.selectResult(null);
+
+        assertNull(viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("toggleVisible() flips visibility")
+    void toggleVisible_shouldFlipVisibility() {
+        assertFalse(viewModel.visibleProperty().get());
+
+        viewModel.toggleVisible();
+        assertTrue(viewModel.visibleProperty().get());
+
+        viewModel.toggleVisible();
+        assertFalse(viewModel.visibleProperty().get());
+    }
+
+    @Test
+    @DisplayName("hide() sets visibility to false")
+    void hide_shouldSetVisibleToFalse() {
+        viewModel.toggleVisible();
+        assertTrue(viewModel.visibleProperty().get());
+
+        viewModel.hide();
+        assertFalse(viewModel.visibleProperty().get());
+    }
+
+    @Test
+    @DisplayName("hide() clears query and results")
+    void hide_shouldClearQueryAndResults() {
+        noteService.createNote("Alpha", "");
+        viewModel.queryProperty().set("alpha");
+        viewModel.search("alpha");
+
+        viewModel.hide();
+
+        assertEquals("", viewModel.queryProperty().get());
+        assertTrue(viewModel.getResults().isEmpty());
+    }
+
+    @Test
+    @DisplayName("search() converts Note to NoteDisplayItem")
+    void search_shouldConvertToNoteDisplayItem() {
+        noteService.createNote("Test Note", "Some content");
+
+        viewModel.search("test");
+
+        NoteDisplayItem item = viewModel.getResults().get(0);
+        assertNotNull(item.getId());
+        assertEquals("Test Note", item.getTitle());
+        assertEquals("Some content", item.getContent());
+    }
+
+    @Test
+    @DisplayName("constructor rejects null noteService")
+    void constructor_shouldRejectNullNoteService() {
+        org.junit.jupiter.api.Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new SearchViewModel(null));
+    }
+}

--- a/src/test/java/com/embervault/application/SearchNotesTest.java
+++ b/src/test/java/com/embervault/application/SearchNotesTest.java
@@ -1,0 +1,143 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SearchNotesTest {
+
+    private NoteService service;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        service = new NoteServiceImpl(repository);
+    }
+
+    @Test
+    @DisplayName("searchNotes() returns empty list for null query")
+    void searchNotes_shouldReturnEmptyForNullQuery() {
+        service.createNote("Alpha", "content");
+
+        List<Note> results = service.searchNotes(null);
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("searchNotes() returns empty list for blank query")
+    void searchNotes_shouldReturnEmptyForBlankQuery() {
+        service.createNote("Alpha", "content");
+
+        List<Note> results = service.searchNotes("   ");
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("searchNotes() returns empty list for empty query")
+    void searchNotes_shouldReturnEmptyForEmptyQuery() {
+        service.createNote("Alpha", "content");
+
+        List<Note> results = service.searchNotes("");
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("searchNotes() matches title substring case-insensitively")
+    void searchNotes_shouldMatchTitleCaseInsensitive() {
+        service.createNote("Hello World", "no match here");
+        service.createNote("Goodbye", "no match either");
+
+        List<Note> results = service.searchNotes("hello");
+
+        assertEquals(1, results.size());
+        assertEquals("Hello World", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("searchNotes() matches text content substring case-insensitively")
+    void searchNotes_shouldMatchTextCaseInsensitive() {
+        service.createNote("NoMatch", "The quick brown fox");
+        service.createNote("AlsoNoMatch", "lazy dog");
+
+        List<Note> results = service.searchNotes("QUICK");
+
+        assertEquals(1, results.size());
+        assertEquals("NoMatch", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("searchNotes() returns title matches before text matches")
+    void searchNotes_shouldReturnTitleMatchesFirst() {
+        Note textMatch = service.createNote("Alpha", "Meeting notes for today");
+        Note titleMatch = service.createNote("Meeting agenda", "some content");
+
+        List<Note> results = service.searchNotes("meeting");
+
+        assertEquals(2, results.size());
+        assertEquals(titleMatch.getId(), results.get(0).getId());
+        assertEquals(textMatch.getId(), results.get(1).getId());
+    }
+
+    @Test
+    @DisplayName("searchNotes() deduplicates notes that match both title and text")
+    void searchNotes_shouldDeduplicateMatches() {
+        service.createNote("Meeting notes", "Meeting agenda for today");
+
+        List<Note> results = service.searchNotes("meeting");
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    @DisplayName("searchNotes() returns empty when no notes match")
+    void searchNotes_shouldReturnEmptyWhenNoMatch() {
+        service.createNote("Alpha", "content");
+        service.createNote("Beta", "more content");
+
+        List<Note> results = service.searchNotes("zzzzz");
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("searchNotes() returns empty when no notes exist")
+    void searchNotes_shouldReturnEmptyWhenNoNotes() {
+        List<Note> results = service.searchNotes("anything");
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("searchNotes() matches partial substrings")
+    void searchNotes_shouldMatchPartialSubstrings() {
+        service.createNote("Embervault", "");
+
+        List<Note> results = service.searchNotes("vault");
+
+        assertEquals(1, results.size());
+        assertEquals("Embervault", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("searchNotes() returns multiple title matches")
+    void searchNotes_shouldReturnMultipleTitleMatches() {
+        service.createNote("Meeting Monday", "");
+        service.createNote("Meeting Tuesday", "");
+        service.createNote("Unrelated", "");
+
+        List<Note> results = service.searchNotes("meeting");
+
+        assertEquals(2, results.size());
+    }
+}


### PR DESCRIPTION
## Summary
- `searchNotes(String query)` in NoteService — case-insensitive substring on $Name and $Text, title matches first
- `SearchViewModel` with query, results list, visibility toggle
- `SearchView.fxml` with TextField + ListView
- Cmd+F / Edit > Find toggles search bar
- Click result selects note in Map and Outline views
- 25 new tests (11 service + 14 ViewModel)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)