### PR TITLE
Audit: ensure single source of truth for notes across all views

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -189,7 +189,10 @@ public class App extends Application {
                 project.getRootNote().getId(),
                 treemapViewModel::loadNotes);
 
-        // Synchronize: any mutation triggers all views to reload.
+        // SYNC CONTRACT — every mutation calls notifyDataChanged(), which
+        // invokes this refreshAll lambda to reload all views from the
+        // single authoritative NoteRepository. No view caches Note objects
+        // across refreshes. New views: add refresh here + wire below.
         Runnable refreshAll = () -> {
             mapPane.refreshCurrentView();
             outlinePane.refreshCurrentView();
@@ -203,6 +206,7 @@ public class App extends Application {
             if (selId != null) {
                 selectedNoteVm.setSelectedNoteId(selId);
             }
+            searchViewModel.refreshResults();
         };
         mapViewModel.setOnDataChanged(refreshAll);
         outlineViewModel.setOnDataChanged(refreshAll);
@@ -210,6 +214,7 @@ public class App extends Application {
         editorViewModel.setOnDataChanged(refreshAll);
         hyperbolicViewModel.setOnDataChanged(refreshAll);
         selectedNoteVm.setOnDataChanged(refreshAll);
+        searchViewModel.setOnDataChanged(refreshAll);
 
         // Wire shared deps into pane contexts for view switching
         ViewPaneDeps paneDeps = new ViewPaneDeps(

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModel.java
@@ -29,6 +29,7 @@ public final class SearchViewModel {
     private final ObjectProperty<UUID> selectedNoteId =
             new SimpleObjectProperty<>();
     private final NoteService noteService;
+    private final DataChangeSupport dataChangeSupport = new DataChangeSupport();
 
     /**
      * Constructs a SearchViewModel backed by the given NoteService.
@@ -38,6 +39,27 @@ public final class SearchViewModel {
     public SearchViewModel(NoteService noteService) {
         this.noteService = Objects.requireNonNull(noteService,
                 "noteService must not be null");
+    }
+
+    /**
+     * Sets a callback to be invoked after any mutation operation.
+     *
+     * @param callback the callback to invoke, or null to clear
+     */
+    public void setOnDataChanged(Runnable callback) {
+        dataChangeSupport.setOnDataChanged(callback);
+    }
+
+    /**
+     * Re-runs the current search query so that results reflect the latest
+     * note state. Called by the global refreshAll cycle to keep search
+     * results in sync with other views.
+     */
+    public void refreshResults() {
+        String currentQuery = query.get();
+        if (visible.get() && currentQuery != null && !currentQuery.isBlank()) {
+            search(currentQuery);
+        }
     }
 
     /** Returns the query property bound to the search text field. */

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/SearchViewModelTest.java
@@ -170,4 +170,53 @@ class SearchViewModelTest {
                 NullPointerException.class,
                 () -> new SearchViewModel(null));
     }
+
+    @Test
+    @DisplayName("refreshResults() re-runs the current search when visible")
+    void refreshResults_shouldRerunSearchWhenVisible() {
+        noteService.createNote("Alpha", "");
+        viewModel.toggleVisible();
+        viewModel.queryProperty().set("alpha");
+        viewModel.search("alpha");
+        assertEquals(1, viewModel.getResults().size());
+
+        // Add another matching note and refresh
+        noteService.createNote("Alpha Two", "");
+        viewModel.refreshResults();
+
+        assertEquals(2, viewModel.getResults().size());
+    }
+
+    @Test
+    @DisplayName("refreshResults() does nothing when search is hidden")
+    void refreshResults_shouldDoNothingWhenHidden() {
+        noteService.createNote("Alpha", "");
+        viewModel.queryProperty().set("alpha");
+        viewModel.search("alpha");
+        assertEquals(1, viewModel.getResults().size());
+
+        // Hidden by default — refresh should not update results
+        noteService.createNote("Alpha Two", "");
+        viewModel.refreshResults();
+
+        assertEquals(1, viewModel.getResults().size());
+    }
+
+    @Test
+    @DisplayName("refreshResults() does nothing when query is blank")
+    void refreshResults_shouldDoNothingWhenQueryBlank() {
+        noteService.createNote("Alpha", "");
+        viewModel.toggleVisible();
+        viewModel.refreshResults();
+
+        assertTrue(viewModel.getResults().isEmpty());
+    }
+
+    @Test
+    @DisplayName("setOnDataChanged() callback is invoked (not used by SearchViewModel mutations, but is wirable)")
+    void setOnDataChanged_shouldAcceptCallback() {
+        // SearchViewModel has no local mutations that call notifyDataChanged,
+        // but the method should exist and not throw.
+        viewModel.setOnDataChanged(() -> { });
+    }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ViewSyncTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ViewSyncTest.java
@@ -14,15 +14,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests that MapViewModel, OutlineViewModel, and TreemapViewModel stay
- * in sync when they share the same NoteService and are wired with an
- * onDataChanged callback.
+ * Tests that MapViewModel, OutlineViewModel, TreemapViewModel,
+ * SearchViewModel, and SelectedNoteViewModel stay in sync when they
+ * share the same NoteService and are wired with an onDataChanged callback.
  */
 class ViewSyncTest {
 
     private MapViewModel mapViewModel;
     private OutlineViewModel outlineViewModel;
     private TreemapViewModel treemapViewModel;
+    private SearchViewModel searchViewModel;
+    private SelectedNoteViewModel selectedNoteViewModel;
     private NoteService noteService;
     private InMemoryNoteRepository repository;
     private Note root;
@@ -36,6 +38,8 @@ class ViewSyncTest {
         mapViewModel = new MapViewModel(noteTitle, noteService);
         outlineViewModel = new OutlineViewModel(noteTitle, noteService);
         treemapViewModel = new TreemapViewModel(noteTitle, noteService);
+        searchViewModel = new SearchViewModel(noteService);
+        selectedNoteViewModel = new SelectedNoteViewModel(noteService);
 
         root = noteService.createNote("Root", "");
         mapViewModel.setBaseNoteId(root.getId());
@@ -47,10 +51,17 @@ class ViewSyncTest {
             mapViewModel.loadNotes();
             outlineViewModel.loadNotes();
             treemapViewModel.loadNotes();
+            searchViewModel.refreshResults();
+            var selId = selectedNoteViewModel.selectedNoteIdProperty().get();
+            if (selId != null) {
+                selectedNoteViewModel.setSelectedNoteId(selId);
+            }
         };
         mapViewModel.setOnDataChanged(refreshAll);
         outlineViewModel.setOnDataChanged(refreshAll);
         treemapViewModel.setOnDataChanged(refreshAll);
+        searchViewModel.setOnDataChanged(refreshAll);
+        selectedNoteViewModel.setOnDataChanged(refreshAll);
 
         mapViewModel.loadNotes();
         outlineViewModel.loadNotes();
@@ -231,5 +242,92 @@ class ViewSyncTest {
         assertEquals(1, treemapViewModel.getNoteItems().size());
         assertEquals("Grandchild",
                 treemapViewModel.getNoteItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Renaming a note in Map refreshes visible search results")
+    void renameInMap_shouldRefreshSearchResults() {
+        Note child = noteService.createChildNote(root.getId(), "Original");
+        mapViewModel.loadNotes();
+
+        // Simulate open search with matching query
+        searchViewModel.toggleVisible();
+        searchViewModel.queryProperty().set("original");
+        searchViewModel.search("original");
+        assertEquals(1, searchViewModel.getResults().size());
+
+        // Rename the note via map
+        mapViewModel.renameNote(child.getId(), "Renamed");
+
+        // Search results should have been refreshed — "original" no longer matches
+        assertEquals(0, searchViewModel.getResults().size());
+    }
+
+    @Test
+    @DisplayName("Creating a note refreshes search results when search is visible")
+    void createInOutline_shouldRefreshSearchResults() {
+        // Open search for "child"
+        searchViewModel.toggleVisible();
+        searchViewModel.queryProperty().set("child");
+        searchViewModel.search("child");
+        assertEquals(0, searchViewModel.getResults().size());
+
+        // Create a matching note
+        outlineViewModel.createChildNote(root.getId(), "Child Note");
+
+        // Search should now find it
+        assertEquals(1, searchViewModel.getResults().size());
+        assertEquals("Child Note", searchViewModel.getResults().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Renaming a note in Outline refreshes SelectedNoteViewModel title")
+    void renameInOutline_shouldRefreshSelectedNote() {
+        Note child = noteService.createChildNote(root.getId(), "Original");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        // Select the note in the text pane
+        selectedNoteViewModel.setSelectedNoteId(child.getId());
+        assertEquals("Original", selectedNoteViewModel.titleProperty().get());
+
+        // Rename via outline
+        outlineViewModel.renameNote(child.getId(), "Renamed");
+
+        // Text pane should reflect the new title
+        assertEquals("Renamed", selectedNoteViewModel.titleProperty().get());
+    }
+
+    @Test
+    @DisplayName("Saving title in SelectedNoteViewModel refreshes Map and Outline")
+    void saveTitleInSelectedNote_shouldRefreshMapAndOutline() {
+        Note child = noteService.createChildNote(root.getId(), "Original");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+        selectedNoteViewModel.setSelectedNoteId(child.getId());
+
+        selectedNoteViewModel.saveTitle("Updated Title");
+
+        assertEquals("Updated Title", mapViewModel.getNoteItems().get(0).getTitle());
+        assertEquals("Updated Title", outlineViewModel.getRootItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Deleting a note in Outline refreshes all views including search")
+    void deleteInOutline_shouldRefreshAllViews() {
+        Note child = noteService.createChildNote(root.getId(), "ToDelete");
+        mapViewModel.loadNotes();
+        outlineViewModel.loadNotes();
+
+        searchViewModel.toggleVisible();
+        searchViewModel.queryProperty().set("delete");
+        searchViewModel.search("delete");
+        assertEquals(1, searchViewModel.getResults().size());
+
+        outlineViewModel.deleteNote(child.getId());
+
+        assertEquals(0, mapViewModel.getNoteItems().size());
+        assertEquals(0, treemapViewModel.getNoteItems().size());
+        assertEquals(0, searchViewModel.getResults().size());
     }
 }


### PR DESCRIPTION
## Summary
- Audited all ViewModels, view controllers, and the repository for single-source-of-truth compliance per issue #120 checklist
- **Found and fixed**: `SearchViewModel` was not wired into the global `refreshAll` cycle, causing stale search results when notes were mutated in other views
- Added `DataChangeSupport`, `setOnDataChanged()`, and `refreshResults()` to `SearchViewModel`
- Wired `searchViewModel` into `App.refreshAll` and `setOnDataChanged`
- Added sync contract documentation comment in `App.java` at the `refreshAll` definition
- Added 9 new tests covering search refresh, selected-note refresh, and cross-view sync paths

## Audit Findings

All items from the issue checklist were verified:

| Area | Status |
|------|--------|
| Repository stores by reference | Pass |
| Every mutation calls `notifyDataChanged()` | Pass |
| `updateNotePosition` intentionally skips refresh | Pass (cosmetic only) |
| `refreshAll` covers all views | **Fixed** (was missing `SearchViewModel`) |
| SearchViewModel wired to `setOnDataChanged` | **Fixed** (was missing) |
| Views query fresh data on each `loadNotes()` | Pass |
| `NoteDisplayItem` objects recreated each refresh | Pass |
| View controllers handle list changes | Pass |
| No stale caches or copies | Pass |

## Test plan
- [x] `SearchViewModelTest`: 4 new tests for `refreshResults()` and `setOnDataChanged()`
- [x] `ViewSyncTest`: 5 new tests for search refresh, selected-note refresh, cross-view title save, and delete propagation
- [x] All 750 tests pass
- [x] Checkstyle clean
- [x] JaCoCo coverage checks pass

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)