### PR TITLE
Map view: place new note at double-click position

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -79,12 +79,12 @@ public class MapViewController {
         viewModel.getNoteItems().addListener(
                 (ListChangeListener<NoteDisplayItem>) this::onNoteItemsChanged);
 
-        // Double-click background to create new note
+        // Double-click background to create new note at click position
         mapCanvas.setOnMouseClicked(event -> {
             if (event.getClickCount() == 2
                     && event.getButton() == MouseButton.PRIMARY
                     && event.getTarget() == mapCanvas) {
-                viewModel.createChildNote("Untitled");
+                viewModel.createChildNoteAt("Untitled", event.getX(), event.getY());
             }
         });
 


### PR DESCRIPTION
## Summary
- Pass `event.getX()` and `event.getY()` to `createChildNoteAt()` in the double-click-on-background handler so the note's upper-left corner is placed at the cursor position instead of a random location
- Context menu "Create Note" already uses `createChildNoteAt` with coordinates (verified, no change needed)

Closes #110

## Test plan
- [ ] Double-click on map background -- new note appears with upper-left corner at cursor
- [ ] Right-click -> Create Note -- note appears at right-click position
- [ ] `./mvnw verify` passes (660 tests, checkstyle clean, coverage met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)