### PR TITLE
Add DocumentFactory for public document API and clean MVVM separation

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/StampEditorViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/StampEditorViewController.java
@@ -8,20 +8,16 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextField;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * FXML controller for the Stamp Editor dialog.
  *
  * <p>Provides a simple CRUD interface for managing stamps. The left panel
  * shows a list of stamps, the right panel allows editing name and action.
- * All domain access is mediated through the {@link StampEditorViewModel}.</p>
+ * All domain access is mediated through the {@link StampEditorViewModel}.
+ * Contains no business logic; validation is handled by the ViewModel.</p>
  */
 public class StampEditorViewController {
-
-    private static final Logger LOG = LoggerFactory.getLogger(
-            StampEditorViewController.class);
 
     @FXML private SplitPane editorRoot;
     @FXML private ListView<String> stampListView;
@@ -53,16 +49,11 @@ public class StampEditorViewController {
     void onAddStamp() {
         String name = nameField.getText();
         String action = actionField.getText();
-        if (name == null || name.isBlank()
-                || action == null || action.isBlank()) {
-            LOG.warn("Cannot create stamp: name and action "
-                    + "must not be blank");
-            return;
+        if (viewModel.createStamp(name, action)) {
+            nameField.clear();
+            actionField.clear();
+            selectedStampId = null;
         }
-        viewModel.createStamp(name, action);
-        nameField.clear();
-        actionField.clear();
-        selectedStampId = null;
     }
 
     @FXML
@@ -83,14 +74,9 @@ public class StampEditorViewController {
         }
         String name = nameField.getText();
         String action = actionField.getText();
-        if (name == null || name.isBlank()
-                || action == null || action.isBlank()) {
-            LOG.warn("Cannot save stamp: name and action "
-                    + "must not be blank");
-            return;
+        if (viewModel.updateStamp(selectedStampId, name, action)) {
+            selectedStampId = null;
         }
-        viewModel.updateStamp(selectedStampId, name, action);
-        selectedStampId = null;
     }
 
     private void onStampSelected(String name) {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/StampEditorViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/StampEditorViewModel.java
@@ -9,6 +9,8 @@ import com.embervault.application.port.in.StampService;
 import com.embervault.domain.Stamp;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ViewModel for the Stamp Editor dialog.
@@ -18,6 +20,9 @@ import javafx.collections.ObservableList;
  * through the {@link StampService}.</p>
  */
 public final class StampEditorViewModel {
+
+    private static final Logger LOG = LoggerFactory.getLogger(
+            StampEditorViewModel.class);
 
     private final StampService stampService;
     private final ObservableList<String> stampNames =
@@ -81,12 +86,23 @@ public final class StampEditorViewModel {
     /**
      * Creates a new stamp with the given name and action.
      *
+     * <p>Returns {@code false} without creating anything if name or action
+     * is null or blank.</p>
+     *
      * @param name   the stamp name
      * @param action the action expression
+     * @return true if the stamp was created, false if validation failed
      */
-    public void createStamp(String name, String action) {
+    public boolean createStamp(String name, String action) {
+        if (name == null || name.isBlank()
+                || action == null || action.isBlank()) {
+            LOG.warn("Cannot create stamp: name and action "
+                    + "must not be blank");
+            return false;
+        }
         stampService.createStamp(name, action);
         refresh();
+        return true;
     }
 
     /**
@@ -102,13 +118,24 @@ public final class StampEditorViewModel {
     /**
      * Updates a stamp by deleting the old one and creating a new one.
      *
+     * <p>Returns {@code false} without modifying anything if name or action
+     * is null or blank.</p>
+     *
      * @param oldId  the id of the stamp to replace
      * @param name   the new name
      * @param action the new action
+     * @return true if the stamp was updated, false if validation failed
      */
-    public void updateStamp(UUID oldId, String name, String action) {
+    public boolean updateStamp(UUID oldId, String name, String action) {
+        if (name == null || name.isBlank()
+                || action == null || action.isBlank()) {
+            LOG.warn("Cannot save stamp: name and action "
+                    + "must not be blank");
+            return false;
+        }
         stampService.deleteStamp(oldId);
         stampService.createStamp(name, action);
         refresh();
+        return true;
     }
 }

--- a/src/main/java/com/embervault/application/DocumentContext.java
+++ b/src/main/java/com/embervault/application/DocumentContext.java
@@ -1,0 +1,28 @@
+package com.embervault.application;
+
+import com.embervault.application.port.in.LinkService;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.application.port.in.StampService;
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.Project;
+
+/**
+ * Holds a fully wired document with all services and the project.
+ *
+ * <p>Returned by {@link DocumentFactory#createEmpty()} so that a developer
+ * can get a ready-to-use document without understanding the internal wiring
+ * of the application. All services share the same underlying repositories.</p>
+ *
+ * @param project        the project containing the root note
+ * @param noteService    the note service for CRUD operations on notes
+ * @param linkService    the link service for creating/querying links
+ * @param stampService   the stamp service for creating/applying stamps
+ * @param noteRepository the note repository (shared by noteService and stampService)
+ */
+public record DocumentContext(
+        Project project,
+        NoteService noteService,
+        LinkService linkService,
+        StampService stampService,
+        NoteRepository noteRepository) {
+}

--- a/src/main/java/com/embervault/application/DocumentFactory.java
+++ b/src/main/java/com/embervault/application/DocumentFactory.java
@@ -1,0 +1,73 @@
+package com.embervault.application;
+
+import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.adapter.out.persistence.InMemoryStampRepository;
+import com.embervault.application.port.in.LinkService;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.application.port.in.StampService;
+import com.embervault.application.port.out.LinkRepository;
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.application.port.out.StampRepository;
+import com.embervault.domain.Project;
+
+/**
+ * Convenience factory for creating a fully wired document.
+ *
+ * <p>Encapsulates the wiring of repositories, services, and the project so
+ * that a developer can create a ready-to-use document in a single call:</p>
+ *
+ * <pre>{@code
+ * DocumentContext ctx = DocumentFactory.createEmpty();
+ * Project project = ctx.project();
+ * NoteService noteService = ctx.noteService();
+ *
+ * // Create child notes, apply stamps, create links, etc.
+ * noteService.createChildNote(project.getRootNote().getId(), "My Note");
+ * }</pre>
+ *
+ * <p>All services share the same underlying repositories, so changes made
+ * through one service are immediately visible to all others.</p>
+ */
+public final class DocumentFactory {
+
+    private DocumentFactory() {
+        // utility class
+    }
+
+    /**
+     * Creates a new empty document with all services wired and the root note
+     * persisted.
+     *
+     * <p>The returned {@link DocumentContext} contains:</p>
+     * <ul>
+     *   <li>A {@link Project} with a root note</li>
+     *   <li>A {@link NoteService} backed by an in-memory repository</li>
+     *   <li>A {@link LinkService} backed by an in-memory repository</li>
+     *   <li>A {@link StampService} backed by in-memory repositories</li>
+     *   <li>The shared {@link NoteRepository} for direct access if needed</li>
+     * </ul>
+     *
+     * @return a fully wired document context
+     */
+    public static DocumentContext createEmpty() {
+        // Create repositories
+        NoteRepository noteRepository = new InMemoryNoteRepository();
+        LinkRepository linkRepository = new InMemoryLinkRepository();
+        StampRepository stampRepository = new InMemoryStampRepository();
+
+        // Create services
+        NoteService noteService = new NoteServiceImpl(noteRepository);
+        LinkService linkService = new LinkServiceImpl(linkRepository);
+        StampService stampService = new StampServiceImpl(
+                stampRepository, noteRepository);
+
+        // Create project and persist root note
+        Project project = new ProjectServiceImpl().createEmptyProject();
+        noteRepository.save(project.getRootNote());
+
+        return new DocumentContext(
+                project, noteService, linkService,
+                stampService, noteRepository);
+    }
+}

--- a/src/test/java/com/embervault/application/DocumentFactoryTest.java
+++ b/src/test/java/com/embervault/application/DocumentFactoryTest.java
@@ -1,0 +1,107 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.embervault.domain.Note;
+import com.embervault.domain.Project;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DocumentFactoryTest {
+
+    @Test
+    @DisplayName("createEmpty() returns a DocumentContext with all services wired")
+    void createEmpty_shouldReturnFullyWiredContext() {
+        DocumentContext ctx = DocumentFactory.createEmpty();
+
+        assertNotNull(ctx.project());
+        assertNotNull(ctx.noteService());
+        assertNotNull(ctx.linkService());
+        assertNotNull(ctx.stampService());
+        assertNotNull(ctx.noteRepository());
+    }
+
+    @Test
+    @DisplayName("createEmpty() persists the root note in the repository")
+    void createEmpty_shouldPersistRootNote() {
+        DocumentContext ctx = DocumentFactory.createEmpty();
+
+        Project project = ctx.project();
+        Optional<Note> rootNote = ctx.noteRepository()
+                .findById(project.getRootNote().getId());
+
+        assertTrue(rootNote.isPresent(),
+                "Root note should be saved in the repository");
+        assertEquals(project.getRootNote().getId(), rootNote.get().getId());
+    }
+
+    @Test
+    @DisplayName("createEmpty() services share the same repository")
+    void createEmpty_servicesShouldShareRepository() {
+        DocumentContext ctx = DocumentFactory.createEmpty();
+
+        // Create a child via the service
+        Note child = ctx.noteService().createChildNote(
+                ctx.project().getRootNote().getId(), "Test Child");
+
+        // Should be findable via the repository
+        Optional<Note> found = ctx.noteRepository().findById(child.getId());
+        assertTrue(found.isPresent());
+        assertEquals("Test Child", found.get().getTitle());
+    }
+
+    @Test
+    @DisplayName("createEmpty() note service can create and retrieve children")
+    void createEmpty_noteServiceShouldWork() {
+        DocumentContext ctx = DocumentFactory.createEmpty();
+
+        Note child = ctx.noteService().createChildNote(
+                ctx.project().getRootNote().getId(), "Child Note");
+
+        List<Note> children = ctx.noteService().getChildren(
+                ctx.project().getRootNote().getId());
+        assertFalse(children.isEmpty());
+        assertEquals("Child Note", children.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("createEmpty() link service can create and retrieve links")
+    void createEmpty_linkServiceShouldWork() {
+        DocumentContext ctx = DocumentFactory.createEmpty();
+
+        Note child1 = ctx.noteService().createChildNote(
+                ctx.project().getRootNote().getId(), "A");
+        Note child2 = ctx.noteService().createChildNote(
+                ctx.project().getRootNote().getId(), "B");
+
+        ctx.linkService().createLink(child1.getId(), child2.getId());
+
+        assertFalse(ctx.linkService()
+                .getLinksFrom(child1.getId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("createEmpty() stamp service can create and apply stamps")
+    void createEmpty_stampServiceShouldWork() {
+        DocumentContext ctx = DocumentFactory.createEmpty();
+
+        ctx.stampService().createStamp("Color:red", "$Color=red");
+
+        assertFalse(ctx.stampService().getAllStamps().isEmpty());
+    }
+
+    @Test
+    @DisplayName("createEmpty() project has a non-blank name")
+    void createEmpty_projectShouldHaveName() {
+        DocumentContext ctx = DocumentFactory.createEmpty();
+
+        assertNotNull(ctx.project().getName());
+        assertFalse(ctx.project().getName().isBlank());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DocumentFactory.createEmpty()` that returns a fully wired `DocumentContext` (project, noteService, linkService, stampService, noteRepository) so developers can create and use documents without understanding `App.java` internals
- Move blank-check validation from `StampEditorViewController` into `StampEditorViewModel` so controllers contain no business logic
- Audit all controllers: confirmed they are thin FXML glue delegating to ViewModels
- Audit all ViewModels: confirmed none import `javafx.scene` (enforced by existing ArchUnit rule)

## Audit Findings
- **Controllers**: All 10 controllers are thin. Only `StampEditorViewController` had validation logic (blank name/action guards), which was moved to `StampEditorViewModel`.
- **ViewModels**: None reference `javafx.scene` classes. All use `javafx.beans`/`javafx.collections` only.
- **Service interfaces**: `NoteService`, `LinkService`, `StampService`, `ProjectService` are complete and self-documenting with full Javadoc.
- **App.java**: Contains only wiring/composition code (repository creation, service creation, view loading, event wiring). No business logic.

## Test plan
- [x] 7 new tests in `DocumentFactoryTest` covering all wired services and repository sharing
- [x] All 715 existing tests pass (`mvn verify -Pskip-ui-tests`)
- [x] ArchUnit rules pass (including ViewModel-no-scene rule)
- [x] Checkstyle passes
- [x] JaCoCo coverage thresholds met

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)