### PR TITLE
Extract DataChangeSupport to eliminate duplicated callback boilerplate

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
@@ -57,7 +57,7 @@ public final class AttributeBrowserViewModel {
     private final NoteService noteService;
     private final AttributeSchemaRegistry schemaRegistry;
     private String selectedAttribute;
-    private Runnable onDataChanged;
+    private final DataChangeSupport dataChangeSupport = new DataChangeSupport();
 
     /**
      * Constructs an AttributeBrowserViewModel.
@@ -81,13 +81,7 @@ public final class AttributeBrowserViewModel {
      * @param callback the callback to invoke, or null to clear
      */
     public void setOnDataChanged(Runnable callback) {
-        this.onDataChanged = callback;
-    }
-
-    private void notifyDataChanged() {
-        if (onDataChanged != null) {
-            onDataChanged.run();
-        }
+        dataChangeSupport.setOnDataChanged(callback);
     }
 
     /** Returns the tab title property. */

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/DataChangeSupport.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/DataChangeSupport.java
@@ -1,0 +1,30 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+/**
+ * Reusable helper that manages a single {@code Runnable} data-change callback.
+ *
+ * <p>ViewModels compose this class to avoid duplicating the
+ * {@code setOnDataChanged / notifyDataChanged} boilerplate.</p>
+ */
+public final class DataChangeSupport {
+
+    private Runnable onDataChanged;
+
+    /**
+     * Registers (or clears) the callback invoked by {@link #notifyDataChanged()}.
+     *
+     * @param callback the callback to invoke, or {@code null} to clear
+     */
+    public void setOnDataChanged(Runnable callback) {
+        this.onDataChanged = callback;
+    }
+
+    /**
+     * Fires the registered callback, if any.
+     */
+    public void notifyDataChanged() {
+        if (onDataChanged != null) {
+            onDataChanged.run();
+        }
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
@@ -52,7 +52,7 @@ public final class HyperbolicViewModel {
             new SimpleObjectProperty<>();
     private final NavigationStack navigationStack = new NavigationStack();
     private double viewportRadius = DEFAULT_VIEWPORT_RADIUS;
-    private Runnable onDataChanged;
+    private final DataChangeSupport dataChangeSupport = new DataChangeSupport();
 
     /**
      * Constructs a HyperbolicViewModel with the given services.
@@ -74,13 +74,7 @@ public final class HyperbolicViewModel {
      * @param callback the callback to invoke, or null to clear
      */
     public void setOnDataChanged(Runnable callback) {
-        this.onDataChanged = callback;
-    }
-
-    private void notifyDataChanged() {
-        if (onDataChanged != null) {
-            onDataChanged.run();
-        }
+        dataChangeSupport.setOnDataChanged(callback);
     }
 
     /**
@@ -151,7 +145,7 @@ public final class HyperbolicViewModel {
     public void createLink(UUID source, UUID dest) {
         linkService.createLink(source, dest);
         computeLayout();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /** Returns the focus note id property. */

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -40,7 +40,7 @@ public final class MapViewModel {
     private final NavigationStack navigationStack = new NavigationStack();
     private final NoteService noteService;
     private final StringProperty rootNoteTitle;
-    private Runnable onDataChanged;
+    private final DataChangeSupport dataChangeSupport = new DataChangeSupport();
 
     /**
      * Constructs a MapViewModel that derives its tab title from the given note title property.
@@ -68,13 +68,7 @@ public final class MapViewModel {
      * @param callback the callback to invoke, or null to clear
      */
     public void setOnDataChanged(Runnable callback) {
-        this.onDataChanged = callback;
-    }
-
-    private void notifyDataChanged() {
-        if (onDataChanged != null) {
-            onDataChanged.run();
-        }
+        dataChangeSupport.setOnDataChanged(callback);
     }
 
     /** Returns the tab title property. */
@@ -140,7 +134,7 @@ public final class MapViewModel {
         Note child = noteService.createChildNote(baseNoteId, title);
         NoteDisplayItem item = toDisplayItem(child);
         noteItems.add(item);
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return item;
     }
 
@@ -160,7 +154,7 @@ public final class MapViewModel {
         child.setAttribute(Attributes.YPOS, new AttributeValue.NumberValue(ypos / SCALE_Y));
         NoteDisplayItem item = toDisplayItem(child);
         noteItems.add(item);
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return item;
     }
 
@@ -184,7 +178,7 @@ public final class MapViewModel {
         }
         NoteDisplayItem item = toDisplayItem(sibling);
         noteItems.add(item);
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return item;
     }
 
@@ -226,7 +220,7 @@ public final class MapViewModel {
                 break;
             }
         }
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return true;
     }
 
@@ -240,7 +234,7 @@ public final class MapViewModel {
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**
@@ -258,7 +252,7 @@ public final class MapViewModel {
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     private void updateTabTitle(String title) {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -33,7 +33,7 @@ public final class OutlineViewModel {
     private final NavigationStack navigationStack = new NavigationStack();
     private final NoteService noteService;
     private final StringProperty rootNoteTitle;
-    private Runnable onDataChanged;
+    private final DataChangeSupport dataChangeSupport = new DataChangeSupport();
 
     /**
      * Constructs an OutlineViewModel that derives its tab title from the given note title property.
@@ -61,13 +61,7 @@ public final class OutlineViewModel {
      * @param callback the callback to invoke, or null to clear
      */
     public void setOnDataChanged(Runnable callback) {
-        this.onDataChanged = callback;
-    }
-
-    private void notifyDataChanged() {
-        if (onDataChanged != null) {
-            onDataChanged.run();
-        }
+        dataChangeSupport.setOnDataChanged(callback);
     }
 
     /** Returns the tab title property. */
@@ -135,7 +129,7 @@ public final class OutlineViewModel {
         if (parentId.equals(navigationStack.getCurrentId())) {
             rootItems.add(item);
         }
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return item;
     }
 
@@ -150,7 +144,7 @@ public final class OutlineViewModel {
         Note sibling = noteService.createSiblingNote(siblingId, title);
         NoteDisplayItem item = toDisplayItem(sibling);
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return item;
     }
 
@@ -162,7 +156,7 @@ public final class OutlineViewModel {
     public void indentNote(UUID noteId) {
         noteService.indentNote(noteId);
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**
@@ -173,7 +167,7 @@ public final class OutlineViewModel {
     public void outdentNote(UUID noteId) {
         noteService.outdentNote(noteId);
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**
@@ -200,7 +194,7 @@ public final class OutlineViewModel {
                 break;
             }
         }
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return true;
     }
 
@@ -219,7 +213,7 @@ public final class OutlineViewModel {
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**
@@ -237,7 +231,7 @@ public final class OutlineViewModel {
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**
@@ -272,7 +266,7 @@ public final class OutlineViewModel {
         boolean deleted = noteService.deleteNoteIfLeaf(noteId);
         if (deleted) {
             loadNotes();
-            notifyDataChanged();
+            dataChangeSupport.notifyDataChanged();
         }
         return deleted;
     }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
@@ -26,7 +26,7 @@ public final class SelectedNoteViewModel {
     private final StringProperty title = new SimpleStringProperty("");
     private final StringProperty text = new SimpleStringProperty("");
     private final NoteService noteService;
-    private Runnable onDataChanged;
+    private final DataChangeSupport dataChangeSupport = new DataChangeSupport();
 
     /**
      * Constructs a SelectedNoteViewModel.
@@ -44,13 +44,7 @@ public final class SelectedNoteViewModel {
      * @param callback the callback to invoke, or null to clear
      */
     public void setOnDataChanged(Runnable callback) {
-        this.onDataChanged = callback;
-    }
-
-    private void notifyDataChanged() {
-        if (onDataChanged != null) {
-            onDataChanged.run();
-        }
+        dataChangeSupport.setOnDataChanged(callback);
     }
 
     /** Returns the selected note id property. */
@@ -101,7 +95,7 @@ public final class SelectedNoteViewModel {
         }
         noteService.renameNote(noteId, newTitle);
         title.set(newTitle);
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**
@@ -119,6 +113,6 @@ public final class SelectedNoteViewModel {
                     new AttributeValue.StringValue(newText));
         });
         text.set(newText);
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
@@ -35,7 +35,7 @@ public final class TreemapViewModel {
     private final NavigationStack navigationStack = new NavigationStack();
     private final NoteService noteService;
     private final StringProperty rootNoteTitle;
-    private Runnable onDataChanged;
+    private final DataChangeSupport dataChangeSupport = new DataChangeSupport();
 
     /**
      * Constructs a TreemapViewModel that derives its tab title from the given note title property.
@@ -62,13 +62,7 @@ public final class TreemapViewModel {
      * @param callback the callback to invoke, or null to clear
      */
     public void setOnDataChanged(Runnable callback) {
-        this.onDataChanged = callback;
-    }
-
-    private void notifyDataChanged() {
-        if (onDataChanged != null) {
-            onDataChanged.run();
-        }
+        dataChangeSupport.setOnDataChanged(callback);
     }
 
     /** Returns the tab title property. */
@@ -135,7 +129,7 @@ public final class TreemapViewModel {
         Note child = noteService.createChildNote(baseNoteId, title);
         NoteDisplayItem item = toDisplayItem(child);
         noteItems.add(item);
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
         return item;
     }
 
@@ -154,7 +148,7 @@ public final class TreemapViewModel {
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**
@@ -172,7 +166,7 @@ public final class TreemapViewModel {
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();
-        notifyDataChanged();
+        dataChangeSupport.notifyDataChanged();
     }
 
     /**

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/DataChangeSupportTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/DataChangeSupportTest.java
@@ -1,0 +1,74 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DataChangeSupportTest {
+
+    private DataChangeSupport support;
+
+    @BeforeEach
+    void setUp() {
+        support = new DataChangeSupport();
+    }
+
+    @Test
+    @DisplayName("notify does nothing when no callback is set")
+    void notify_shouldDoNothingWhenNoCallback() {
+        assertDoesNotThrow(() -> support.notifyDataChanged());
+    }
+
+    @Test
+    @DisplayName("notify invokes the registered callback")
+    void notify_shouldInvokeCallback() {
+        int[] count = {0};
+        support.setOnDataChanged(() -> count[0]++);
+
+        support.notifyDataChanged();
+
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    @DisplayName("notify invokes the callback each time")
+    void notify_shouldInvokeCallbackEachTime() {
+        int[] count = {0};
+        support.setOnDataChanged(() -> count[0]++);
+
+        support.notifyDataChanged();
+        support.notifyDataChanged();
+        support.notifyDataChanged();
+
+        assertEquals(3, count[0]);
+    }
+
+    @Test
+    @DisplayName("setting callback to null clears it")
+    void setOnDataChanged_null_shouldClearCallback() {
+        int[] count = {0};
+        support.setOnDataChanged(() -> count[0]++);
+        support.setOnDataChanged(null);
+
+        support.notifyDataChanged();
+
+        assertEquals(0, count[0]);
+    }
+
+    @Test
+    @DisplayName("replacing callback uses the new one")
+    void setOnDataChanged_shouldReplaceCallback() {
+        int[] countA = {0};
+        int[] countB = {0};
+        support.setOnDataChanged(() -> countA[0]++);
+        support.setOnDataChanged(() -> countB[0]++);
+
+        support.notifyDataChanged();
+
+        assertEquals(0, countA[0]);
+        assertEquals(1, countB[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces a `DataChangeSupport` helper class that encapsulates the `setOnDataChanged(Runnable)` / `notifyDataChanged()` pattern
- Refactors all 6 ViewModels (MapViewModel, OutlineViewModel, TreemapViewModel, HyperbolicViewModel, AttributeBrowserViewModel, SelectedNoteViewModel) to compose a `DataChangeSupport` field and delegate to it
- Removes ~8 lines of duplicated boilerplate from each ViewModel

## Test plan
- [x] New `DataChangeSupportTest` covers: no-callback safety, invocation, multiple invocations, null clearing, callback replacement
- [x] All 193 existing viewmodel tests pass unchanged (MapViewModelTest, OutlineViewModelTest, TreemapViewModelTest, HyperbolicViewModelTest, AttributeBrowserViewModelTest, SelectedNoteViewModelTest, ViewSyncTest)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)