### PR TITLE
Replace raw attribute name strings with Attributes constants

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
@@ -1,5 +1,8 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import static com.embervault.domain.Attributes.BADGE;
+import static com.embervault.domain.Attributes.COLOR;
+
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -213,11 +216,11 @@ public final class AttributeBrowserViewModel {
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {
-        String colorHex = note.getAttribute("$Color")
+        String colorHex = note.getAttribute(COLOR)
                 .map(v -> ((AttributeValue.ColorValue) v).value())
                 .map(TbxColor::toHex)
                 .orElse(DEFAULT_COLOR_HEX);
-        String badge = note.getAttribute("$Badge")
+        String badge = note.getAttribute(BADGE)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .flatMap(BadgeRegistry::getBadgeSymbol)
                 .orElse("");

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
@@ -1,5 +1,7 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import static com.embervault.domain.Attributes.BADGE;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -213,7 +215,7 @@ public final class HyperbolicViewModel {
      */
     public String getNoteBadge(UUID noteId) {
         return noteService.getNote(noteId)
-                .flatMap(note -> note.getAttribute("$Badge"))
+                .flatMap(note -> note.getAttribute(BADGE))
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .flatMap(BadgeRegistry::getBadgeSymbol)
                 .orElse("");

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteEditorViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteEditorViewModel.java
@@ -1,5 +1,8 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import static com.embervault.domain.Attributes.NAME;
+import static com.embervault.domain.Attributes.TEXT;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -125,7 +128,7 @@ public final class NoteEditorViewModel {
             return;
         }
         noteService.getNote(currentNoteId).ifPresent(note -> {
-            note.setAttribute("$Text", new AttributeValue.StringValue(newText));
+            note.setAttribute(TEXT, new AttributeValue.StringValue(newText));
         });
         text.set(newText);
         notifyDataChanged();
@@ -156,7 +159,7 @@ public final class NoteEditorViewModel {
         for (Map.Entry<String, AttributeValue> entry : entries.entrySet()) {
             String attrName = entry.getKey();
             // Skip $Name and $Text since they have dedicated fields
-            if ("$Name".equals(attrName) || "$Text".equals(attrName)) {
+            if (NAME.equals(attrName) || TEXT.equals(attrName)) {
                 continue;
             }
             // Skip intrinsic/read-only attributes

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
@@ -1,5 +1,7 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import static com.embervault.domain.Attributes.TEXT;
+
 import java.util.Objects;
 import java.util.UUID;
 
@@ -113,7 +115,7 @@ public final class SelectedNoteViewModel {
             return;
         }
         noteService.getNote(noteId).ifPresent(note -> {
-            note.setAttribute("$Text",
+            note.setAttribute(TEXT,
                     new AttributeValue.StringValue(newText));
         });
         text.set(newText);

--- a/src/main/java/com/embervault/adapter/out/persistence/InMemoryNoteRepository.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/InMemoryNoteRepository.java
@@ -1,5 +1,8 @@
 package com.embervault.adapter.out.persistence;
 
+import static com.embervault.domain.Attributes.CONTAINER;
+import static com.embervault.domain.Attributes.OUTLINE_ORDER;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -39,12 +42,12 @@ public final class InMemoryNoteRepository implements NoteRepository {
     public List<Note> findChildren(UUID parentId) {
         String parentIdStr = parentId.toString();
         return store.values().stream()
-                .filter(note -> note.getAttribute("$Container")
+                .filter(note -> note.getAttribute(CONTAINER)
                         .filter(v -> v instanceof AttributeValue.StringValue sv
                                 && parentIdStr.equals(sv.value()))
                         .isPresent())
                 .sorted(Comparator.comparingDouble(note ->
-                        note.getAttribute("$OutlineOrder")
+                        note.getAttribute(OUTLINE_ORDER)
                                 .filter(v -> v instanceof AttributeValue.NumberValue)
                                 .map(v -> ((AttributeValue.NumberValue) v).value())
                                 .orElse(0.0)))

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -1,5 +1,14 @@
 package com.embervault.application;
 
+import static com.embervault.domain.Attributes.CONTAINER;
+import static com.embervault.domain.Attributes.CREATED;
+import static com.embervault.domain.Attributes.MODIFIED;
+import static com.embervault.domain.Attributes.NAME;
+import static com.embervault.domain.Attributes.OUTLINE_ORDER;
+import static com.embervault.domain.Attributes.TEXT;
+import static com.embervault.domain.Attributes.XPOS;
+import static com.embervault.domain.Attributes.YPOS;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,13 +91,13 @@ public final class NoteServiceImpl implements NoteService {
         int nextOrder = repository.findChildren(parentId).size();
 
         Note child = Note.create(title, "");
-        child.setAttribute("$Container",
+        child.setAttribute(CONTAINER,
                 new AttributeValue.StringValue(parentId.toString()));
-        child.setAttribute("$OutlineOrder",
+        child.setAttribute(OUTLINE_ORDER,
                 new AttributeValue.NumberValue(nextOrder));
-        child.setAttribute("$Xpos",
+        child.setAttribute(XPOS,
                 new AttributeValue.NumberValue(random.nextDouble() * MAX_XPOS));
-        child.setAttribute("$Ypos",
+        child.setAttribute(YPOS,
                 new AttributeValue.NumberValue(random.nextDouble() * MAX_YPOS));
 
         return repository.save(child);
@@ -103,7 +112,7 @@ public final class NoteServiceImpl implements NoteService {
         Note note = repository.findById(noteId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
-        note.setAttribute("$Name", new AttributeValue.StringValue(newTitle));
+        note.setAttribute(NAME, new AttributeValue.StringValue(newTitle));
         return repository.save(note);
     }
 
@@ -127,9 +136,9 @@ public final class NoteServiceImpl implements NoteService {
                         "Parent note not found: " + newParentId));
 
         int nextOrder = repository.findChildren(newParentId).size();
-        note.setAttribute("$Container",
+        note.setAttribute(CONTAINER,
                 new AttributeValue.StringValue(newParentId.toString()));
-        note.setAttribute("$OutlineOrder",
+        note.setAttribute(OUTLINE_ORDER,
                 new AttributeValue.NumberValue(nextOrder));
 
         return repository.save(note);
@@ -141,13 +150,13 @@ public final class NoteServiceImpl implements NoteService {
                 .orElseThrow(() -> new NoSuchElementException(
                         "Sibling note not found: " + siblingId));
 
-        String containerId = sibling.getAttribute("$Container")
+        String containerId = sibling.getAttribute(CONTAINER)
                 .filter(v -> v instanceof AttributeValue.StringValue)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .orElseThrow(() -> new NoSuchElementException(
                         "Sibling has no $Container: " + siblingId));
 
-        double siblingOrder = sibling.getAttribute("$OutlineOrder")
+        double siblingOrder = sibling.getAttribute(OUTLINE_ORDER)
                 .filter(v -> v instanceof AttributeValue.NumberValue)
                 .map(v -> ((AttributeValue.NumberValue) v).value())
                 .orElse(0.0);
@@ -157,12 +166,12 @@ public final class NoteServiceImpl implements NoteService {
         // Bump order of all siblings after this one
         List<Note> siblings = repository.findChildren(parentId);
         for (Note s : siblings) {
-            double order = s.getAttribute("$OutlineOrder")
+            double order = s.getAttribute(OUTLINE_ORDER)
                     .filter(v -> v instanceof AttributeValue.NumberValue)
                     .map(v -> ((AttributeValue.NumberValue) v).value())
                     .orElse(0.0);
             if (order > siblingOrder) {
-                s.setAttribute("$OutlineOrder",
+                s.setAttribute(OUTLINE_ORDER,
                         new AttributeValue.NumberValue(order + 1));
                 repository.save(s);
             }
@@ -170,13 +179,13 @@ public final class NoteServiceImpl implements NoteService {
 
         // Create the new note (use AttributeMap constructor to allow empty titles)
         Note newNote = createNoteWithTitle(title);
-        newNote.setAttribute("$Container",
+        newNote.setAttribute(CONTAINER,
                 new AttributeValue.StringValue(containerId));
-        newNote.setAttribute("$OutlineOrder",
+        newNote.setAttribute(OUTLINE_ORDER,
                 new AttributeValue.NumberValue(siblingOrder + 1));
-        newNote.setAttribute("$Xpos",
+        newNote.setAttribute(XPOS,
                 new AttributeValue.NumberValue(random.nextDouble() * MAX_XPOS));
-        newNote.setAttribute("$Ypos",
+        newNote.setAttribute(YPOS,
                 new AttributeValue.NumberValue(random.nextDouble() * MAX_YPOS));
 
         return repository.save(newNote);
@@ -188,7 +197,7 @@ public final class NoteServiceImpl implements NoteService {
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
 
-        String containerId = note.getAttribute("$Container")
+        String containerId = note.getAttribute(CONTAINER)
                 .filter(v -> v instanceof AttributeValue.StringValue)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .orElse(null);
@@ -198,7 +207,7 @@ public final class NoteServiceImpl implements NoteService {
         }
 
         UUID parentId = UUID.fromString(containerId);
-        double noteOrder = note.getAttribute("$OutlineOrder")
+        double noteOrder = note.getAttribute(OUTLINE_ORDER)
                 .filter(v -> v instanceof AttributeValue.NumberValue)
                 .map(v -> ((AttributeValue.NumberValue) v).value())
                 .orElse(0.0);
@@ -211,7 +220,7 @@ public final class NoteServiceImpl implements NoteService {
             if (s.getId().equals(noteId)) {
                 continue;
             }
-            double order = s.getAttribute("$OutlineOrder")
+            double order = s.getAttribute(OUTLINE_ORDER)
                     .filter(v -> v instanceof AttributeValue.NumberValue)
                     .map(v -> ((AttributeValue.NumberValue) v).value())
                     .orElse(0.0);
@@ -227,9 +236,9 @@ public final class NoteServiceImpl implements NoteService {
 
         // Move note to be a child of noteAbove
         int newOrder = repository.findChildren(noteAbove.getId()).size();
-        note.setAttribute("$Container",
+        note.setAttribute(CONTAINER,
                 new AttributeValue.StringValue(noteAbove.getId().toString()));
-        note.setAttribute("$OutlineOrder",
+        note.setAttribute(OUTLINE_ORDER,
                 new AttributeValue.NumberValue(newOrder));
 
         return repository.save(note);
@@ -241,7 +250,7 @@ public final class NoteServiceImpl implements NoteService {
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
 
-        String containerId = note.getAttribute("$Container")
+        String containerId = note.getAttribute(CONTAINER)
                 .filter(v -> v instanceof AttributeValue.StringValue)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .orElse(null);
@@ -256,7 +265,7 @@ public final class NoteServiceImpl implements NoteService {
             return note;
         }
 
-        String grandparentContainerId = parent.getAttribute("$Container")
+        String grandparentContainerId = parent.getAttribute(CONTAINER)
                 .filter(v -> v instanceof AttributeValue.StringValue)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .orElse(null);
@@ -268,7 +277,7 @@ public final class NoteServiceImpl implements NoteService {
         UUID grandparentId = UUID.fromString(grandparentContainerId);
 
         // Find parent's order in grandparent's children
-        double parentOrder = parent.getAttribute("$OutlineOrder")
+        double parentOrder = parent.getAttribute(OUTLINE_ORDER)
                 .filter(v -> v instanceof AttributeValue.NumberValue)
                 .map(v -> ((AttributeValue.NumberValue) v).value())
                 .orElse(0.0);
@@ -276,21 +285,21 @@ public final class NoteServiceImpl implements NoteService {
         // Bump order of grandparent's children that come after parent
         List<Note> grandparentChildren = repository.findChildren(grandparentId);
         for (Note gc : grandparentChildren) {
-            double order = gc.getAttribute("$OutlineOrder")
+            double order = gc.getAttribute(OUTLINE_ORDER)
                     .filter(v -> v instanceof AttributeValue.NumberValue)
                     .map(v -> ((AttributeValue.NumberValue) v).value())
                     .orElse(0.0);
             if (order > parentOrder) {
-                gc.setAttribute("$OutlineOrder",
+                gc.setAttribute(OUTLINE_ORDER,
                         new AttributeValue.NumberValue(order + 1));
                 repository.save(gc);
             }
         }
 
         // Move note to grandparent, positioned just after parent
-        note.setAttribute("$Container",
+        note.setAttribute(CONTAINER,
                 new AttributeValue.StringValue(grandparentContainerId));
-        note.setAttribute("$OutlineOrder",
+        note.setAttribute(OUTLINE_ORDER,
                 new AttributeValue.NumberValue(parentOrder + 1));
 
         return repository.save(note);
@@ -307,7 +316,7 @@ public final class NoteServiceImpl implements NoteService {
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
 
-        String containerId = note.getAttribute("$Container")
+        String containerId = note.getAttribute(CONTAINER)
                 .filter(v -> v instanceof AttributeValue.StringValue)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .orElse(null);
@@ -317,7 +326,7 @@ public final class NoteServiceImpl implements NoteService {
         }
 
         UUID parentId = UUID.fromString(containerId);
-        double noteOrder = note.getAttribute("$OutlineOrder")
+        double noteOrder = note.getAttribute(OUTLINE_ORDER)
                 .filter(v -> v instanceof AttributeValue.NumberValue)
                 .map(v -> ((AttributeValue.NumberValue) v).value())
                 .orElse(0.0);
@@ -330,7 +339,7 @@ public final class NoteServiceImpl implements NoteService {
             if (s.getId().equals(noteId)) {
                 continue;
             }
-            double order = s.getAttribute("$OutlineOrder")
+            double order = s.getAttribute(OUTLINE_ORDER)
                     .filter(v -> v instanceof AttributeValue.NumberValue)
                     .map(v -> ((AttributeValue.NumberValue) v).value())
                     .orElse(0.0);
@@ -403,11 +412,11 @@ public final class NoteServiceImpl implements NoteService {
         }
         Instant now = Instant.now();
         AttributeMap attrs = new AttributeMap();
-        attrs.set("$Name", new AttributeValue.StringValue(
+        attrs.set(NAME, new AttributeValue.StringValue(
                 title == null ? "" : title));
-        attrs.set("$Text", new AttributeValue.StringValue(""));
-        attrs.set("$Created", new AttributeValue.DateValue(now));
-        attrs.set("$Modified", new AttributeValue.DateValue(now));
+        attrs.set(TEXT, new AttributeValue.StringValue(""));
+        attrs.set(CREATED, new AttributeValue.DateValue(now));
+        attrs.set(MODIFIED, new AttributeValue.DateValue(now));
         return new Note(UUID.randomUUID(), attrs);
     }
 }

--- a/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
+++ b/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
@@ -1,5 +1,28 @@
 package com.embervault.domain;
 
+import static com.embervault.domain.Attributes.BADGE;
+import static com.embervault.domain.Attributes.BORDER_COLOR;
+import static com.embervault.domain.Attributes.CAPTION;
+import static com.embervault.domain.Attributes.CHECKED;
+import static com.embervault.domain.Attributes.COLOR;
+import static com.embervault.domain.Attributes.CONTAINER;
+import static com.embervault.domain.Attributes.CREATED;
+import static com.embervault.domain.Attributes.DISPLAYED_ATTRIBUTES;
+import static com.embervault.domain.Attributes.FLAGS;
+import static com.embervault.domain.Attributes.HEIGHT;
+import static com.embervault.domain.Attributes.IS_PROTOTYPE;
+import static com.embervault.domain.Attributes.MODIFIED;
+import static com.embervault.domain.Attributes.NAME;
+import static com.embervault.domain.Attributes.OUTLINE_ORDER;
+import static com.embervault.domain.Attributes.PROTOTYPE;
+import static com.embervault.domain.Attributes.SHAPE;
+import static com.embervault.domain.Attributes.SUBTITLE;
+import static com.embervault.domain.Attributes.TEXT;
+import static com.embervault.domain.Attributes.URL;
+import static com.embervault.domain.Attributes.WIDTH;
+import static com.embervault.domain.Attributes.XPOS;
+import static com.embervault.domain.Attributes.YPOS;
+
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -84,47 +107,47 @@ public final class AttributeSchemaRegistry {
 
     private void registerSystemAttributes() {
         // Identity & Structure
-        systemAttr("$Name", AttributeType.STRING, new AttributeValue.StringValue(""));
-        systemAttr("$IsPrototype", AttributeType.BOOLEAN, new AttributeValue.BooleanValue(false));
-        systemAttr("$Prototype", AttributeType.STRING, new AttributeValue.StringValue(""));
-        intrinsicAttr("$Container", AttributeType.STRING,
+        systemAttr(NAME, AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr(IS_PROTOTYPE, AttributeType.BOOLEAN, new AttributeValue.BooleanValue(false));
+        systemAttr(PROTOTYPE, AttributeType.STRING, new AttributeValue.StringValue(""));
+        intrinsicAttr(CONTAINER, AttributeType.STRING,
                 new AttributeValue.StringValue(""), false);
-        intrinsicAttr("$OutlineOrder", AttributeType.NUMBER,
+        intrinsicAttr(OUTLINE_ORDER, AttributeType.NUMBER,
                 new AttributeValue.NumberValue(0), false);
 
         // Content
-        systemAttr("$Text", AttributeType.STRING, new AttributeValue.StringValue(""));
-        systemAttr("$Subtitle", AttributeType.STRING, new AttributeValue.StringValue(""));
-        systemAttr("$Caption", AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr(TEXT, AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr(SUBTITLE, AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr(CAPTION, AttributeType.STRING, new AttributeValue.StringValue(""));
 
         // Appearance
-        systemAttr("$Color", AttributeType.COLOR,
+        systemAttr(COLOR, AttributeType.COLOR,
                 new AttributeValue.ColorValue(TbxColor.named("warm gray")));
-        systemAttr("$BorderColor", AttributeType.COLOR,
+        systemAttr(BORDER_COLOR, AttributeType.COLOR,
                 new AttributeValue.ColorValue(TbxColor.hex("#000000")));
-        systemAttr("$Shape", AttributeType.STRING, new AttributeValue.StringValue("normal"));
+        systemAttr(SHAPE, AttributeType.STRING, new AttributeValue.StringValue("normal"));
 
         // Position & Size (intrinsic)
-        intrinsicAttr("$Xpos", AttributeType.NUMBER, new AttributeValue.NumberValue(0), false);
-        intrinsicAttr("$Ypos", AttributeType.NUMBER, new AttributeValue.NumberValue(0), false);
-        intrinsicAttr("$Width", AttributeType.NUMBER, new AttributeValue.NumberValue(6), false);
-        intrinsicAttr("$Height", AttributeType.NUMBER, new AttributeValue.NumberValue(4), false);
+        intrinsicAttr(XPOS, AttributeType.NUMBER, new AttributeValue.NumberValue(0), false);
+        intrinsicAttr(YPOS, AttributeType.NUMBER, new AttributeValue.NumberValue(0), false);
+        intrinsicAttr(WIDTH, AttributeType.NUMBER, new AttributeValue.NumberValue(6), false);
+        intrinsicAttr(HEIGHT, AttributeType.NUMBER, new AttributeValue.NumberValue(4), false);
 
         // Dates (intrinsic, read-only)
-        intrinsicAttr("$Created", AttributeType.DATE,
+        intrinsicAttr(CREATED, AttributeType.DATE,
                 new AttributeValue.DateValue(Instant.EPOCH), true);
-        intrinsicAttr("$Modified", AttributeType.DATE,
+        intrinsicAttr(MODIFIED, AttributeType.DATE,
                 new AttributeValue.DateValue(Instant.EPOCH), true);
 
         // Flags & State
-        systemAttr("$Checked", AttributeType.BOOLEAN, new AttributeValue.BooleanValue(false));
-        systemAttr("$URL", AttributeType.URL, new AttributeValue.UrlValue(""));
+        systemAttr(CHECKED, AttributeType.BOOLEAN, new AttributeValue.BooleanValue(false));
+        systemAttr(URL, AttributeType.URL, new AttributeValue.UrlValue(""));
 
         // Display
-        systemAttr("$DisplayedAttributes", AttributeType.SET,
+        systemAttr(DISPLAYED_ATTRIBUTES, AttributeType.SET,
                 new AttributeValue.SetValue(Set.of()));
-        systemAttr("$Flags", AttributeType.SET, new AttributeValue.SetValue(Set.of()));
-        systemAttr("$Badge", AttributeType.STRING, new AttributeValue.StringValue(""));
+        systemAttr(FLAGS, AttributeType.SET, new AttributeValue.SetValue(Set.of()));
+        systemAttr(BADGE, AttributeType.STRING, new AttributeValue.StringValue(""));
     }
 
     private void systemAttr(String name, AttributeType type, AttributeValue defaultValue) {

--- a/src/main/java/com/embervault/domain/Note.java
+++ b/src/main/java/com/embervault/domain/Note.java
@@ -1,5 +1,10 @@
 package com.embervault.domain;
 
+import static com.embervault.domain.Attributes.CREATED;
+import static com.embervault.domain.Attributes.MODIFIED;
+import static com.embervault.domain.Attributes.NAME;
+import static com.embervault.domain.Attributes.TEXT;
+
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,10 +57,10 @@ public final class Note {
 
         this.id = id;
         this.attributes = new AttributeMap();
-        this.attributes.set("$Name", new AttributeValue.StringValue(title));
-        this.attributes.set("$Text", new AttributeValue.StringValue(content));
-        this.attributes.set("$Created", new AttributeValue.DateValue(createdAt));
-        this.attributes.set("$Modified", new AttributeValue.DateValue(updatedAt));
+        this.attributes.set(NAME, new AttributeValue.StringValue(title));
+        this.attributes.set(TEXT, new AttributeValue.StringValue(content));
+        this.attributes.set(CREATED, new AttributeValue.DateValue(createdAt));
+        this.attributes.set(MODIFIED, new AttributeValue.DateValue(updatedAt));
     }
 
     /**
@@ -73,7 +78,7 @@ public final class Note {
 
     /** Returns the title ($Name attribute). */
     public String getTitle() {
-        return attributes.get("$Name")
+        return attributes.get(NAME)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .orElse("");
     }
@@ -85,7 +90,7 @@ public final class Note {
 
     /** Returns the content ($Text attribute). */
     public String getContent() {
-        return attributes.get("$Text")
+        return attributes.get(TEXT)
                 .map(v -> ((AttributeValue.StringValue) v).value())
                 .orElse("");
     }
@@ -97,14 +102,14 @@ public final class Note {
 
     /** Returns the creation timestamp ($Created attribute). */
     public Instant getCreatedAt() {
-        return attributes.get("$Created")
+        return attributes.get(CREATED)
                 .map(v -> ((AttributeValue.DateValue) v).value())
                 .orElse(Instant.EPOCH);
     }
 
     /** Returns the last-updated timestamp ($Modified attribute). */
     public Instant getUpdatedAt() {
-        return attributes.get("$Modified")
+        return attributes.get(MODIFIED)
                 .map(v -> ((AttributeValue.DateValue) v).value())
                 .orElse(Instant.EPOCH);
     }
@@ -168,9 +173,9 @@ public final class Note {
             throw new IllegalArgumentException("title must not be blank");
         }
 
-        this.attributes.set("$Name", new AttributeValue.StringValue(newTitle));
-        this.attributes.set("$Text", new AttributeValue.StringValue(newContent));
-        this.attributes.set("$Modified", new AttributeValue.DateValue(Instant.now()));
+        this.attributes.set(NAME, new AttributeValue.StringValue(newTitle));
+        this.attributes.set(TEXT, new AttributeValue.StringValue(newContent));
+        this.attributes.set(MODIFIED, new AttributeValue.DateValue(Instant.now()));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Replace all raw `"$AttrName"` string literals with `Attributes.CONSTANT` references (via static imports) across 8 source files
- Use centralized constants from `Attributes.java` to eliminate typo risk and enable safe refactoring
- No new constants needed -- all existing constants in `Attributes.java` already covered the full set

## Files changed
- `Note.java` -- `$Name`, `$Text`, `$Created`, `$Modified`
- `NoteServiceImpl.java` -- `$Container`, `$OutlineOrder`, `$Xpos`, `$Ypos`, `$Name`, `$Text`, `$Created`, `$Modified`
- `InMemoryNoteRepository.java` -- `$Container`, `$OutlineOrder`
- `SelectedNoteViewModel.java` -- `$Text`
- `HyperbolicViewModel.java` -- `$Badge`
- `AttributeBrowserViewModel.java` -- `$Color`, `$Badge`
- `NoteEditorViewModel.java` -- `$Text`, `$Name`
- `AttributeSchemaRegistry.java` -- all 21 system attribute registrations

## Test plan
- [x] `mvn clean test` passes (633 tests, 0 failures)
- [x] `mvn checkstyle:check` passes (0 violations)
- [x] No raw `"$..."` attribute name strings remain outside `Attributes.java` (action expression strings in `App.java` and prefix check in `StampAction.java` are intentionally unchanged)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)