### PR TITLE
Add UI controller tests for 4 view controllers

### DIFF
--- a/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerTest.java
@@ -1,0 +1,247 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link OutlineViewController}.
+ *
+ * <p>Verifies tree building from notes, selection propagation to the ViewModel,
+ * drill-down and back navigation, and child note creation.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class OutlineViewControllerTest {
+
+    private OutlineViewController controller;
+    private OutlineViewModel viewModel;
+    private NoteService noteService;
+    private TreeView<NoteDisplayItem> outlineTreeView;
+    private VBox outlineRoot;
+    private UUID parentId;
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+
+        parentId = noteService.createNote("Parent", "").getId();
+        SimpleStringProperty noteTitle = new SimpleStringProperty("Parent");
+        viewModel = new OutlineViewModel(noteTitle, noteService);
+        viewModel.setBaseNoteId(parentId);
+
+        controller = new OutlineViewController();
+        outlineTreeView = new TreeView<>();
+        outlineRoot = new VBox();
+
+        injectField("outlineTreeView", outlineTreeView);
+        injectField("outlineRoot", outlineRoot);
+
+        controller.initViewModel(viewModel);
+    }
+
+    @Test
+    @DisplayName("tree is built with root items after initViewModel")
+    void initViewModel_buildsTree() {
+        assertNotNull(outlineTreeView.getRoot(),
+                "Tree should have a root after init");
+        assertFalse(outlineTreeView.isShowRoot(),
+                "Root should be hidden");
+    }
+
+    @Test
+    @DisplayName("tree contains children after adding notes")
+    void addNotes_treeContainsChildren() {
+        viewModel.createChildNote(parentId, "Child A");
+        viewModel.createChildNote(parentId, "Child B");
+
+        TreeItem<NoteDisplayItem> root = outlineTreeView.getRoot();
+        assertEquals(2, root.getChildren().size(),
+                "Tree root should have 2 children");
+    }
+
+    @Test
+    @DisplayName("tree item titles match note titles")
+    void treeItems_matchNoteTitles() {
+        viewModel.createChildNote(parentId, "First Note");
+        viewModel.createChildNote(parentId, "Second Note");
+
+        TreeItem<NoteDisplayItem> root = outlineTreeView.getRoot();
+        assertEquals("First Note",
+                root.getChildren().get(0).getValue().getTitle());
+        assertEquals("Second Note",
+                root.getChildren().get(1).getValue().getTitle());
+    }
+
+    @Test
+    @DisplayName("selecting a tree item sets viewModel selectedNoteId")
+    void selectTreeItem_setsViewModelSelection() {
+        NoteDisplayItem child = viewModel.createChildNote(parentId,
+                "Selectable");
+
+        TreeItem<NoteDisplayItem> root = outlineTreeView.getRoot();
+        outlineTreeView.getSelectionModel().select(
+                root.getChildren().get(0));
+
+        assertEquals(child.getId(),
+                viewModel.selectedNoteIdProperty().get(),
+                "ViewModel should reflect tree selection");
+    }
+
+    @Test
+    @DisplayName("clearing selection sets viewModel selectedNoteId to null")
+    void clearSelection_setsViewModelNull() {
+        viewModel.createChildNote(parentId, "Temp");
+
+        TreeItem<NoteDisplayItem> root = outlineTreeView.getRoot();
+        outlineTreeView.getSelectionModel().select(
+                root.getChildren().get(0));
+        assertNotNull(viewModel.selectedNoteIdProperty().get());
+
+        outlineTreeView.getSelectionModel().clearSelection();
+        assertNull(viewModel.selectedNoteIdProperty().get(),
+                "ViewModel selection should be null after clear");
+    }
+
+    @Test
+    @DisplayName("drill-down rebuilds tree with child's children")
+    void drillDown_rebuildsTree() {
+        NoteDisplayItem child = viewModel.createChildNote(parentId,
+                "Container");
+        noteService.createChildNote(child.getId(), "Grandchild A");
+        noteService.createChildNote(child.getId(), "Grandchild B");
+
+        viewModel.drillDown(child.getId());
+
+        TreeItem<NoteDisplayItem> root = outlineTreeView.getRoot();
+        assertEquals(2, root.getChildren().size(),
+                "After drill-down, tree should show grandchildren");
+        assertEquals("Grandchild A",
+                root.getChildren().get(0).getValue().getTitle());
+    }
+
+    @Test
+    @DisplayName("back button is inserted into outlineRoot")
+    void backButton_insertedIntoRoot() {
+        // The back button is added at index 0
+        assertTrue(outlineRoot.getChildren().size() >= 1,
+                "outlineRoot should contain back button");
+    }
+
+    @Test
+    @DisplayName("canNavigateBack is false at root level")
+    void canNavigateBack_falseAtRoot() {
+        assertFalse(viewModel.canNavigateBackProperty().get(),
+                "Should not be able to navigate back at root");
+    }
+
+    @Test
+    @DisplayName("canNavigateBack is true after drill-down")
+    void canNavigateBack_trueAfterDrillDown() {
+        NoteDisplayItem child = viewModel.createChildNote(parentId,
+                "Container");
+
+        viewModel.drillDown(child.getId());
+
+        assertTrue(viewModel.canNavigateBackProperty().get(),
+                "Should be able to navigate back after drill-down");
+    }
+
+    @Test
+    @DisplayName("navigateBack restores parent's children")
+    void navigateBack_restoresParentChildren() {
+        NoteDisplayItem child = viewModel.createChildNote(parentId,
+                "Container");
+        viewModel.createChildNote(parentId, "Sibling");
+        noteService.createChildNote(child.getId(), "Grandchild");
+
+        viewModel.drillDown(child.getId());
+        assertEquals(1, outlineTreeView.getRoot().getChildren().size());
+
+        viewModel.navigateBack();
+
+        assertEquals(2, outlineTreeView.getRoot().getChildren().size(),
+                "After navigating back, should show parent's children");
+    }
+
+    @Test
+    @DisplayName("renaming a note updates the tree item title")
+    void renameNote_updatesTreeItem() {
+        NoteDisplayItem child = viewModel.createChildNote(parentId,
+                "Original");
+
+        viewModel.renameNote(child.getId(), "Renamed");
+
+        TreeItem<NoteDisplayItem> root = outlineTreeView.getRoot();
+        assertEquals("Renamed",
+                root.getChildren().get(0).getValue().getTitle(),
+                "Tree item should show renamed title");
+    }
+
+    @Test
+    @DisplayName("getViewModel returns the injected viewModel")
+    void getViewModel_returnsInjectedViewModel() {
+        assertEquals(viewModel, controller.getViewModel(),
+                "getViewModel should return the initialized ViewModel");
+    }
+
+    @Test
+    @DisplayName("nested children appear in tree hierarchy")
+    void nestedChildren_appearInHierarchy() {
+        NoteDisplayItem child = viewModel.createChildNote(parentId,
+                "Parent Note");
+        noteService.createChildNote(child.getId(), "Nested Child");
+
+        // Reload to pick up the nested child
+        viewModel.loadNotes();
+
+        TreeItem<NoteDisplayItem> root = outlineTreeView.getRoot();
+        TreeItem<NoteDisplayItem> parentItem = root.getChildren().get(0);
+        assertTrue(parentItem.getValue().isHasChildren(),
+                "Parent note should be marked as having children");
+        assertEquals(1, parentItem.getChildren().size(),
+                "Parent tree item should have nested child");
+        assertEquals("Nested Child",
+                parentItem.getChildren().get(0).getValue().getTitle());
+    }
+
+    private void injectField(String fieldName, Object value) {
+        try {
+            var field = OutlineViewController.class
+                    .getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(controller, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/SearchViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/SearchViewControllerTest.java
@@ -1,0 +1,231 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import javafx.scene.control.Button;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link SearchViewController}.
+ *
+ * <p>Verifies visibility toggling, search result population, result list
+ * show/hide behavior, Enter-key immediate search, and Escape-key hide.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class SearchViewControllerTest {
+
+    private SearchViewController controller;
+    private SearchViewModel viewModel;
+    private NoteService noteService;
+    private VBox searchRoot;
+    private TextField searchField;
+    private Button closeButton;
+    private ListView<?> resultsList;
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+
+        // Create some notes for searching
+        noteService.createNote("Alpha Note", "content about alpha");
+        noteService.createNote("Beta Note", "content about beta");
+        noteService.createNote("Alpha Beta", "mixed content");
+
+        viewModel = new SearchViewModel(noteService);
+
+        controller = new SearchViewController();
+        searchRoot = new VBox();
+        searchField = new TextField();
+        closeButton = new Button("X");
+        resultsList = new ListView<>();
+
+        injectField("searchRoot", searchRoot);
+        injectField("searchField", searchField);
+        injectField("closeButton", closeButton);
+        injectField("resultsList", resultsList);
+
+        controller.initViewModel(viewModel);
+    }
+
+    @Test
+    @DisplayName("search root visibility is bound to viewModel visible property")
+    void searchRoot_visibilityBoundToViewModel() {
+        assertFalse(searchRoot.isVisible(),
+                "Search bar should be hidden initially");
+
+        viewModel.visibleProperty().set(true);
+        assertTrue(searchRoot.isVisible(),
+                "Search bar should be visible after setting visible true");
+
+        viewModel.visibleProperty().set(false);
+        assertFalse(searchRoot.isVisible(),
+                "Search bar should hide after setting visible false");
+    }
+
+    @Test
+    @DisplayName("search field text is bound bidirectionally to query property")
+    void searchField_boundToQueryProperty() {
+        viewModel.queryProperty().set("test query");
+        assertEquals("test query", searchField.getText());
+
+        searchField.setText("another query");
+        assertEquals("another query", viewModel.queryProperty().get());
+    }
+
+    @Test
+    @DisplayName("results list is hidden when results are empty")
+    void resultsList_hiddenWhenEmpty() {
+        assertFalse(resultsList.isVisible(),
+                "Results list should be hidden when empty");
+        assertFalse(resultsList.isManaged(),
+                "Results list should not be managed when empty");
+    }
+
+    @Test
+    @DisplayName("results list is shown after search produces results")
+    void resultsList_shownAfterSearchWithResults() {
+        viewModel.search("Alpha");
+
+        assertTrue(resultsList.isVisible(),
+                "Results list should be visible after search with results");
+        assertTrue(resultsList.isManaged(),
+                "Results list should be managed after search with results");
+        assertEquals(2, viewModel.getResults().size(),
+                "Should find two notes matching 'Alpha'");
+    }
+
+    @Test
+    @DisplayName("results list hides when results are cleared")
+    void resultsList_hidesWhenCleared() {
+        viewModel.search("Alpha");
+        assertTrue(resultsList.isVisible());
+
+        viewModel.getResults().clear();
+        assertFalse(resultsList.isVisible(),
+                "Results list should hide when cleared");
+    }
+
+    @Test
+    @DisplayName("Enter key bypasses debounce and searches immediately")
+    void enterKey_searchesImmediately(FxRobot robot) {
+        viewModel.visibleProperty().set(true);
+        searchField.setText("Beta");
+
+        robot.interact(() -> {
+            searchField.requestFocus();
+            searchField.fireEvent(new javafx.scene.input.KeyEvent(
+                    javafx.scene.input.KeyEvent.KEY_PRESSED,
+                    "", "", KeyCode.ENTER,
+                    false, false, false, false));
+        });
+
+        assertFalse(viewModel.getResults().isEmpty(),
+                "Enter should trigger immediate search");
+        assertTrue(viewModel.getResults().size() >= 1,
+                "Should find notes matching 'Beta'");
+    }
+
+    @Test
+    @DisplayName("Enter key selects first result when results exist")
+    void enterKey_selectsFirstResult(FxRobot robot) {
+        viewModel.visibleProperty().set(true);
+        searchField.setText("Alpha");
+
+        robot.interact(() -> {
+            searchField.requestFocus();
+            searchField.fireEvent(new javafx.scene.input.KeyEvent(
+                    javafx.scene.input.KeyEvent.KEY_PRESSED,
+                    "", "", KeyCode.ENTER,
+                    false, false, false, false));
+        });
+
+        UUID selectedId = viewModel.selectedNoteIdProperty().get();
+        assertNotNull(selectedId,
+                "Enter should select first search result");
+    }
+
+    @Test
+    @DisplayName("Escape key hides the search bar")
+    void escapeKey_hidesSearchBar(FxRobot robot) {
+        viewModel.visibleProperty().set(true);
+        assertTrue(searchRoot.isVisible());
+
+        robot.interact(() -> {
+            searchField.requestFocus();
+            searchField.fireEvent(new javafx.scene.input.KeyEvent(
+                    javafx.scene.input.KeyEvent.KEY_PRESSED,
+                    "", "", KeyCode.ESCAPE,
+                    false, false, false, false));
+        });
+
+        assertFalse(viewModel.visibleProperty().get(),
+                "Escape should hide the search bar");
+    }
+
+    @Test
+    @DisplayName("hide() clears query and results")
+    void hide_clearsQueryAndResults() {
+        viewModel.queryProperty().set("test");
+        viewModel.search("Alpha");
+        assertFalse(viewModel.getResults().isEmpty());
+
+        viewModel.hide();
+
+        assertEquals("", viewModel.queryProperty().get(),
+                "Query should be cleared after hide");
+        assertTrue(viewModel.getResults().isEmpty(),
+                "Results should be cleared after hide");
+        assertFalse(viewModel.visibleProperty().get(),
+                "Visible should be false after hide");
+    }
+
+    @Test
+    @DisplayName("search with no matches produces empty results")
+    void search_noMatches_emptyResults() {
+        viewModel.search("NonexistentNoteTitle");
+
+        assertTrue(viewModel.getResults().isEmpty(),
+                "Search for non-existent term should produce no results");
+        assertFalse(resultsList.isVisible(),
+                "Results list should be hidden with no matches");
+    }
+
+    private void injectField(String fieldName, Object value) {
+        try {
+            var field = SearchViewController.class
+                    .getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(controller, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/TextPaneViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/TextPaneViewControllerTest.java
@@ -1,0 +1,232 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link TextPaneViewController}.
+ *
+ * <p>Verifies placeholder visibility, title/text binding to the ViewModel,
+ * save-on-focus-lost behavior, and save-on-Enter for the title field.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class TextPaneViewControllerTest {
+
+    private TextPaneViewController controller;
+    private SelectedNoteViewModel viewModel;
+    private NoteService noteService;
+    private VBox textPaneRoot;
+    private Label placeholderLabel;
+    private TextField titleField;
+    private TextArea textArea;
+    private UUID noteId;
+
+    @Start
+    private void start(Stage stage) {
+        textPaneRoot = new VBox();
+        placeholderLabel = new Label("Select a note to edit");
+        titleField = new TextField();
+        textArea = new TextArea();
+        textPaneRoot.getChildren().addAll(placeholderLabel, titleField,
+                textArea);
+        stage.setScene(new javafx.scene.Scene(textPaneRoot, 400, 300));
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+
+        noteId = noteService.createNote("Test Note", "Test content").getId();
+
+        viewModel = new SelectedNoteViewModel(noteService);
+
+        controller = new TextPaneViewController();
+
+        injectField("textPaneRoot", textPaneRoot);
+        injectField("placeholderLabel", placeholderLabel);
+        injectField("titleField", titleField);
+        injectField("textArea", textArea);
+
+        controller.initViewModel(viewModel);
+    }
+
+    @Test
+    @DisplayName("placeholder is shown and editor hidden when no note selected")
+    void noNoteSelected_showsPlaceholder() {
+        assertTrue(placeholderLabel.isVisible(),
+                "Placeholder should be visible with no note selected");
+        assertFalse(titleField.isVisible(),
+                "Title field should be hidden with no note selected");
+        assertFalse(textArea.isVisible(),
+                "Text area should be hidden with no note selected");
+    }
+
+    @Test
+    @DisplayName("editor fields shown when a note is selected")
+    void noteSelected_showsEditorFields() {
+        viewModel.setSelectedNoteId(noteId);
+
+        assertFalse(placeholderLabel.isVisible(),
+                "Placeholder should be hidden when note selected");
+        assertTrue(titleField.isVisible(),
+                "Title field should be visible when note selected");
+        assertTrue(textArea.isVisible(),
+                "Text area should be visible when note selected");
+    }
+
+    @Test
+    @DisplayName("title field populated from viewModel when note selected")
+    void noteSelected_titleFieldPopulated() {
+        viewModel.setSelectedNoteId(noteId);
+
+        assertEquals("Test Note", titleField.getText(),
+                "Title field should show note title");
+    }
+
+    @Test
+    @DisplayName("text area populated from viewModel when note selected")
+    void noteSelected_textAreaPopulated() {
+        viewModel.setSelectedNoteId(noteId);
+
+        assertEquals("Test content", textArea.getText(),
+                "Text area should show note content");
+    }
+
+    @Test
+    @DisplayName("title updates in field when viewModel title changes")
+    void viewModelTitleChange_updatesField() {
+        viewModel.setSelectedNoteId(noteId);
+        assertEquals("Test Note", titleField.getText());
+
+        viewModel.titleProperty().set("Updated Title");
+        assertEquals("Updated Title", titleField.getText(),
+                "Title field should reflect viewModel title change");
+    }
+
+    @Test
+    @DisplayName("text updates in area when viewModel text changes")
+    void viewModelTextChange_updatesArea() {
+        viewModel.setSelectedNoteId(noteId);
+        assertEquals("Test content", textArea.getText());
+
+        viewModel.textProperty().set("Updated text");
+        assertEquals("Updated text", textArea.getText(),
+                "Text area should reflect viewModel text change");
+    }
+
+    @Test
+    @DisplayName("title saved on focus lost")
+    void titleField_savesOnFocusLost(FxRobot robot) {
+        viewModel.setSelectedNoteId(noteId);
+
+        robot.interact(() -> {
+            titleField.requestFocus();
+            titleField.setText("Renamed Note");
+        });
+
+        // Move focus away to trigger save
+        robot.interact(() -> textArea.requestFocus());
+
+        assertEquals("Renamed Note", viewModel.titleProperty().get(),
+                "Title should be saved after focus lost");
+
+        // Verify persistence
+        String persistedTitle = noteService.getNote(noteId)
+                .map(n -> n.getTitle())
+                .orElse("");
+        assertEquals("Renamed Note", persistedTitle,
+                "Title should be persisted via NoteService");
+    }
+
+    @Test
+    @DisplayName("title saved on Enter key")
+    void titleField_savesOnEnter(FxRobot robot) {
+        viewModel.setSelectedNoteId(noteId);
+
+        robot.interact(() -> {
+            titleField.requestFocus();
+            titleField.setText("Enter Title");
+        });
+
+        robot.interact(() -> titleField.fireEvent(
+                new javafx.event.ActionEvent()));
+
+        assertEquals("Enter Title", viewModel.titleProperty().get(),
+                "Title should be saved after Enter");
+    }
+
+    @Test
+    @DisplayName("text saved on focus lost")
+    void textArea_savesOnFocusLost(FxRobot robot) {
+        viewModel.setSelectedNoteId(noteId);
+
+        robot.interact(() -> {
+            textArea.requestFocus();
+            textArea.setText("Updated body text");
+        });
+
+        // Move focus away to trigger save
+        robot.interact(() -> titleField.requestFocus());
+
+        assertEquals("Updated body text", viewModel.textProperty().get(),
+                "Text should be saved after focus lost");
+    }
+
+    @Test
+    @DisplayName("clearing selection hides editor and shows placeholder")
+    void clearSelection_showsPlaceholder() {
+        viewModel.setSelectedNoteId(noteId);
+        assertTrue(titleField.isVisible());
+
+        viewModel.setSelectedNoteId(null);
+
+        assertTrue(placeholderLabel.isVisible(),
+                "Placeholder should reappear after clearing selection");
+        assertFalse(titleField.isVisible(),
+                "Title field should hide after clearing selection");
+        assertFalse(textArea.isVisible(),
+                "Text area should hide after clearing selection");
+    }
+
+    @Test
+    @DisplayName("getViewModel returns the injected viewModel")
+    void getViewModel_returnsInjectedViewModel() {
+        assertEquals(viewModel, controller.getViewModel(),
+                "getViewModel should return the initialized ViewModel");
+    }
+
+    private void injectField(String fieldName, Object value) {
+        try {
+            var field = TextPaneViewController.class
+                    .getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(controller, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/TreemapViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/TreemapViewControllerTest.java
@@ -1,0 +1,242 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Rectangle;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link TreemapViewController}.
+ *
+ * <p>Verifies layout rendering, note node creation, click-to-select,
+ * drill-down navigation, and back button behavior.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class TreemapViewControllerTest {
+
+    private TreemapViewController controller;
+    private TreemapViewModel viewModel;
+    private NoteService noteService;
+    private Pane treemapCanvas;
+    private UUID parentId;
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+
+        parentId = noteService.createNote("Parent", "").getId();
+        SimpleStringProperty noteTitle = new SimpleStringProperty("Parent");
+        viewModel = new TreemapViewModel(noteTitle, noteService);
+        viewModel.setBaseNoteId(parentId);
+
+        controller = new TreemapViewController();
+        treemapCanvas = new Pane();
+
+        injectField("treemapCanvas", treemapCanvas);
+
+        controller.initViewModel(viewModel);
+    }
+
+    @Test
+    @DisplayName("canvas contains only back button when no children exist")
+    void noChildren_canvasHasBackButtonOnly() {
+        // With zero-size canvas, only back button is added
+        assertEquals(1, treemapCanvas.getChildren().size(),
+                "Canvas should contain only back button when no children");
+    }
+
+    @Test
+    @DisplayName("adding notes creates note nodes on canvas after resize")
+    void addNotes_createsNodesAfterResize() {
+        viewModel.createChildNote("Note A");
+        viewModel.createChildNote("Note B");
+
+        // Simulate canvas resize to trigger layout
+        resizeCanvas(400, 300);
+
+        // Count StackPane children (note nodes) — back button is a Button
+        long noteNodes = treemapCanvas.getChildren().stream()
+                .filter(n -> n instanceof StackPane)
+                .count();
+        assertEquals(2, noteNodes,
+                "Canvas should have 2 note nodes after adding 2 notes");
+    }
+
+    @Test
+    @DisplayName("note nodes have userData set to note UUID")
+    void noteNodes_haveUserData() {
+        NoteDisplayItem item = viewModel.createChildNote("Tagged Note");
+        resizeCanvas(400, 300);
+
+        StackPane noteNode = findNodeByUserData(item.getId());
+        assertNotNull(noteNode,
+                "Should find note node by its UUID userData");
+    }
+
+    @Test
+    @DisplayName("clicking a note node sets viewModel selectedNoteId")
+    void clickNote_setsSelection() {
+        NoteDisplayItem item = viewModel.createChildNote("Clickable");
+        resizeCanvas(400, 300);
+
+        StackPane noteNode = findNodeByUserData(item.getId());
+        assertNotNull(noteNode);
+
+        // Simulate mouse press which triggers selection
+        noteNode.fireEvent(new javafx.scene.input.MouseEvent(
+                javafx.scene.input.MouseEvent.MOUSE_PRESSED,
+                0, 0, 0, 0,
+                javafx.scene.input.MouseButton.PRIMARY, 1,
+                false, false, false, false,
+                true, false, false,
+                false, false, false, null));
+
+        assertEquals(item.getId(),
+                viewModel.selectedNoteIdProperty().get(),
+                "ViewModel should reflect clicked note");
+    }
+
+    @Test
+    @DisplayName("selected note has highlight border")
+    void selectedNote_hasHighlightBorder() {
+        NoteDisplayItem item = viewModel.createChildNote("Highlighted");
+        viewModel.selectNote(item.getId());
+        resizeCanvas(400, 300);
+
+        StackPane noteNode = findNodeByUserData(item.getId());
+        assertNotNull(noteNode);
+
+        // The first child of the StackPane is the Rectangle
+        Rectangle rect = (Rectangle) noteNode.getChildren().get(0);
+        assertEquals(3.0, rect.getStrokeWidth(),
+                "Selected note should have thicker border");
+    }
+
+    @Test
+    @DisplayName("drill-down replaces canvas with child's children")
+    void drillDown_replacesCanvasContent() {
+        NoteDisplayItem container = viewModel.createChildNote("Container");
+        noteService.createChildNote(container.getId(), "GrandchildA");
+        noteService.createChildNote(container.getId(), "GrandchildB");
+
+        viewModel.drillDown(container.getId());
+        resizeCanvas(400, 300);
+
+        long noteNodes = treemapCanvas.getChildren().stream()
+                .filter(n -> n instanceof StackPane)
+                .count();
+        assertEquals(2, noteNodes,
+                "After drill-down, canvas should show grandchildren");
+    }
+
+    @Test
+    @DisplayName("canNavigateBack is false at root, true after drill-down")
+    void canNavigateBack_togglesOnDrillDown() {
+        assertFalse(viewModel.canNavigateBackProperty().get());
+
+        NoteDisplayItem child = viewModel.createChildNote("Container");
+        viewModel.drillDown(child.getId());
+
+        assertTrue(viewModel.canNavigateBackProperty().get(),
+                "Should be able to navigate back after drill-down");
+    }
+
+    @Test
+    @DisplayName("navigateBack restores parent's notes on canvas")
+    void navigateBack_restoresParentNotes() {
+        NoteDisplayItem container = viewModel.createChildNote("Container");
+        viewModel.createChildNote("Sibling");
+        noteService.createChildNote(container.getId(), "Grandchild");
+
+        viewModel.drillDown(container.getId());
+        resizeCanvas(400, 300);
+
+        long afterDrillDown = treemapCanvas.getChildren().stream()
+                .filter(n -> n instanceof StackPane)
+                .count();
+        assertEquals(1, afterDrillDown);
+
+        viewModel.navigateBack();
+        resizeCanvas(400, 300);
+
+        long afterBack = treemapCanvas.getChildren().stream()
+                .filter(n -> n instanceof StackPane)
+                .count();
+        assertEquals(2, afterBack,
+                "After back, canvas should show original children");
+    }
+
+    @Test
+    @DisplayName("canvas is focusable for keyboard events")
+    void canvas_isFocusTraversable() {
+        assertTrue(treemapCanvas.isFocusTraversable(),
+                "Canvas should be focus-traversable for keyboard events");
+    }
+
+    @Test
+    @DisplayName("getViewModel returns the injected viewModel")
+    void getViewModel_returnsInjectedViewModel() {
+        assertEquals(viewModel, controller.getViewModel(),
+                "getViewModel should return the initialized ViewModel");
+    }
+
+    /**
+     * Simulates a canvas resize which triggers re-rendering.
+     */
+    private void resizeCanvas(double width, double height) {
+        treemapCanvas.resize(width, height);
+        // Force the width/height properties to fire listeners
+        treemapCanvas.setMinSize(width, height);
+        treemapCanvas.setPrefSize(width, height);
+        treemapCanvas.setMaxSize(width, height);
+    }
+
+    private StackPane findNodeByUserData(UUID id) {
+        for (Node child : treemapCanvas.getChildren()) {
+            if (child instanceof StackPane sp
+                    && id.equals(sp.getUserData())) {
+                return sp;
+            }
+        }
+        return null;
+    }
+
+    private void injectField(String fieldName, Object value) {
+        try {
+            var field = TreemapViewController.class
+                    .getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(controller, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SearchViewControllerTest` (10 tests): visibility binding, bidirectional query binding, results show/hide, Enter immediate search with first-result selection, Escape hides bar
- Adds `TextPaneViewControllerTest` (11 tests): placeholder/editor visibility toggling, title/text binding from ViewModel, save-on-focus-lost for both title and text, save-on-Enter for title, selection clearing
- Adds `OutlineViewControllerTest` (13 tests): tree building, item title matching, selection propagation, drill-down/back navigation, rename updates, nested child hierarchy
- Adds `TreemapViewControllerTest` (10 tests): canvas rendering after resize, userData tagging, click-to-select, selected highlight border, drill-down/back navigation, focus traversability

## Test plan
- [x] All 704 tests pass (`mvn test`)
- [x] Checkstyle clean (0 violations)
- [x] JaCoCo coverage thresholds met
- [ ] CI passes with `@Tag("ui")` tests included (or excluded via `-Pskip-ui-tests`)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)