### PR TITLE
Audit SOLID compliance and fix DIP violation in DocumentFactory

### DIFF
--- a/src/main/java/com/embervault/DocumentFactory.java
+++ b/src/main/java/com/embervault/DocumentFactory.java
@@ -1,8 +1,13 @@
-package com.embervault.application;
+package com.embervault;
 
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.adapter.out.persistence.InMemoryStampRepository;
+import com.embervault.application.DocumentContext;
+import com.embervault.application.LinkServiceImpl;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.ProjectServiceImpl;
+import com.embervault.application.StampServiceImpl;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
@@ -13,6 +18,11 @@ import com.embervault.domain.Project;
 
 /**
  * Convenience factory for creating a fully wired document.
+ *
+ * <p>Lives in the composition-root package ({@code com.embervault}) because it
+ * wires concrete adapter implementations to application-layer ports. Placing it
+ * here keeps the {@code application} package free of adapter dependencies,
+ * respecting the Dependency Inversion Principle.</p>
  *
  * <p>Encapsulates the wiring of repositories, services, and the project so
  * that a developer can create a ready-to-use document in a single call:</p>

--- a/src/main/java/com/embervault/application/DocumentContext.java
+++ b/src/main/java/com/embervault/application/DocumentContext.java
@@ -9,7 +9,7 @@ import com.embervault.domain.Project;
 /**
  * Holds a fully wired document with all services and the project.
  *
- * <p>Returned by {@link DocumentFactory#createEmpty()} so that a developer
+ * <p>Returned by {@link com.embervault.DocumentFactory#createEmpty()} so that a developer
  * can get a ready-to-use document without understanding the internal wiring
  * of the application. All services share the same underlying repositories.</p>
  *

--- a/src/test/java/com/embervault/application/DocumentFactoryTest.java
+++ b/src/test/java/com/embervault/application/DocumentFactoryTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Optional;
 
+import com.embervault.DocumentFactory;
 import com.embervault.domain.Note;
 import com.embervault.domain.Project;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/embervault/architecture/ArchitectureTest.java
+++ b/src/test/java/com/embervault/architecture/ArchitectureTest.java
@@ -219,4 +219,18 @@ class ArchitectureTest {
                 .allowEmptyShould(true)
                 .check(classes);
     }
+
+    @Test
+    @DisplayName("ADR-0009: Application services must not depend on adapter packages")
+    void applicationServicesMustNotDependOnAdapters() {
+        noClasses()
+                .that().resideInAPackage("com.embervault.application..")
+                .should().dependOnClassesThat()
+                .resideInAPackage("com.embervault.adapter..")
+                .because("ADR-0009 mandates that application services depend on ports "
+                        + "(abstractions), not on adapter implementations "
+                        + "(dependency flows inward only)")
+                .allowEmptyShould(true)
+                .check(classes);
+    }
 }


### PR DESCRIPTION
## Summary

SOLID compliance audit for issue #163. One concrete fix; the rest are documented findings.

- **Fix**: Moved `DocumentFactory` from `com.embervault.application` to `com.embervault` (composition root) to eliminate a Dependency Inversion Principle violation — it imported concrete adapter classes (`InMemoryNoteRepository`, etc.) from within the application layer
- **Guard**: Added ArchUnit rule ensuring `application..` classes never depend on `adapter..` classes

## Audit Findings

### Single Responsibility
- **App.java** (492 lines): Composition root + menu construction + stamp wiring. Acceptable — this is the nature of a composition root. Menu logic is already extracted into helper methods. No split warranted.
- **MapViewController** (500 lines): Rendering + drag interaction + zoom + inline editing. These responsibilities are tightly coupled to the same UI canvas. Splitting would create artificial boundaries and increase coupling via shared state. No split warranted.
- **NoteService** (17 methods): See Interface Segregation below.

### Open/Closed
- **ViewType enum**: Adding a new view type requires modifying the enum. Acceptable — this is a bounded, known set of view types, not a plugin system.
- **AttributeValue sealed hierarchy**: New types require modifying the `permits` clause. By design — sealed types provide exhaustiveness checking.

### Interface Segregation
- **NoteService** has 17 methods. A split into `NoteQueryService` / `NoteMutationService` was considered but is **not warranted**:
  - Most consumers (ViewModels) use both reads and writes
  - The methods form a cohesive API around note lifecycle (CRUD + hierarchy + outline operations)
  - Splitting would add complexity without reducing coupling, since most callers would need to inject both interfaces
- **StampService** (5 methods) and **LinkService** (5 methods): Already focused and cohesive. No changes needed.

### Dependency Inversion
- **DocumentFactory** (FIXED): Was in `com.embervault.application` but depended on `InMemoryNoteRepository`, `InMemoryLinkRepository`, `InMemoryStampRepository`. Moved to `com.embervault` (composition root package, alongside `App.java`).
- **App.java**: References concrete implementations — acceptable as the composition root.
- **All other application/domain code**: Clean. Services depend on port interfaces, not implementations.
- **New ArchUnit rule** guards against future violations: `application..` must not depend on `adapter..`

## Test plan
- [x] All 817 tests pass (`mvn verify`)
- [x] Checkstyle clean (0 violations)
- [x] JaCoCo coverage thresholds met
- [x] New ArchUnit rule passes (would have caught the original violation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)