### PR TITLE
Add Text Pane for editing selected note content

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -2,6 +2,7 @@ package com.embervault;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -12,6 +13,7 @@ import com.embervault.adapter.in.ui.view.NoteEditorViewController;
 import com.embervault.adapter.in.ui.view.OutlineViewController;
 import com.embervault.adapter.in.ui.view.SearchViewController;
 import com.embervault.adapter.in.ui.view.StampEditorViewController;
+import com.embervault.adapter.in.ui.view.TextPaneViewController;
 import com.embervault.adapter.in.ui.view.TreemapViewController;
 import com.embervault.adapter.in.ui.viewmodel.AttributeBrowserViewModel;
 import com.embervault.adapter.in.ui.viewmodel.HyperbolicViewModel;
@@ -19,6 +21,7 @@ import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.NoteEditorViewModel;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
+import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.adapter.in.ui.viewmodel.StampEditorViewModel;
 import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
@@ -126,68 +129,26 @@ public class App extends Application {
         NoteEditorViewModel editorViewModel =
                 new NoteEditorViewModel(noteService, schemaRegistry);
 
-        // Load MapView
-        FXMLLoader mapLoader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/MapView.fxml"));
-        Parent mapView = mapLoader.load();
-        MapViewController mapController = mapLoader.getController();
-        mapController.initViewModel(mapViewModel);
-
-        // Load OutlineView
-        FXMLLoader outlineLoader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/OutlineView.fxml"));
-        Parent outlineView = outlineLoader.load();
-        OutlineViewController outlineController =
-                outlineLoader.getController();
-        outlineController.initViewModel(outlineViewModel);
-
-        // Load TreemapView
-        FXMLLoader treemapLoader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/TreemapView.fxml"));
-        Parent treemapView = treemapLoader.load();
-        TreemapViewController treemapController =
-                treemapLoader.getController();
-        treemapController.initViewModel(treemapViewModel);
-
-        // Create HyperbolicViewModel with shared services
+        // Load views
+        Parent mapView = loadView("MapView.fxml",
+                c -> ((MapViewController) c).initViewModel(mapViewModel));
+        Parent outlineView = loadView("OutlineView.fxml",
+                c -> ((OutlineViewController) c).initViewModel(outlineViewModel));
+        Parent treemapView = loadView("TreemapView.fxml",
+                c -> ((TreemapViewController) c).initViewModel(treemapViewModel));
         HyperbolicViewModel hyperbolicViewModel =
                 new HyperbolicViewModel(noteService, linkService);
-
-        // Load HyperbolicView
-        FXMLLoader hyperbolicLoader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/HyperbolicView.fxml"));
-        Parent hyperbolicView = hyperbolicLoader.load();
-        HyperbolicViewController hyperbolicController =
-                hyperbolicLoader.getController();
-        hyperbolicController.initViewModel(hyperbolicViewModel);
-
-        // Load AttributeBrowserView
-        FXMLLoader browserLoader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/AttributeBrowserView.fxml"));
-        Parent browserView = browserLoader.load();
-        AttributeBrowserViewController browserController =
-                browserLoader.getController();
-        browserController.initViewModel(browserViewModel);
-
-        // Load NoteEditorView
-        FXMLLoader editorLoader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/NoteEditorView.fxml"));
-        Parent editorView = editorLoader.load();
-        NoteEditorViewController editorController =
-                editorLoader.getController();
-        editorController.initViewModel(editorViewModel);
-
-        // Wire browser note selection to editor
+        Parent hyperbolicView = loadView("HyperbolicView.fxml",
+                c -> ((HyperbolicViewController) c).initViewModel(hyperbolicViewModel));
+        Parent browserView = loadView("AttributeBrowserView.fxml",
+                c -> ((AttributeBrowserViewController) c).initViewModel(browserViewModel));
+        Parent editorView = loadView("NoteEditorView.fxml",
+                c -> ((NoteEditorViewController) c).initViewModel(editorViewModel));
         browserViewModel.selectedNoteIdProperty().addListener(
                 (obs, oldVal, newVal) -> editorViewModel.setNote(newVal));
-
         SearchViewModel searchViewModel = new SearchViewModel(noteService);
-        FXMLLoader searchLoader = new FXMLLoader(getClass().getResource(
-                "/com/embervault/adapter/in/ui/view/SearchView.fxml"));
-        Parent searchView = searchLoader.load();
-        SearchViewController searchController =
-                searchLoader.getController();
-        searchController.initViewModel(searchViewModel);
+        Parent searchView = loadView("SearchView.fxml",
+                c -> ((SearchViewController) c).initViewModel(searchViewModel));
         searchViewModel.selectedNoteIdProperty().addListener(
                 (obs, oldVal, newVal) -> {
                     if (newVal != null) {
@@ -196,8 +157,20 @@ public class App extends Application {
                     }
                 });
 
-        // Synchronize: any mutation in any view triggers all to reload
-        // from the shared NoteService/Repository.
+        // Create SelectedNoteViewModel and load TextPaneView
+        SelectedNoteViewModel selectedNoteVm =
+                new SelectedNoteViewModel(noteService);
+        FXMLLoader textPaneLoader = new FXMLLoader(getClass().getResource(
+                "/com/embervault/adapter/in/ui/view/TextPaneView.fxml"));
+        Parent textPaneView = textPaneLoader.load();
+        ((TextPaneViewController) textPaneLoader.getController())
+                .initViewModel(selectedNoteVm);
+        // Wire all views' selection to the text pane
+        wireSelection(mapViewModel.selectedNoteIdProperty(), selectedNoteVm);
+        wireSelection(outlineViewModel.selectedNoteIdProperty(), selectedNoteVm);
+        wireSelection(treemapViewModel.selectedNoteIdProperty(), selectedNoteVm);
+
+        // Synchronize: any mutation triggers all views to reload.
         Runnable refreshAll = () -> {
             mapViewModel.loadNotes();
             outlineViewModel.loadNotes();
@@ -207,12 +180,17 @@ public class App extends Application {
                 hyperbolicViewModel.setFocusNote(
                         hyperbolicViewModel.getFocusNoteId());
             }
+            UUID selId = selectedNoteVm.selectedNoteIdProperty().get();
+            if (selId != null) {
+                selectedNoteVm.setSelectedNoteId(selId);
+            }
         };
         mapViewModel.setOnDataChanged(refreshAll);
         outlineViewModel.setOnDataChanged(refreshAll);
         treemapViewModel.setOnDataChanged(refreshAll);
         editorViewModel.setOnDataChanged(refreshAll);
         hyperbolicViewModel.setOnDataChanged(refreshAll);
+        selectedNoteVm.setOnDataChanged(refreshAll);
 
         // Wrap each view with a title label
         VBox mapContainer = wrapWithLabel(
@@ -236,13 +214,20 @@ public class App extends Application {
         browserEditorPane.setDividerPositions(0.4);
 
         // SplitPane with Map, Outline, and Treemap
-        SplitPane splitPane = new SplitPane(
+        SplitPane viewsSplitPane = new SplitPane(
                 mapContainer, outlineContainer, treemapContainer);
-        splitPane.setDividerPositions(0.33, 0.66);
+        viewsSplitPane.setDividerPositions(0.33, 0.66);
+
+        // Vertical SplitPane: views on top, text pane on bottom
+        SplitPane mainSplitPane = new SplitPane();
+        mainSplitPane.setOrientation(
+                javafx.geometry.Orientation.VERTICAL);
+        mainSplitPane.getItems().addAll(viewsSplitPane, textPaneView);
+        mainSplitPane.setDividerPositions(0.6);
 
         // Menu bar
         MenuBar menuBar = createMenuBar(
-                mapViewModel, outlineViewModel, splitPane,
+                mapViewModel, outlineViewModel, mainSplitPane,
                 browserEditorPane, hyperbolicContainer,
                 hyperbolicViewModel, project, stampService,
                 mapViewModel.selectedNoteIdProperty(),
@@ -254,7 +239,7 @@ public class App extends Application {
         // BorderPane: top area on top, split pane in center
         BorderPane root = new BorderPane();
         root.setTop(topArea);
-        root.setCenter(splitPane);
+        root.setCenter(mainSplitPane);
 
         Scene scene = new Scene(root, 1024, 768);
         stage.setTitle("EmberVault - " + project.getName());
@@ -462,6 +447,15 @@ public class App extends Application {
                 refreshAll, ownerStage);
     }
 
+    private Parent loadView(String fxml,
+            java.util.function.Consumer<Object> init) throws IOException {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource(
+                "/com/embervault/adapter/in/ui/view/" + fxml));
+        Parent view = loader.load();
+        init.accept(loader.getController());
+        return view;
+    }
+
     private static VBox wrapWithLabel(
             ReadOnlyStringProperty titleProp,
             Parent view) {
@@ -480,17 +474,17 @@ public class App extends Application {
         stampService.createStamp("Mark Done", "$Checked=true");
         stampService.createStamp("Mark Undone", "$Checked=false");
 
-        // Badge stamps
-        stampService.createStamp("Badge:star", "$Badge=star");
-        stampService.createStamp("Badge:flag", "$Badge=flag");
-        stampService.createStamp("Badge:check", "$Badge=check");
-        stampService.createStamp("Badge:warning", "$Badge=warning");
-        stampService.createStamp("Badge:book", "$Badge=book");
-        stampService.createStamp("Badge:person", "$Badge=person");
-        stampService.createStamp("Badge:idea", "$Badge=idea");
-        stampService.createStamp("Badge:heart", "$Badge=heart");
-        stampService.createStamp("Badge:pin", "$Badge=pin");
-        stampService.createStamp("Badge:fire", "$Badge=fire");
+        for (String b : List.of("star", "flag", "check", "warning",
+                "book", "person", "idea", "heart", "pin", "fire")) {
+            stampService.createStamp("Badge:" + b, "$Badge=" + b);
+        }
+    }
+
+    private static void wireSelection(
+            ObjectProperty<UUID> source,
+            SelectedNoteViewModel target) {
+        source.addListener(
+                (obs, oldVal, newVal) -> target.setSelectedNoteId(newVal));
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/embervault/adapter/in/ui/view/TextPaneViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TextPaneViewController.java
@@ -1,0 +1,91 @@
+package com.embervault.adapter.in.ui.view;
+
+import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
+
+/**
+ * FXML controller for the Text Pane view.
+ *
+ * <p>Binds the title and text fields to the SelectedNoteViewModel.
+ * Shows a placeholder when no note is selected, and saves changes
+ * on focus-lost or Enter key press.</p>
+ */
+public class TextPaneViewController {
+
+    @FXML private VBox textPaneRoot;
+    @FXML private Label placeholderLabel;
+    @FXML private TextField titleField;
+    @FXML private TextArea textArea;
+
+    private SelectedNoteViewModel viewModel;
+
+    /**
+     * Injects the ViewModel and binds UI controls to its properties.
+     *
+     * @param viewModel the selected note view model
+     */
+    public void initViewModel(SelectedNoteViewModel viewModel) {
+        this.viewModel = viewModel;
+
+        // Show/hide placeholder vs editor based on selection
+        viewModel.selectedNoteIdProperty().addListener(
+                (obs, oldVal, newVal) -> updateVisibility(newVal != null));
+        updateVisibility(viewModel.selectedNoteIdProperty().get() != null);
+
+        // Bind title field
+        titleField.setText(viewModel.titleProperty().get());
+        viewModel.titleProperty().addListener(
+                (obs, oldVal, newVal) -> {
+                    if (!titleField.getText().equals(newVal)) {
+                        titleField.setText(newVal);
+                    }
+                });
+
+        // Save title on focus lost
+        titleField.focusedProperty().addListener(
+                (obs, wasFocused, isFocused) -> {
+                    if (!isFocused) {
+                        viewModel.saveTitle(titleField.getText());
+                    }
+                });
+
+        // Save title on Enter
+        titleField.setOnAction(
+                e -> viewModel.saveTitle(titleField.getText()));
+
+        // Bind text area
+        textArea.setText(viewModel.textProperty().get());
+        viewModel.textProperty().addListener(
+                (obs, oldVal, newVal) -> {
+                    if (!textArea.getText().equals(newVal)) {
+                        textArea.setText(newVal);
+                    }
+                });
+
+        // Save text on focus lost
+        textArea.focusedProperty().addListener(
+                (obs, wasFocused, isFocused) -> {
+                    if (!isFocused) {
+                        viewModel.saveText(textArea.getText());
+                    }
+                });
+    }
+
+    /** Returns the associated ViewModel. */
+    public SelectedNoteViewModel getViewModel() {
+        return viewModel;
+    }
+
+    private void updateVisibility(boolean noteSelected) {
+        placeholderLabel.setVisible(!noteSelected);
+        placeholderLabel.setManaged(!noteSelected);
+        titleField.setVisible(noteSelected);
+        titleField.setManaged(noteSelected);
+        textArea.setVisible(noteSelected);
+        textArea.setManaged(noteSelected);
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
@@ -1,0 +1,122 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+/**
+ * ViewModel for the text pane that edits the currently selected note.
+ *
+ * <p>Listens to all views' selection changes and loads the selected note's
+ * title and text content. Provides save methods that persist changes via
+ * the NoteService and notify listeners for cross-view synchronization.</p>
+ */
+public final class SelectedNoteViewModel {
+
+    private final ObjectProperty<UUID> selectedNoteId =
+            new SimpleObjectProperty<>();
+    private final StringProperty title = new SimpleStringProperty("");
+    private final StringProperty text = new SimpleStringProperty("");
+    private final NoteService noteService;
+    private Runnable onDataChanged;
+
+    /**
+     * Constructs a SelectedNoteViewModel.
+     *
+     * @param noteService the note service for querying and updating notes
+     */
+    public SelectedNoteViewModel(NoteService noteService) {
+        this.noteService = Objects.requireNonNull(noteService,
+                "noteService must not be null");
+    }
+
+    /**
+     * Sets a callback to be invoked after any mutation operation.
+     *
+     * @param callback the callback to invoke, or null to clear
+     */
+    public void setOnDataChanged(Runnable callback) {
+        this.onDataChanged = callback;
+    }
+
+    private void notifyDataChanged() {
+        if (onDataChanged != null) {
+            onDataChanged.run();
+        }
+    }
+
+    /** Returns the selected note id property. */
+    public ObjectProperty<UUID> selectedNoteIdProperty() {
+        return selectedNoteId;
+    }
+
+    /** Returns the title property. */
+    public StringProperty titleProperty() {
+        return title;
+    }
+
+    /** Returns the text property. */
+    public StringProperty textProperty() {
+        return text;
+    }
+
+    /**
+     * Selects a note by id, loading its title and text content.
+     *
+     * @param noteId the note id to select, or null to clear
+     */
+    public void setSelectedNoteId(UUID noteId) {
+        selectedNoteId.set(noteId);
+        if (noteId == null) {
+            title.set("");
+            text.set("");
+            return;
+        }
+        noteService.getNote(noteId).ifPresentOrElse(note -> {
+            title.set(note.getTitle());
+            text.set(note.getContent());
+        }, () -> {
+            title.set("");
+            text.set("");
+        });
+    }
+
+    /**
+     * Saves a new title for the currently selected note.
+     *
+     * @param newTitle the new title
+     */
+    public void saveTitle(String newTitle) {
+        UUID noteId = selectedNoteId.get();
+        if (noteId == null || newTitle == null || newTitle.isBlank()) {
+            return;
+        }
+        noteService.renameNote(noteId, newTitle);
+        title.set(newTitle);
+        notifyDataChanged();
+    }
+
+    /**
+     * Saves new text content for the currently selected note.
+     *
+     * @param newText the new text content
+     */
+    public void saveText(String newText) {
+        UUID noteId = selectedNoteId.get();
+        if (noteId == null || newText == null) {
+            return;
+        }
+        noteService.getNote(noteId).ifPresent(note -> {
+            note.setAttribute("$Text",
+                    new AttributeValue.StringValue(newText));
+        });
+        text.set(newText);
+        notifyDataChanged();
+    }
+}

--- a/src/main/resources/com/embervault/adapter/in/ui/view/TextPaneView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/TextPaneView.fxml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox fx:id="textPaneRoot" xmlns:fx="http://javafx.com/fxml"
+      fx:controller="com.embervault.adapter.in.ui.view.TextPaneViewController"
+      spacing="4">
+
+    <padding>
+        <Insets top="4" right="8" bottom="4" left="8"/>
+    </padding>
+
+    <Label fx:id="placeholderLabel" text="Select a note to edit"
+           style="-fx-text-fill: #888888; -fx-font-style: italic;"/>
+    <TextField fx:id="titleField" promptText="Note title"
+               style="-fx-font-weight: bold; -fx-font-size: 16px;"
+               visible="false" managed="false"/>
+    <TextArea fx:id="textArea" promptText="Note content" wrapText="true"
+              VBox.vgrow="ALWAYS" visible="false" managed="false"/>
+</VBox>

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModelTest.java
@@ -1,0 +1,223 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SelectedNoteViewModelTest {
+
+    private SelectedNoteViewModel viewModel;
+    private NoteService noteService;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        viewModel = new SelectedNoteViewModel(noteService);
+    }
+
+    @Test
+    @DisplayName("Constructor rejects null noteService")
+    void constructor_shouldRejectNullNoteService() {
+        assertThrows(NullPointerException.class,
+                () -> new SelectedNoteViewModel(null));
+    }
+
+    @Test
+    @DisplayName("Initial state has empty title and text")
+    void initialState_shouldHaveEmptyTitleAndText() {
+        assertEquals("", viewModel.titleProperty().get());
+        assertEquals("", viewModel.textProperty().get());
+        assertNull(viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("setSelectedNoteId loads note title and text")
+    void setSelectedNoteId_shouldLoadTitleAndText() {
+        Note note = noteService.createNote("Test Title", "Test Content");
+
+        viewModel.setSelectedNoteId(note.getId());
+
+        assertEquals("Test Title", viewModel.titleProperty().get());
+        assertEquals("Test Content", viewModel.textProperty().get());
+        assertEquals(note.getId(), viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("setSelectedNoteId(null) clears title and text")
+    void setSelectedNoteId_null_shouldClearTitleAndText() {
+        Note note = noteService.createNote("Test", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+
+        viewModel.setSelectedNoteId(null);
+
+        assertEquals("", viewModel.titleProperty().get());
+        assertEquals("", viewModel.textProperty().get());
+        assertNull(viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("setSelectedNoteId with unknown id clears properties")
+    void setSelectedNoteId_unknownId_shouldClearProperties() {
+        Note note = noteService.createNote("Test", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+
+        viewModel.setSelectedNoteId(UUID.randomUUID());
+
+        assertEquals("", viewModel.titleProperty().get());
+        assertEquals("", viewModel.textProperty().get());
+    }
+
+    @Test
+    @DisplayName("Changing selection loads new note data")
+    void changingSelection_shouldLoadNewNoteData() {
+        Note note1 = noteService.createNote("Note One", "Content One");
+        Note note2 = noteService.createNote("Note Two", "Content Two");
+
+        viewModel.setSelectedNoteId(note1.getId());
+        assertEquals("Note One", viewModel.titleProperty().get());
+
+        viewModel.setSelectedNoteId(note2.getId());
+        assertEquals("Note Two", viewModel.titleProperty().get());
+        assertEquals("Content Two", viewModel.textProperty().get());
+    }
+
+    @Test
+    @DisplayName("saveTitle persists and updates title property")
+    void saveTitle_shouldPersistAndUpdateProperty() {
+        Note note = noteService.createNote("Old Title", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+
+        viewModel.saveTitle("New Title");
+
+        assertEquals("New Title", viewModel.titleProperty().get());
+        Note reloaded = noteService.getNote(note.getId()).orElseThrow();
+        assertEquals("New Title", reloaded.getTitle());
+    }
+
+    @Test
+    @DisplayName("saveTitle does nothing when no note is selected")
+    void saveTitle_shouldDoNothingWhenNoNote() {
+        viewModel.saveTitle("Something");
+        assertEquals("", viewModel.titleProperty().get());
+    }
+
+    @Test
+    @DisplayName("saveTitle does nothing for blank title")
+    void saveTitle_shouldDoNothingForBlankTitle() {
+        Note note = noteService.createNote("Original", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+
+        viewModel.saveTitle("   ");
+
+        assertEquals("Original", viewModel.titleProperty().get());
+    }
+
+    @Test
+    @DisplayName("saveTitle does nothing for null title")
+    void saveTitle_shouldDoNothingForNullTitle() {
+        Note note = noteService.createNote("Original", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+
+        viewModel.saveTitle(null);
+
+        assertEquals("Original", viewModel.titleProperty().get());
+    }
+
+    @Test
+    @DisplayName("saveText persists and updates text property")
+    void saveText_shouldPersistAndUpdateProperty() {
+        Note note = noteService.createNote("Title", "Old Content");
+        viewModel.setSelectedNoteId(note.getId());
+
+        viewModel.saveText("New Content");
+
+        assertEquals("New Content", viewModel.textProperty().get());
+        Note reloaded = noteService.getNote(note.getId()).orElseThrow();
+        assertEquals("New Content", reloaded.getContent());
+    }
+
+    @Test
+    @DisplayName("saveText does nothing when no note is selected")
+    void saveText_shouldDoNothingWhenNoNote() {
+        viewModel.saveText("Something");
+        assertEquals("", viewModel.textProperty().get());
+    }
+
+    @Test
+    @DisplayName("saveText does nothing for null text")
+    void saveText_shouldDoNothingForNull() {
+        Note note = noteService.createNote("Title", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+
+        viewModel.saveText(null);
+
+        assertEquals("Content", viewModel.textProperty().get());
+    }
+
+    @Test
+    @DisplayName("saveTitle notifies data changed")
+    void saveTitle_shouldNotifyDataChanged() {
+        Note note = noteService.createNote("Title", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+        boolean[] notified = {false};
+        viewModel.setOnDataChanged(() -> notified[0] = true);
+
+        viewModel.saveTitle("New Title");
+
+        assertTrue(notified[0]);
+    }
+
+    @Test
+    @DisplayName("saveText notifies data changed")
+    void saveText_shouldNotifyDataChanged() {
+        Note note = noteService.createNote("Title", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+        boolean[] notified = {false};
+        viewModel.setOnDataChanged(() -> notified[0] = true);
+
+        viewModel.saveText("New Content");
+
+        assertTrue(notified[0]);
+    }
+
+    @Test
+    @DisplayName("onDataChanged callback can be cleared with null")
+    void onDataChanged_shouldBeCleared() {
+        Note note = noteService.createNote("Title", "Content");
+        viewModel.setSelectedNoteId(note.getId());
+        boolean[] notified = {false};
+        viewModel.setOnDataChanged(() -> notified[0] = true);
+        viewModel.setOnDataChanged(null);
+
+        viewModel.saveTitle("New Title");
+
+        // notified should still be false since callback was cleared
+        assertTrue(!notified[0]);
+    }
+
+    @Test
+    @DisplayName("setSelectedNoteId loads note with $Text attribute")
+    void setSelectedNoteId_shouldLoadNoteWithTextAttribute() {
+        Note note = noteService.createNote("Title", "");
+        note.setAttribute("$Text",
+                new AttributeValue.StringValue("Attribute text"));
+
+        viewModel.setSelectedNoteId(note.getId());
+
+        assertEquals("Attribute text", viewModel.textProperty().get());
+    }
+}


### PR DESCRIPTION
## Summary
- `SelectedNoteViewModel` — tracks selected note across all views, exposes editable title/text properties
- `TextPaneView.fxml` with placeholder, bold title field, growable TextArea
- `TextPaneViewController` — saves on focus-lost and Enter
- Vertical SplitPane: views on top (60%), text pane on bottom (40%)
- Wired to Map, Outline, and Treemap selection properties
- 17 new ViewModel tests

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)