### PR TITLE
Add ArchUnit enforcement tests for ADR audit

### DIFF
--- a/src/test/java/com/embervault/architecture/ArchitectureTest.java
+++ b/src/test/java/com/embervault/architecture/ArchitectureTest.java
@@ -180,4 +180,43 @@ class ArchitectureTest {
                 .allowEmptyShould(true)
                 .check(classes);
     }
+
+    @Test
+    @DisplayName("ADR-0010: Inbound port types must be interfaces")
+    void inboundPortTypesMustBeInterfaces() {
+        classes()
+                .that().resideInAPackage("com.embervault.application.port.in..")
+                .and().areTopLevelClasses()
+                .should().beInterfaces()
+                .because("ADR-0010 mandates that inbound ports (use case contracts) "
+                        + "are defined as interfaces")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0010: Outbound port types must be interfaces")
+    void outboundPortTypesMustBeInterfaces() {
+        classes()
+                .that().resideInAPackage("com.embervault.application.port.out..")
+                .and().areTopLevelClasses()
+                .should().beInterfaces()
+                .because("ADR-0010 mandates that outbound ports (repository contracts) "
+                        + "are defined as interfaces")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
+
+    @Test
+    @DisplayName("ADR-0009: Application ports must not depend on adapter packages")
+    void applicationPortsMustNotDependOnAdapters() {
+        noClasses()
+                .that().resideInAPackage("com.embervault.application.port..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("com.embervault.adapter..")
+                .because("ADR-0009 mandates that ports define contracts independent "
+                        + "of adapter implementations (dependency flows inward only)")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #128.

Audited all 18 ADRs against the existing ArchUnit test suite and added three new enforcement rules for gaps identified in the issue.

### New ArchUnit tests added

- **ADR-0010**: Inbound port types (`application.port.in`) must be interfaces
- **ADR-0010**: Outbound port types (`application.port.out`) must be interfaces
- **ADR-0009**: Application port interfaces must not depend on adapter packages

### Already enforced (verified present and correct)

| ADR | Rule | Status |
|-----|------|--------|
| ADR-0005 | SLF4J for logging, no java.util.logging | Enforced |
| ADR-0009 | Domain must not depend on adapters | Enforced |
| ADR-0009 | Domain must not depend on application | Enforced |
| ADR-0009 | Domain must not depend on JavaFX | Enforced |
| ADR-0009 | Domain must not depend on Spring | Enforced |
| ADR-0009 | Adapters not accessed by domain | Enforced |
| ADR-0013 | ViewModels must not reference javafx.scene | Enforced |
| ADR-0013 | Views must not access domain packages | Enforced |
| ADR-0013 | Views must not access infrastructure packages | Enforced |
| ADR-0016 | Domain exceptions must extend DomainException | Enforced |

### ADRs not enforceable via ArchUnit (process/design discipline)

- **ADR-0001**: Pure TDD workflow — process discipline, not code structure
- **ADR-0011**: SOLID principles — requires human code review
- **ADR-0012**: DRY principle — requires human code review
- **ADR-0017**: Result-oriented APIs — design choice, not structural constraint
- **ADR-0018**: Type-safe attribute map — `Attributes` constants usage verified by grep; no raw `"$"` strings found outside `Attributes.java` and `AttributeSchemaRegistry`

### Audit findings

- **Zero violations found** in the current codebase
- All port types in `port.in` and `port.out` are already interfaces
- Views have no imports from `com.embervault.domain`
- ViewModels have no imports from `javafx.scene`
- All domain exceptions (`EntityNotFoundException`, `ValidationException`) extend `DomainException`
- No adapter imports in application port packages

## Test plan

- [x] `./mvnw verify` passes (711 tests, 0 failures)
- [x] Checkstyle clean (0 violations)
- [x] JaCoCo coverage thresholds met
- [x] All 15 ArchUnit rules pass (12 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)