### PR TITLE
Add branch and PR workflow to ADR-0001 and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,4 +56,9 @@ All enforced by `mvn verify`:
 
 ## PR Workflow
 
-Do not auto-merge PRs. Always leave PRs open for manual review and merge.
+All work is done on issue branches and submitted as PRs to main (see ADR-0001):
+
+- Branch from main: `issue-<number>/<short-description>` or `fix/<description>`
+- PRs require passing CI (tests, checkstyle, JaCoCo, ArchUnit)
+- Manual merge only — no auto-merge, no direct pushes to main
+- Do not merge PRs automatically — leave them for manual review and merge

--- a/doc/adr/0001-use-pure-tdd-as-development-process.md
+++ b/doc/adr/0001-use-pure-tdd-as-development-process.md
@@ -36,6 +36,16 @@ Concretely this means:
 - Every commit on a feature branch must leave all tests passing.
 - Pull requests are expected to show a commit history that reflects the TDD cycle.
 
+### Branch and PR Workflow
+
+All development work is done on **issue branches** and submitted as **pull requests to main**:
+
+- **No direct commits to main.** Branch protection blocks direct pushes.
+- **Branch naming:** `issue-<number>/<short-description>` (e.g., `issue-42/map-outline-views`) or `fix/<description>` for non-issue fixes.
+- **PRs require passing CI:** tests, checkstyle, JaCoCo coverage, and ArchUnit rules must all pass before merge.
+- **Manual merge only.** Auto-merge is disabled. PRs are reviewed and merged by pressing the merge button.
+- **Exploratory spikes** use throwaway branches that are never merged directly — results are reimplemented via TDD on a proper issue branch.
+
 ## Consequences
 
 ### Positive


### PR DESCRIPTION
## Summary
Adds branch/PR workflow documentation to existing ADR-0001 (instead of a new ADR) and updates CLAUDE.md.

- ADR-0001: added "Branch and PR Workflow" subsection under Decision
- CLAUDE.md: expanded PR Workflow section with branch naming, references ADR-0001

Closes #107