### PR TITLE
TDD: fix badge not rendered after stamp applied + reload

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -106,7 +106,6 @@ public class MapViewController {
             }
         });
 
-        // Scroll wheel zoom toward cursor
         mapCanvas.setOnScroll(event -> {
             double factor = event.getDeltaY() > 0
                     ? SCROLL_ZOOM_FACTOR : 1.0 / SCROLL_ZOOM_FACTOR;
@@ -117,7 +116,6 @@ public class MapViewController {
             event.consume();
         });
 
-        // Return key to create new note; Escape to navigate back
         mapCanvas.setOnKeyPressed(event -> {
             if (event.getCode() == KeyCode.ENTER) {
                 viewModel.createChildNote("Untitled");
@@ -127,7 +125,6 @@ public class MapViewController {
             }
         });
 
-        // Context menu
         ContextMenu contextMenu = createContextMenu();
         mapCanvas.setOnContextMenuRequested(event -> {
             contextMenu.getItems().get(0).setOnAction(e ->
@@ -191,7 +188,6 @@ public class MapViewController {
         zoomToolbar.setMouseTransparent(false);
         zoomToolbar.setId("zoomToolbar");
 
-        // Add toolbar directly to mapCanvas so it floats on top
         mapCanvas.getChildren().add(zoomToolbar);
     }
 
@@ -271,7 +267,6 @@ public class MapViewController {
         }
     }
 
-    /** Updates an existing node in-place. */
     private void updateNoteNode(StackPane notePane, NoteDisplayItem item) {
         notePane.setLayoutX(item.getXpos());
         notePane.setLayoutY(item.getYpos());
@@ -301,10 +296,13 @@ public class MapViewController {
                 contentLabel.setMaxWidth(item.getWidth() - 8);
             }
         }
+        String badge = item.getBadge();
+        ZoomTier tier = viewModel.getCurrentTier();
         if (notePane.getChildren().size() > 2
                 && notePane.getChildren().get(2) instanceof Label badgeLabel) {
-            String badge = item.getBadge();
             badgeLabel.setText(badge != null ? badge : "");
+        } else if (tier.isShowBadge() && badge != null && !badge.isEmpty()) {
+            notePane.getChildren().add(createBadgeLabel(badge, item));
         }
         if (item.getId().equals(viewModel.selectedNoteIdProperty().get())) {
             if (notePane.getChildren().get(0) instanceof Rectangle rect) {
@@ -316,7 +314,6 @@ public class MapViewController {
 
     private StackPane createNoteNode(NoteDisplayItem item) {
         ZoomTier tier = viewModel.getCurrentTier();
-
         Rectangle rect = new Rectangle(item.getWidth(), item.getHeight());
         rect.setFill(Color.web(item.getColorHex()));
         rect.setStroke(currentColors != null
@@ -372,15 +369,7 @@ public class MapViewController {
             notePane.setAlignment(Pos.TOP_LEFT);
             String badge = item.getBadge();
             if (tier.isShowBadge() && badge != null && !badge.isEmpty()) {
-                Label badgeLabel = new Label(badge);
-                badgeLabel.setFont(Font.font(BADGE_FONT_SIZE));
-                badgeLabel.setTextFill(Color.web(
-                        ViewColorConfig.contrastTextColor(item.getColorHex())));
-                badgeLabel.setEffect(new DropShadow(2, Color.gray(0.3, 0.6)));
-                badgeLabel.setMouseTransparent(true);
-                StackPane.setAlignment(badgeLabel, Pos.TOP_RIGHT);
-                StackPane.setMargin(badgeLabel, new Insets(2, 4, 0, 0));
-                notePane.getChildren().add(badgeLabel);
+                notePane.getChildren().add(createBadgeLabel(badge, item));
             }
         }
         notePane.setUserData(item.getId());
@@ -448,6 +437,17 @@ public class MapViewController {
             }
         });
         return dragging;
+    }
+
+    private Label createBadgeLabel(String badge, NoteDisplayItem item) {
+        Label l = new Label(badge);
+        l.setFont(Font.font(BADGE_FONT_SIZE));
+        l.setTextFill(Color.web(ViewColorConfig.contrastTextColor(item.getColorHex())));
+        l.setEffect(new DropShadow(2, Color.gray(0.3, 0.6)));
+        l.setMouseTransparent(true);
+        StackPane.setAlignment(l, Pos.TOP_RIGHT);
+        StackPane.setMargin(l, new Insets(2, 4, 0, 0));
+        return l;
     }
 
     /** Checks if target is a descendant of ancestor. */

--- a/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerTest.java
@@ -479,6 +479,38 @@ class MapViewControllerTest {
         return null;
     }
 
+    @Test
+    @DisplayName("RED/GREEN: badge visible after setting attribute and reloading")
+    void badge_shouldAppearAfterSetAndReload() {
+        // Step 1: Create note via ViewModel (user creates note)
+        NoteDisplayItem item = viewModel.createChildNote("Stamp Test");
+
+        // Step 2: Set badge on the note (simulates stamp application)
+        noteService.getNote(item.getId()).ifPresent(note ->
+                note.setAttribute(Attributes.BADGE,
+                        new AttributeValue.StringValue("star")));
+
+        // Step 3: Reload notes (simulates refreshAll after stamp)
+        viewModel.loadNotes();
+
+        // Step 4: Verify the display item has the badge
+        NoteDisplayItem reloaded = viewModel.getNoteItems().stream()
+                .filter(i -> i.getId().equals(item.getId()))
+                .findFirst().orElse(null);
+        assertNotNull(reloaded, "Reloaded display item should exist");
+        assertEquals("\u2B50", reloaded.getBadge(),
+                "Display item should have star badge after reload");
+
+        // Step 5: Verify the rendered node has the badge label
+        StackPane noteNode = findNodeByUserData(item.getId());
+        assertNotNull(noteNode, "Note should exist on canvas after reload");
+        Label badgeLabel = findBadgeLabel(noteNode);
+        assertNotNull(badgeLabel,
+                "Badge label should be rendered after set + reload");
+        assertEquals("\u2B50", badgeLabel.getText(),
+                "Badge label text should be star symbol");
+    }
+
     /** Finds the VBox child within a StackPane note node. */
     private VBox findTextBox(StackPane noteNode) {
         for (Node child : noteNode.getChildren()) {

--- a/src/test/java/com/embervault/adapter/in/ui/view/TextPaneViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/TextPaneViewControllerTest.java
@@ -73,6 +73,7 @@ class TextPaneViewControllerTest {
         injectField("textArea", textArea);
 
         controller.initViewModel(viewModel);
+        WaitForAsyncUtils.waitForFxEvents();
     }
 
     @Test
@@ -142,15 +143,17 @@ class TextPaneViewControllerTest {
     @Test
     @DisplayName("title saved on focus lost")
     void titleField_savesOnFocusLost(FxRobot robot) {
-        viewModel.setSelectedNoteId(noteId);
+        robot.interact(() -> viewModel.setSelectedNoteId(noteId));
+        WaitForAsyncUtils.waitForFxEvents();
 
         robot.interact(() -> {
             titleField.requestFocus();
             titleField.setText("Renamed Note");
         });
+        WaitForAsyncUtils.waitForFxEvents();
 
-        // Move focus away to trigger save
         robot.interact(() -> textArea.requestFocus());
+        WaitForAsyncUtils.waitForFxEvents();
 
         assertEquals("Renamed Note", viewModel.titleProperty().get(),
                 "Title should be saved after focus lost");
@@ -166,7 +169,8 @@ class TextPaneViewControllerTest {
     @Test
     @DisplayName("title saved on Enter key")
     void titleField_savesOnEnter(FxRobot robot) {
-        viewModel.setSelectedNoteId(noteId);
+        robot.interact(() -> viewModel.setSelectedNoteId(noteId));
+        WaitForAsyncUtils.waitForFxEvents();
 
         robot.interact(() -> {
             titleField.requestFocus();
@@ -184,14 +188,14 @@ class TextPaneViewControllerTest {
     @Test
     @DisplayName("text saved on focus lost")
     void textArea_savesOnFocusLost(FxRobot robot) {
-        viewModel.setSelectedNoteId(noteId);
+        robot.interact(() -> viewModel.setSelectedNoteId(noteId));
+        WaitForAsyncUtils.waitForFxEvents();
 
         robot.interact(() -> {
             textArea.requestFocus();
             textArea.setText("Updated body text");
         });
-
-        // Move focus away to trigger save
+        WaitForAsyncUtils.waitForFxEvents();
         robot.interact(() -> titleField.requestFocus());
 
         assertEquals("Updated body text", viewModel.textProperty().get(),
@@ -201,10 +205,14 @@ class TextPaneViewControllerTest {
     @Test
     @DisplayName("clearing selection hides editor and shows placeholder")
     void clearSelection_showsPlaceholder() {
-        viewModel.setSelectedNoteId(noteId);
+        javafx.application.Platform.runLater(
+                () -> viewModel.setSelectedNoteId(noteId));
+        WaitForAsyncUtils.waitForFxEvents();
         assertTrue(titleField.isVisible());
 
-        viewModel.setSelectedNoteId(null);
+        javafx.application.Platform.runLater(
+                () -> viewModel.setSelectedNoteId(null));
+        WaitForAsyncUtils.waitForFxEvents();
 
         assertTrue(placeholderLabel.isVisible(),
                 "Placeholder should reappear after clearing selection");


### PR DESCRIPTION
## TDD Commits

1. **RED** (657bf6d): Failing test — creates note, sets `$Badge=star`, reloads, asserts badge Label exists. Display item has the badge but rendered node doesn't.
2. **GREEN** (this commit): Fixed `updateNoteNode()` to create badge Label when one doesn't exist but badge is now set. Extracted `createBadgeLabel()` helper.

## Root Cause
`updateNoteNode()` only updated existing badge Labels (child at index 2). When a note was created without a badge and later gained one via stamp, the node had no badge Label to update.

Closes #158