### PR TITLE
Fix badge not appearing on notes in Map view

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -330,6 +330,7 @@ public class MapViewController {
         StackPane notePane;
         if (!tier.isShowTitle()) {
             notePane = new StackPane(rect);
+            notePane.setAlignment(Pos.TOP_LEFT);
         } else {
             double fontSize = tier.getTitleFontSize();
             Label titleLabel = new Label(item.getTitle());
@@ -370,20 +371,18 @@ public class MapViewController {
             Rectangle clip = new Rectangle(item.getWidth(), item.getHeight());
             textBox.setClip(clip);
             notePane = new StackPane(rect, textBox);
-            if (tier.isShowBadge()) {
-                String badge = item.getBadge();
-                if (badge != null && !badge.isEmpty()) {
-                    Label badgeLabel = new Label(badge);
-                    badgeLabel.setFont(Font.font("System", fontSize));
-                    badgeLabel.setMouseTransparent(true);
-                    badgeLabel.setPadding(new Insets(2, 4, 0, 0));
-                    StackPane.setAlignment(badgeLabel, Pos.TOP_RIGHT);
-                    notePane.getChildren().add(badgeLabel);
-                }
+            notePane.setAlignment(Pos.TOP_LEFT);
+            String badge = item.getBadge();
+            if (tier.isShowBadge() && badge != null && !badge.isEmpty()) {
+                Label badgeLabel = new Label(badge);
+                badgeLabel.setFont(Font.font("System", fontSize));
+                badgeLabel.setMouseTransparent(true);
+                StackPane.setAlignment(badgeLabel, Pos.TOP_RIGHT);
+                StackPane.setMargin(badgeLabel, new Insets(2, 4, 0, 0));
+                notePane.getChildren().add(badgeLabel);
             }
         }
         notePane.setUserData(item.getId());
-        notePane.setAlignment(Pos.TOP_LEFT);
         notePane.setLayoutX(item.getXpos());
         notePane.setLayoutY(item.getYpos());
         notePane.setCursor(Cursor.HAND);

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ZoomTier.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ZoomTier.java
@@ -13,7 +13,7 @@ public enum ZoomTier {
     OVERVIEW(false, false, false, 0),
 
     /** 0.4 &le; zoom &lt; 0.8: title text only, compact font. */
-    TITLES_ONLY(true, false, false, 10),
+    TITLES_ONLY(true, false, true, 10),
 
     /** 0.8 &le; zoom &lt; 1.5: title (bold) + truncated content. */
     NORMAL(true, true, true, 14),

--- a/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
@@ -432,6 +432,7 @@ class MapViewControllerTest {
         Note child = noteService.createChildNote(parentId, "Overview Badge");
         child.setAttribute(Attributes.BADGE,
                 new AttributeValue.StringValue("star"));
+        viewModel.loadNotes();
 
         viewModel.setZoomLevel(0.2); // OVERVIEW tier
         WaitForAsyncUtils.sleep(200, TimeUnit.MILLISECONDS);
@@ -451,6 +452,7 @@ class MapViewControllerTest {
         Note child = noteService.createChildNote(parentId, "Titles Badge");
         child.setAttribute(Attributes.BADGE,
                 new AttributeValue.StringValue("star"));
+        viewModel.loadNotes();
 
         viewModel.setZoomLevel(0.5); // TITLES_ONLY tier
         WaitForAsyncUtils.sleep(200, TimeUnit.MILLISECONDS);

--- a/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
@@ -14,7 +14,11 @@ import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
@@ -373,6 +377,104 @@ class MapViewControllerTest {
         // Check that the mapCanvas parent has a toolbar
         assertNotNull(controller.getViewModel(),
                 "ViewModel should be set");
+    }
+
+    @Test
+    @DisplayName("badge label appears in StackPane when $Badge is set (issue #154)")
+    void badge_shouldAppearWhenBadgeAttributeSet() {
+        // Set zoom to NORMAL tier so badges are visible
+        viewModel.setZoomLevel(1.0);
+
+        // Create a child note and set $Badge=star on it
+        Note child = noteService.createChildNote(parentId, "Badged Note");
+        child.setAttribute(Attributes.BADGE,
+                new AttributeValue.StringValue("star"));
+
+        // Reload notes so the display item picks up the badge
+        viewModel.loadNotes();
+
+        StackPane noteNode = findNodeByUserData(child.getId());
+        assertNotNull(noteNode, "Note node should exist on canvas");
+
+        // Find the badge label — it should be the last child of the StackPane
+        Label badgeLabel = findBadgeLabel(noteNode);
+        assertNotNull(badgeLabel,
+                "Badge label should be present in the StackPane");
+        assertEquals("\u2B50", badgeLabel.getText(),
+                "Badge label should show the star symbol");
+        assertTrue(badgeLabel.isMouseTransparent(),
+                "Badge label should be mouse-transparent");
+
+        // Verify badge is aligned TOP_RIGHT
+        assertEquals(Pos.TOP_RIGHT,
+                StackPane.getAlignment(badgeLabel),
+                "Badge label should be aligned to TOP_RIGHT");
+    }
+
+    @Test
+    @DisplayName("badge label not present when $Badge is empty")
+    void badge_shouldNotAppearWhenBadgeEmpty() {
+        viewModel.setZoomLevel(1.0);
+        viewModel.createChildNote("No Badge");
+
+        StackPane noteNode = findNodeByUserData(
+                viewModel.getNoteItems().get(0).getId());
+        assertNotNull(noteNode);
+
+        Label badgeLabel = findBadgeLabel(noteNode);
+        assertEquals(null, badgeLabel,
+                "Badge label should not be present when badge is empty");
+    }
+
+    @Test
+    @DisplayName("badge label not present at OVERVIEW tier even with badge set")
+    void badge_shouldNotAppearAtOverviewTier() throws Exception {
+        Note child = noteService.createChildNote(parentId, "Overview Badge");
+        child.setAttribute(Attributes.BADGE,
+                new AttributeValue.StringValue("star"));
+
+        viewModel.setZoomLevel(0.2); // OVERVIEW tier
+        WaitForAsyncUtils.sleep(200, TimeUnit.MILLISECONDS);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        StackPane noteNode = findNodeByUserData(child.getId());
+        assertNotNull(noteNode, "Note node should exist");
+
+        Label badgeLabel = findBadgeLabel(noteNode);
+        assertEquals(null, badgeLabel,
+                "Badge label should not be present at OVERVIEW tier");
+    }
+
+    @Test
+    @DisplayName("badge label appears at TITLES_ONLY tier (issue #154)")
+    void badge_shouldAppearAtTitlesOnlyTier() throws Exception {
+        Note child = noteService.createChildNote(parentId, "Titles Badge");
+        child.setAttribute(Attributes.BADGE,
+                new AttributeValue.StringValue("star"));
+
+        viewModel.setZoomLevel(0.5); // TITLES_ONLY tier
+        WaitForAsyncUtils.sleep(200, TimeUnit.MILLISECONDS);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        StackPane noteNode = findNodeByUserData(child.getId());
+        assertNotNull(noteNode, "Note node should exist");
+
+        Label badgeLabel = findBadgeLabel(noteNode);
+        assertNotNull(badgeLabel,
+                "Badge label should be present at TITLES_ONLY tier");
+        assertEquals("\u2B50", badgeLabel.getText());
+    }
+
+    /** Finds a Label child of a StackPane that is not inside a VBox (i.e., the badge). */
+    private Label findBadgeLabel(StackPane noteNode) {
+        for (Node child : noteNode.getChildren()) {
+            if (child instanceof Label label
+                    && !(child instanceof Rectangle)
+                    && !(child instanceof VBox)) {
+                return label;
+            }
+        }
+        return null;
     }
 
     /** Finds the VBox child within a StackPane note node. */

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ZoomTierTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ZoomTierTest.java
@@ -54,11 +54,11 @@ class ZoomTierTest {
     }
 
     @Test
-    @DisplayName("TITLES_ONLY tier shows title but not content")
+    @DisplayName("TITLES_ONLY tier shows title and badge but not content")
     void titlesOnlyTier_shouldShowTitleOnly() {
         assertTrue(ZoomTier.TITLES_ONLY.isShowTitle());
         assertFalse(ZoomTier.TITLES_ONLY.isShowContent());
-        assertFalse(ZoomTier.TITLES_ONLY.isShowBadge());
+        assertTrue(ZoomTier.TITLES_ONLY.isShowBadge());
         assertEquals(10, ZoomTier.TITLES_ONLY.getTitleFontSize());
     }
 


### PR DESCRIPTION
## Summary
- Fix badge Label rendering in `MapViewController.createNoteNode()` by setting StackPane alignment before adding the badge child, and using `StackPane.setMargin` instead of internal padding for proper TOP_RIGHT positioning
- Enable `showBadge` on `TITLES_ONLY` zoom tier so badges appear at all non-OVERVIEW tiers
- Add 4 new tests verifying badge presence/absence at different zoom tiers and with/without `$Badge` attribute

Closes #154

## Test plan
- [ ] Verify `mvn verify` passes (816+ tests, checkstyle, JaCoCo, ArchUnit)
- [ ] Set `$Badge=star` on a note and confirm star emoji appears at top-right in Map view
- [ ] Confirm badge visible at TITLES_ONLY, NORMAL, and DETAILED zoom tiers
- [ ] Confirm no badge at OVERVIEW tier
- [ ] Confirm no badge when `$Badge` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)