### PR TITLE
Extract shared navigation stack from ViewModels

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
@@ -16,12 +16,10 @@ import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.BadgeRegistry;
 import com.embervault.domain.Link;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -50,9 +48,7 @@ public final class HyperbolicViewModel {
             new SimpleObjectProperty<>();
     private final ObjectProperty<UUID> selectedNoteId =
             new SimpleObjectProperty<>();
-    private final BooleanProperty canNavigateBack =
-            new SimpleBooleanProperty(false);
-    private final Deque<UUID> navigationHistory = new ArrayDeque<>();
+    private final NavigationStack navigationStack = new NavigationStack();
     private double viewportRadius = DEFAULT_VIEWPORT_RADIUS;
     private Runnable onDataChanged;
 
@@ -118,8 +114,8 @@ public final class HyperbolicViewModel {
     public void drillDown(UUID noteId) {
         UUID current = focusNoteId.get();
         if (current != null) {
-            navigationHistory.push(current);
-            canNavigateBack.set(true);
+            navigationStack.setCurrentId(current);
+            navigationStack.push(noteId);
         }
         setFocusNote(noteId);
     }
@@ -128,11 +124,10 @@ public final class HyperbolicViewModel {
      * Navigates back to the previous focus note.
      */
     public void navigateBack() {
-        if (navigationHistory.isEmpty()) {
+        UUID previous = navigationStack.pop();
+        if (previous == null) {
             return;
         }
-        UUID previous = navigationHistory.pop();
-        canNavigateBack.set(!navigationHistory.isEmpty());
         setFocusNote(previous);
     }
 
@@ -189,7 +184,7 @@ public final class HyperbolicViewModel {
 
     /** Returns the canNavigateBack property. */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
-        return canNavigateBack;
+        return navigationStack.canNavigateBackProperty();
     }
 
     /**

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -1,7 +1,5 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -9,12 +7,10 @@ import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Attributes;
 import com.embervault.domain.Note;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
@@ -41,12 +37,9 @@ public final class MapViewModel {
             FXCollections.observableArrayList();
     private final ObjectProperty<UUID> selectedNoteId =
             new SimpleObjectProperty<>();
-    private final BooleanProperty canNavigateBack =
-            new SimpleBooleanProperty(false);
+    private final NavigationStack navigationStack = new NavigationStack();
     private final NoteService noteService;
     private final StringProperty rootNoteTitle;
-    private final Deque<UUID> navigationHistory = new ArrayDeque<>();
-    private UUID baseNoteId;
     private Runnable onDataChanged;
 
     /**
@@ -63,7 +56,7 @@ public final class MapViewModel {
         updateTabTitle(noteTitle.get());
         // When the root note title changes and we're at the root level, update tab title
         noteTitle.addListener((obs, oldVal, newVal) -> {
-            if (navigationHistory.isEmpty()) {
+            if (navigationStack.isAtRoot()) {
                 updateTabTitle(newVal);
             }
         });
@@ -105,12 +98,12 @@ public final class MapViewModel {
      * @param noteId the base note id
      */
     public void setBaseNoteId(UUID noteId) {
-        this.baseNoteId = noteId;
+        navigationStack.setCurrentId(noteId);
     }
 
     /** Returns the base note id. */
     public UUID getBaseNoteId() {
-        return baseNoteId;
+        return navigationStack.getCurrentId();
     }
 
     /**
@@ -124,6 +117,7 @@ public final class MapViewModel {
 
     /** Loads the children of the base note into the observable list. */
     public void loadNotes() {
+        UUID baseNoteId = navigationStack.getCurrentId();
         if (baseNoteId == null) {
             noteItems.clear();
             return;
@@ -141,6 +135,7 @@ public final class MapViewModel {
      * @return the display item for the created note
      */
     public NoteDisplayItem createChildNote(String title) {
+        UUID baseNoteId = navigationStack.getCurrentId();
         Objects.requireNonNull(baseNoteId, "baseNoteId must be set before creating children");
         Note child = noteService.createChildNote(baseNoteId, title);
         NoteDisplayItem item = toDisplayItem(child);
@@ -158,6 +153,7 @@ public final class MapViewModel {
      * @return the display item for the created note
      */
     public NoteDisplayItem createChildNoteAt(String title, double xpos, double ypos) {
+        UUID baseNoteId = navigationStack.getCurrentId();
         Objects.requireNonNull(baseNoteId, "baseNoteId must be set before creating children");
         Note child = noteService.createChildNote(baseNoteId, title);
         child.setAttribute(Attributes.XPOS, new AttributeValue.NumberValue(xpos / SCALE_X));
@@ -203,7 +199,7 @@ public final class MapViewModel {
 
     /** Returns the canNavigateBack property. */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
-        return canNavigateBack;
+        return navigationStack.canNavigateBackProperty();
     }
 
     /**
@@ -240,9 +236,7 @@ public final class MapViewModel {
      * @param noteId the note id to drill into
      */
     public void drillDown(UUID noteId) {
-        navigationHistory.push(baseNoteId);
-        canNavigateBack.set(true);
-        baseNoteId = noteId;
+        navigationStack.push(noteId);
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
@@ -253,15 +247,14 @@ public final class MapViewModel {
      * Navigates back to the previous base note.
      */
     public void navigateBack() {
-        if (navigationHistory.isEmpty()) {
+        UUID previous = navigationStack.pop();
+        if (previous == null) {
             return;
         }
-        baseNoteId = navigationHistory.pop();
-        canNavigateBack.set(!navigationHistory.isEmpty());
-        if (navigationHistory.isEmpty()) {
+        if (navigationStack.isAtRoot()) {
             updateTabTitle(rootNoteTitle.get());
         } else {
-            noteService.getNote(baseNoteId).ifPresent(note ->
+            noteService.getNote(previous).ifPresent(note ->
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NavigationStack.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NavigationStack.java
@@ -1,0 +1,89 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.UUID;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+/**
+ * Reusable navigation history stack for ViewModels that support drill-down navigation.
+ *
+ * <p>Encapsulates a {@link Deque} of {@link UUID} entries representing previously
+ * visited note ids, along with a {@code currentId} tracking the active note.
+ * Exposes an observable {@code canNavigateBack} property that the view layer
+ * can bind to for enabling/disabling back-navigation controls.</p>
+ */
+public final class NavigationStack {
+
+    private final Deque<UUID> history = new ArrayDeque<>();
+    private final BooleanProperty canNavigateBack =
+            new SimpleBooleanProperty(false);
+    private UUID currentId;
+
+    /**
+     * Returns the id currently at the top of the stack (the active note).
+     *
+     * @return the current id, or {@code null} if not set
+     */
+    public UUID getCurrentId() {
+        return currentId;
+    }
+
+    /**
+     * Sets the current id without affecting the navigation history.
+     *
+     * <p>Use this for initial setup; use {@link #push(UUID)} for drill-down.</p>
+     *
+     * @param id the current id
+     */
+    public void setCurrentId(UUID id) {
+        this.currentId = id;
+    }
+
+    /**
+     * Pushes the current id onto the history stack and sets a new current id.
+     *
+     * @param newId the new current id to navigate to
+     */
+    public void push(UUID newId) {
+        history.push(currentId);
+        currentId = newId;
+        canNavigateBack.set(true);
+    }
+
+    /**
+     * Pops the most recent id from the history and makes it the current id.
+     *
+     * @return the restored id, or {@code null} if the history was empty
+     */
+    public UUID pop() {
+        if (history.isEmpty()) {
+            return null;
+        }
+        UUID previous = history.pop();
+        currentId = previous;
+        canNavigateBack.set(!history.isEmpty());
+        return previous;
+    }
+
+    /**
+     * Returns whether the navigation history is empty (i.e., we are at the root level).
+     *
+     * @return {@code true} if the history is empty
+     */
+    public boolean isAtRoot() {
+        return history.isEmpty();
+    }
+
+    /**
+     * Returns the observable property indicating whether back-navigation is possible.
+     *
+     * @return the read-only boolean property
+     */
+    public ReadOnlyBooleanProperty canNavigateBackProperty() {
+        return canNavigateBack;
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -1,18 +1,14 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.Objects;
 import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.Note;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
@@ -34,12 +30,9 @@ public final class OutlineViewModel {
             FXCollections.observableArrayList();
     private final ObjectProperty<UUID> selectedNoteId =
             new SimpleObjectProperty<>();
-    private final BooleanProperty canNavigateBack =
-            new SimpleBooleanProperty(false);
+    private final NavigationStack navigationStack = new NavigationStack();
     private final NoteService noteService;
     private final StringProperty rootNoteTitle;
-    private final Deque<UUID> navigationHistory = new ArrayDeque<>();
-    private UUID baseNoteId;
     private Runnable onDataChanged;
 
     /**
@@ -56,7 +49,7 @@ public final class OutlineViewModel {
         updateTabTitle(noteTitle.get());
         // When the root note title changes and we're at the root level, update tab title
         noteTitle.addListener((obs, oldVal, newVal) -> {
-            if (navigationHistory.isEmpty()) {
+            if (navigationStack.isAtRoot()) {
                 updateTabTitle(newVal);
             }
         });
@@ -98,12 +91,12 @@ public final class OutlineViewModel {
      * @param noteId the base note id
      */
     public void setBaseNoteId(UUID noteId) {
-        this.baseNoteId = noteId;
+        navigationStack.setCurrentId(noteId);
     }
 
     /** Returns the base note id. */
     public UUID getBaseNoteId() {
-        return baseNoteId;
+        return navigationStack.getCurrentId();
     }
 
     /**
@@ -117,6 +110,7 @@ public final class OutlineViewModel {
 
     /** Loads the children of the base note into the observable list. */
     public void loadNotes() {
+        UUID baseNoteId = navigationStack.getCurrentId();
         if (baseNoteId == null) {
             rootItems.clear();
             return;
@@ -138,7 +132,7 @@ public final class OutlineViewModel {
         Note child = noteService.createChildNote(parentId, title);
         NoteDisplayItem item = toDisplayItem(child);
         // Add to root items if parent is the base note
-        if (parentId.equals(baseNoteId)) {
+        if (parentId.equals(navigationStack.getCurrentId())) {
             rootItems.add(item);
         }
         notifyDataChanged();
@@ -212,7 +206,7 @@ public final class OutlineViewModel {
 
     /** Returns the canNavigateBack property. */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
-        return canNavigateBack;
+        return navigationStack.canNavigateBackProperty();
     }
 
     /**
@@ -221,9 +215,7 @@ public final class OutlineViewModel {
      * @param noteId the note id to drill into
      */
     public void drillDown(UUID noteId) {
-        navigationHistory.push(baseNoteId);
-        canNavigateBack.set(true);
-        baseNoteId = noteId;
+        navigationStack.push(noteId);
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
@@ -234,15 +226,14 @@ public final class OutlineViewModel {
      * Navigates back to the previous base note.
      */
     public void navigateBack() {
-        if (navigationHistory.isEmpty()) {
+        UUID previous = navigationStack.pop();
+        if (previous == null) {
             return;
         }
-        baseNoteId = navigationHistory.pop();
-        canNavigateBack.set(!navigationHistory.isEmpty());
-        if (navigationHistory.isEmpty()) {
+        if (navigationStack.isAtRoot()) {
             updateTabTitle(rootNoteTitle.get());
         } else {
-            noteService.getNote(baseNoteId).ifPresent(note ->
+            noteService.getNote(previous).ifPresent(note ->
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
@@ -1,19 +1,15 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.Note;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
@@ -36,12 +32,9 @@ public final class TreemapViewModel {
             FXCollections.observableArrayList();
     private final ObjectProperty<UUID> selectedNoteId =
             new SimpleObjectProperty<>();
-    private final BooleanProperty canNavigateBack =
-            new SimpleBooleanProperty(false);
+    private final NavigationStack navigationStack = new NavigationStack();
     private final NoteService noteService;
     private final StringProperty rootNoteTitle;
-    private final Deque<UUID> navigationHistory = new ArrayDeque<>();
-    private UUID baseNoteId;
     private Runnable onDataChanged;
 
     /**
@@ -57,7 +50,7 @@ public final class TreemapViewModel {
         this.rootNoteTitle = noteTitle;
         updateTabTitle(noteTitle.get());
         noteTitle.addListener((obs, oldVal, newVal) -> {
-            if (navigationHistory.isEmpty()) {
+            if (navigationStack.isAtRoot()) {
                 updateTabTitle(newVal);
             }
         });
@@ -99,12 +92,12 @@ public final class TreemapViewModel {
      * @param noteId the base note id
      */
     public void setBaseNoteId(UUID noteId) {
-        this.baseNoteId = noteId;
+        navigationStack.setCurrentId(noteId);
     }
 
     /** Returns the base note id. */
     public UUID getBaseNoteId() {
-        return baseNoteId;
+        return navigationStack.getCurrentId();
     }
 
     /**
@@ -118,6 +111,7 @@ public final class TreemapViewModel {
 
     /** Loads the children of the base note into the observable list. */
     public void loadNotes() {
+        UUID baseNoteId = navigationStack.getCurrentId();
         if (baseNoteId == null) {
             noteItems.clear();
             return;
@@ -135,6 +129,7 @@ public final class TreemapViewModel {
      * @return the display item for the created note
      */
     public NoteDisplayItem createChildNote(String title) {
+        UUID baseNoteId = navigationStack.getCurrentId();
         Objects.requireNonNull(baseNoteId,
                 "baseNoteId must be set before creating children");
         Note child = noteService.createChildNote(baseNoteId, title);
@@ -146,7 +141,7 @@ public final class TreemapViewModel {
 
     /** Returns the canNavigateBack property. */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
-        return canNavigateBack;
+        return navigationStack.canNavigateBackProperty();
     }
 
     /**
@@ -155,9 +150,7 @@ public final class TreemapViewModel {
      * @param noteId the note id to drill into
      */
     public void drillDown(UUID noteId) {
-        navigationHistory.push(baseNoteId);
-        canNavigateBack.set(true);
-        baseNoteId = noteId;
+        navigationStack.push(noteId);
         noteService.getNote(noteId).ifPresent(note ->
                 updateTabTitle(note.getTitle()));
         loadNotes();
@@ -168,15 +161,14 @@ public final class TreemapViewModel {
      * Navigates back to the previous base note.
      */
     public void navigateBack() {
-        if (navigationHistory.isEmpty()) {
+        UUID previous = navigationStack.pop();
+        if (previous == null) {
             return;
         }
-        baseNoteId = navigationHistory.pop();
-        canNavigateBack.set(!navigationHistory.isEmpty());
-        if (navigationHistory.isEmpty()) {
+        if (navigationStack.isAtRoot()) {
             updateTabTitle(rootNoteTitle.get());
         } else {
-            noteService.getNote(baseNoteId).ifPresent(note ->
+            noteService.getNote(previous).ifPresent(note ->
                     updateTabTitle(note.getTitle()));
         }
         loadNotes();

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/NavigationStackTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/NavigationStackTest.java
@@ -1,0 +1,182 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NavigationStackTest {
+
+    private NavigationStack stack;
+
+    @BeforeEach
+    void setUp() {
+        stack = new NavigationStack();
+    }
+
+    @Test
+    @DisplayName("currentId is null initially")
+    void currentId_shouldBeNullInitially() {
+        assertNull(stack.getCurrentId());
+    }
+
+    @Test
+    @DisplayName("canNavigateBack is false initially")
+    void canNavigateBack_shouldBeFalseInitially() {
+        assertFalse(stack.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("push sets currentId and enables back navigation")
+    void push_shouldSetCurrentIdAndEnableBack() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        stack.setCurrentId(first);
+
+        stack.push(second);
+
+        assertEquals(second, stack.getCurrentId());
+        assertTrue(stack.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("pop returns to previous id")
+    void pop_shouldReturnToPreviousId() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        stack.setCurrentId(first);
+        stack.push(second);
+
+        UUID popped = stack.pop();
+
+        assertEquals(first, popped);
+        assertEquals(first, stack.getCurrentId());
+    }
+
+    @Test
+    @DisplayName("canNavigateBack is false after popping all entries")
+    void canNavigateBack_shouldBeFalseAfterPoppingAll() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        stack.setCurrentId(first);
+        stack.push(second);
+
+        stack.pop();
+
+        assertFalse(stack.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("pop returns null when history is empty")
+    void pop_shouldReturnNullWhenEmpty() {
+        assertNull(stack.pop());
+    }
+
+    @Test
+    @DisplayName("pop does not change currentId when history is empty")
+    void pop_shouldNotChangeCurrentIdWhenEmpty() {
+        UUID id = UUID.randomUUID();
+        stack.setCurrentId(id);
+
+        stack.pop();
+
+        assertEquals(id, stack.getCurrentId());
+    }
+
+    @Test
+    @DisplayName("multiple push/pop cycles work correctly")
+    void multiplePushPop_shouldWorkCorrectly() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        UUID third = UUID.randomUUID();
+        stack.setCurrentId(first);
+
+        stack.push(second);
+        stack.push(third);
+
+        assertTrue(stack.canNavigateBackProperty().get());
+        assertEquals(third, stack.getCurrentId());
+
+        stack.pop();
+        assertEquals(second, stack.getCurrentId());
+        assertTrue(stack.canNavigateBackProperty().get());
+
+        stack.pop();
+        assertEquals(first, stack.getCurrentId());
+        assertFalse(stack.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("isAtRoot returns true when history is empty")
+    void isAtRoot_shouldBeTrueWhenHistoryIsEmpty() {
+        assertTrue(stack.isAtRoot());
+    }
+
+    @Test
+    @DisplayName("isAtRoot returns false after push")
+    void isAtRoot_shouldBeFalseAfterPush() {
+        UUID first = UUID.randomUUID();
+        stack.setCurrentId(first);
+        stack.push(UUID.randomUUID());
+
+        assertFalse(stack.isAtRoot());
+    }
+
+    @Test
+    @DisplayName("isAtRoot returns true after popping all entries")
+    void isAtRoot_shouldBeTrueAfterPoppingAll() {
+        UUID first = UUID.randomUUID();
+        stack.setCurrentId(first);
+        stack.push(UUID.randomUUID());
+
+        stack.pop();
+
+        assertTrue(stack.isAtRoot());
+    }
+
+    @Test
+    @DisplayName("setCurrentId does not affect navigation history")
+    void setCurrentId_shouldNotAffectHistory() {
+        UUID first = UUID.randomUUID();
+        stack.setCurrentId(first);
+
+        assertFalse(stack.canNavigateBackProperty().get());
+        assertTrue(stack.isAtRoot());
+    }
+
+    @Test
+    @DisplayName("canNavigateBack property is observable and updates on push")
+    void canNavigateBackProperty_shouldUpdateOnPush() {
+        boolean[] observed = {false};
+        stack.canNavigateBackProperty().addListener(
+                (obs, oldVal, newVal) -> observed[0] = newVal);
+
+        UUID first = UUID.randomUUID();
+        stack.setCurrentId(first);
+        stack.push(UUID.randomUUID());
+
+        assertTrue(observed[0]);
+    }
+
+    @Test
+    @DisplayName("canNavigateBack property is observable and updates on pop")
+    void canNavigateBackProperty_shouldUpdateOnPop() {
+        UUID first = UUID.randomUUID();
+        stack.setCurrentId(first);
+        stack.push(UUID.randomUUID());
+
+        boolean[] observed = {true};
+        stack.canNavigateBackProperty().addListener(
+                (obs, oldVal, newVal) -> observed[0] = newVal);
+
+        stack.pop();
+
+        assertFalse(observed[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NavigationStack` helper class encapsulating `Deque<UUID>`, push/pop, `canNavigateBack` BooleanProperty, and `currentId` tracking
- Refactor `MapViewModel`, `OutlineViewModel`, `TreemapViewModel`, and `HyperbolicViewModel` to delegate to `NavigationStack` instead of each managing their own Deque and BooleanProperty fields
- Add 14 unit tests for `NavigationStack` covering push/pop cycles, empty-stack edge cases, observable property updates, and `isAtRoot` semantics

Closes #92

## Test plan
- [x] All 14 new `NavigationStackTest` tests pass
- [x] All 647 existing tests pass (no regressions)
- [x] Checkstyle passes
- [x] JaCoCo coverage thresholds met
- [x] `mvn verify` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)