### PR TITLE
Fix Map view stale nodes after indent in Outline

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -1,7 +1,9 @@
 package com.embervault.adapter.in.ui.view;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
@@ -146,13 +148,25 @@ public class MapViewController {
                 return;
             }
             if (change.wasReplaced()) {
+                // Collect added IDs so we can detect which removed items are stale
+                Set<UUID> addedIds = new HashSet<>();
                 for (NoteDisplayItem item : change.getAddedSubList()) {
+                    addedIds.add(item.getId());
                     StackPane existing = nodeMap.get(item.getId());
                     if (existing != null) {
                         updateNoteNode(existing, item);
                     } else {
                         renderAllNotes();
                         return;
+                    }
+                }
+                // Remove nodes for items that were removed but not re-added
+                for (NoteDisplayItem removed : change.getRemoved()) {
+                    if (!addedIds.contains(removed.getId())) {
+                        StackPane node = nodeMap.remove(removed.getId());
+                        if (node != null) {
+                            mapCanvas.getChildren().remove(node);
+                        }
                     }
                 }
             } else {

--- a/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
@@ -184,6 +184,37 @@ class MapViewControllerTest {
                 "Reloaded note should be present");
     }
 
+    @Test
+    @DisplayName("loadNotes after indent removes indented note node from canvas (issue #118)")
+    void loadNotes_afterIndent_shouldRemoveIndentedNoteNode() {
+        // Create 3 children: A, B, C
+        viewModel.createChildNote("A");
+        viewModel.createChildNote("B");
+        viewModel.createChildNote("C");
+        // Canvas: 3 note nodes + back button = 4
+        assertEquals(4, mapCanvas.getChildren().size(),
+                "Should have 3 note nodes + back button before indent");
+        assertNotNull(findNodeByTitle("A"));
+        assertNotNull(findNodeByTitle("B"));
+        assertNotNull(findNodeByTitle("C"));
+
+        // Indent B under A (via service, then reload)
+        noteService.indentNote(
+                noteService.getChildren(parentId).get(1).getId());
+        viewModel.loadNotes();
+
+        // After indent: canvas should have 2 note nodes + back button = 3
+        assertEquals(3, mapCanvas.getChildren().size(),
+                "Should have 2 note nodes + back button after indent; "
+                        + "indented note B must be removed from canvas");
+        assertNotNull(findNodeByTitle("A"),
+                "A should still be on canvas");
+        assertNotNull(findNodeByTitle("C"),
+                "C should still be on canvas");
+        assertEquals(null, findNodeByTitle("B"),
+                "B should NOT be on canvas after being indented under A");
+    }
+
     /** Finds a StackPane on the canvas whose title label matches the given text. */
     private StackPane findNodeByTitle(String title) {
         for (Node child : mapCanvas.getChildren()) {

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ViewSyncTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ViewSyncTest.java
@@ -116,6 +116,39 @@ class ViewSyncTest {
     }
 
     @Test
+    @DisplayName("Indent middle child in Outline removes it from Map's children (issue #118)")
+    void indentMiddleChild_shouldRemoveFromMapChildren() {
+        // Reproduce exact scenario from issue #118:
+        // root -> A, B, C; indent B under A
+        Note childA = noteService.createChildNote(root.getId(), "A");
+        noteService.createChildNote(root.getId(), "B");
+        Note childC = noteService.createChildNote(root.getId(), "C");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        // Verify initial state: Map shows 3 children
+        assertEquals(3, mapViewModel.getNoteItems().size());
+
+        // Indent B (goes under A, the note above it)
+        outlineViewModel.indentNote(
+                noteService.getChildren(root.getId()).get(1).getId());
+
+        // After indent: Map should show only A and C (2 items), NOT B
+        assertEquals(2, mapViewModel.getNoteItems().size(),
+                "Map should show only 2 top-level notes after indent of B under A");
+        assertEquals("A", mapViewModel.getNoteItems().get(0).getTitle());
+        assertEquals("C", mapViewModel.getNoteItems().get(1).getTitle());
+
+        // A should now have children flag set
+        assertTrue(mapViewModel.getNoteItems().get(0).isHasChildren(),
+                "A should report hasChildren=true after B was indented under it");
+
+        // Verify getChildren at service level too
+        assertEquals(1, noteService.getChildren(childA.getId()).size());
+        assertEquals("B", noteService.getChildren(childA.getId()).get(0).getTitle());
+    }
+
+    @Test
     @DisplayName("Outdenting a note in Outline refreshes Map view")
     void outdentInOutline_shouldRefreshMap() {
         Note child1 = noteService.createChildNote(root.getId(), "Child1");

--- a/src/test/java/com/embervault/application/NoteServiceImplTest.java
+++ b/src/test/java/com/embervault/application/NoteServiceImplTest.java
@@ -420,6 +420,37 @@ class NoteServiceImplTest {
     }
 
     @Test
+    @DisplayName("indentNote() removes indented note from original parent's children (issue #118)")
+    void indentNote_shouldRemoveFromOriginalParentChildren() {
+        // Reproduce: root -> A, B, C; indent B under A
+        // Then getChildren(root) should return only A and C, not B
+        Note root = service.createNote("Root", "");
+        Note childA = service.createChildNote(root.getId(), "A");
+        Note childB = service.createChildNote(root.getId(), "B");
+        Note childC = service.createChildNote(root.getId(), "C");
+
+        // Before indent: root has 3 children
+        List<Note> before = service.getChildren(root.getId());
+        assertEquals(3, before.size());
+
+        // Indent B (should go under A, the note above it)
+        service.indentNote(childB.getId());
+
+        // After indent: root should have only A and C
+        List<Note> rootChildren = service.getChildren(root.getId());
+        assertEquals(2, rootChildren.size(),
+                "Root should have 2 children after indenting B under A");
+        assertEquals("A", rootChildren.get(0).getTitle());
+        assertEquals("C", rootChildren.get(1).getTitle());
+
+        // A should now have B as its child
+        List<Note> childrenOfA = service.getChildren(childA.getId());
+        assertEquals(1, childrenOfA.size(),
+                "A should have 1 child (B) after indent");
+        assertEquals("B", childrenOfA.get(0).getTitle());
+    }
+
+    @Test
     @DisplayName("indentNote() throws when note does not exist")
     void indentNote_shouldThrowForMissingNote() {
         assertThrows(NoSuchElementException.class,


### PR DESCRIPTION
## Summary
- **Root cause**: `MapViewController.onNoteItemsChanged()` had a bug in the `wasReplaced()` branch — it updated existing nodes and added new ones, but never removed nodes for items that disappeared from the list. When `loadNotes()` called `setAll()` with fewer items (after indent removed a child from the current level), the stale node remained on the canvas.
- **Fix**: Track added IDs in the replacement handler and remove canvas nodes for any removed items not present in the new list.
- **Tests**: Added 3 regression tests at different layers (service, cross-ViewModel sync, and JavaFX controller) confirming the fix.

## Test plan
- [x] `NoteServiceImplTest.indentNote_shouldRemoveFromOriginalParentChildren` — verifies service layer correctly updates `$Container` for 3-child indent scenario
- [x] `ViewSyncTest.indentMiddleChild_shouldRemoveFromMapChildren` — verifies MapViewModel `noteItems` are correct after OutlineViewModel indent with shared `refreshAll` wiring
- [x] `MapViewControllerTest.loadNotes_afterIndent_shouldRemoveIndentedNoteNode` — verifies the actual JavaFX canvas node is removed (this was the failing test before the fix)
- [x] Full suite: 744 tests pass, checkstyle clean, coverage met

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)