### PR TITLE
Make skip-ui-tests the default, add ui-tests profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt-get install -y xvfb
 
       - name: Run Maven verify
-        run: xvfb-run ./mvnw verify --batch-mode --no-transfer-progress
+        run: xvfb-run ./mvnw verify -Pui-tests --batch-mode --no-transfer-progress
 
       - name: Upload JaCoCo coverage report
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,11 @@ EmberVault is a Tinderbox-inspired note-taking application built with JavaFX. Ja
 ## Build
 
 ```bash
-JAVA_HOME=$(/usr/libexec/java_home -v 25) ./mvnw verify
+# Logic tests only (no display needed):
+JAVA_HOME=/Users/sartin/Library/Java/JavaVirtualMachines/openjdk-25.0.2/Contents/Home ./mvnw verify
+
+# Full suite including UI tests (requires display or xvfb):
+JAVA_HOME=/Users/sartin/Library/Java/JavaVirtualMachines/openjdk-25.0.2/Contents/Home ./mvnw verify -Pui-tests
 ```
 
 ## Pure TDD Workflow (mandatory for all code changes)
@@ -101,8 +105,9 @@ All enforced by `mvn verify`:
 ## Test Conventions
 
 - `@Tag("ui")` on all TestFX UI tests
-- CI runs UI tests under `xvfb` (X virtual framebuffer)
-- `skip-ui-tests` Maven profile to exclude `@Tag("ui")` tests locally: `./mvnw verify -Pskip-ui-tests`
+- `mvn verify` excludes `@Tag("ui")` tests by default (no display needed)
+- `mvn verify -Pui-tests` includes UI tests (requires display or xvfb)
+- CI runs full suite with `-Pui-tests` under `xvfb` (X virtual framebuffer)
 
 ## PR Workflow
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,14 +62,14 @@
             </properties>
         </profile>
         <profile>
-            <id>skip-ui-tests</id>
+            <id>ui-tests</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <excludedGroups>ui</excludedGroups>
+                            <excludedGroups combine.self="override"/>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -169,6 +169,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
+                        <excludedGroups>ui</excludedGroups>
                         <argLine>
                             @{argLine}
                             --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED


### PR DESCRIPTION
## Summary
- Default `mvn verify` now excludes `@Tag("ui")` tests via `<excludedGroups>ui</excludedGroups>` in surefire config, so logic tests run without a display
- New `ui-tests` Maven profile overrides the exclusion to include UI tests: `mvn verify -Pui-tests`
- CI workflow updated to use `-Pui-tests` with xvfb so all tests (logic + UI) still run in CI
- CLAUDE.md build section updated with both commands
- Removed old `skip-ui-tests` profile (inverted default makes it unnecessary)

**Test counts:** 816 logic tests pass headless; 944 total (128 UI tests across 11 test classes) pass with display.

## Test plan
- [ ] `mvn verify` passes without a display (only logic tests)
- [ ] `mvn verify -Pui-tests` passes with display/xvfb (all tests including UI)
- [ ] CI build passes with the updated workflow

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)