### PR TITLE
Eliminate code duplication across ViewModels

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/AttributeBrowserViewModel.java
@@ -194,12 +194,8 @@ public final class AttributeBrowserViewModel {
     }
 
     private void updateTabTitle(String attributeName) {
-        if (attributeName == null || attributeName.isEmpty()) {
-            tabTitle.set("Browser");
-        } else {
-            tabTitle.set("Browser: "
-                    + TextUtils.truncate(attributeName, MAX_TITLE_LENGTH));
-        }
+        tabTitle.set(TextUtils.tabTitle("Browser", attributeName,
+                MAX_TITLE_LENGTH));
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
@@ -1,7 +1,5 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
-import static com.embervault.domain.Attributes.BADGE;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -15,8 +13,6 @@ import java.util.UUID;
 
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
-import com.embervault.domain.AttributeValue;
-import com.embervault.domain.BadgeRegistry;
 import com.embervault.domain.Link;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
@@ -96,8 +92,8 @@ public final class HyperbolicViewModel {
         focusNoteId.set(noteId);
 
         noteService.getNote(noteId).ifPresent(note ->
-                tabTitle.set("Hyperbolic: "
-                        + TextUtils.truncate(note.getTitle(), MAX_TITLE_LENGTH)));
+                tabTitle.set(TextUtils.tabTitle("Hyperbolic",
+                        note.getTitle(), MAX_TITLE_LENGTH)));
 
         computeLayout();
     }
@@ -204,9 +200,7 @@ public final class HyperbolicViewModel {
      */
     public String getNoteBadge(UUID noteId) {
         return noteService.getNote(noteId)
-                .flatMap(note -> note.getAttribute(BADGE))
-                .map(v -> ((AttributeValue.StringValue) v).value())
-                .flatMap(BadgeRegistry::getBadgeSymbol)
+                .map(NoteDisplayHelper::resolveBadge)
                 .orElse("");
     }
 

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -36,7 +36,6 @@ public final class MapViewModel {
     private static final double SCALE_Y = 40.0;
     private static final double DEFAULT_WIDTH = 6.0;
     private static final double DEFAULT_HEIGHT = 4.0;
-    private static final String DEFAULT_COLOR_HEX = "#808080";
     private static final double MIN_ZOOM = 0.1;
     private static final double MAX_ZOOM = 5.0;
     private static final double ZOOM_IN_FACTOR = 1.25;
@@ -342,7 +341,7 @@ public final class MapViewModel {
     }
 
     private void updateTabTitle(String title) {
-        tabTitle.set("Map: " + TextUtils.truncate(title, MAX_TITLE_LENGTH));
+        tabTitle.set(TextUtils.tabTitle("Map", title, MAX_TITLE_LENGTH));
     }
 
     /**

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -295,7 +295,7 @@ public final class OutlineViewModel {
     }
 
     private void updateTabTitle(String title) {
-        tabTitle.set("Outline: " + TextUtils.truncate(title, MAX_TITLE_LENGTH));
+        tabTitle.set(TextUtils.tabTitle("Outline", title, MAX_TITLE_LENGTH));
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TextUtils.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TextUtils.java
@@ -22,4 +22,22 @@ final class TextUtils {
         }
         return text.substring(0, maxLength) + "\u2026";
     }
+
+    /**
+     * Computes a tab title of the form "Prefix: Name", truncating the name
+     * if it exceeds the given maximum length.
+     *
+     * <p>If the name is null or empty, returns just the prefix.</p>
+     *
+     * @param prefix the view type prefix (e.g., "Map", "Outline")
+     * @param name   the name to include, may be null or empty
+     * @param maxLen the maximum length for the name portion before truncation
+     * @return the formatted tab title
+     */
+    static String tabTitle(String prefix, String name, int maxLen) {
+        if (name == null || name.isEmpty()) {
+            return prefix;
+        }
+        return prefix + ": " + truncate(name, maxLen);
+    }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
@@ -26,7 +26,6 @@ import javafx.collections.ObservableList;
 public final class TreemapViewModel {
 
     private static final int MAX_TITLE_LENGTH = 20;
-    private static final String DEFAULT_COLOR_HEX = "#808080";
 
     private final ReadOnlyStringWrapper tabTitle = new ReadOnlyStringWrapper();
     private final ObservableList<NoteDisplayItem> noteItems =
@@ -191,7 +190,7 @@ public final class TreemapViewModel {
     }
 
     private void updateTabTitle(String title) {
-        tabTitle.set("Treemap: " + TextUtils.truncate(title, MAX_TITLE_LENGTH));
+        tabTitle.set(TextUtils.tabTitle("Treemap", title, MAX_TITLE_LENGTH));
     }
 
     private NoteDisplayItem toDisplayItem(Note note) {

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/TextUtilsTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/TextUtilsTest.java
@@ -45,4 +45,37 @@ class TextUtilsTest {
     void truncate_shouldWorkWithMaxLengthOfOne() {
         assertEquals("a\u2026", TextUtils.truncate("abc", 1));
     }
+
+    @Test
+    @DisplayName("tabTitle returns prefix only when name is null")
+    void tabTitle_shouldReturnPrefixOnlyWhenNameIsNull() {
+        assertEquals("Map", TextUtils.tabTitle("Map", null, 20));
+    }
+
+    @Test
+    @DisplayName("tabTitle returns prefix only when name is empty")
+    void tabTitle_shouldReturnPrefixOnlyWhenNameIsEmpty() {
+        assertEquals("Map", TextUtils.tabTitle("Map", "", 20));
+    }
+
+    @Test
+    @DisplayName("tabTitle combines prefix and short name")
+    void tabTitle_shouldCombinePrefixAndShortName() {
+        assertEquals("Map: Hello", TextUtils.tabTitle("Map", "Hello", 20));
+    }
+
+    @Test
+    @DisplayName("tabTitle truncates long name with ellipsis")
+    void tabTitle_shouldTruncateLongName() {
+        assertEquals("Outline: A Very Long Note Tit\u2026",
+                TextUtils.tabTitle("Outline",
+                        "A Very Long Note Title That Should Be Truncated", 20));
+    }
+
+    @Test
+    @DisplayName("tabTitle handles exact-length name")
+    void tabTitle_shouldHandleExactLengthName() {
+        String name = "12345678901234567890"; // exactly 20 chars
+        assertEquals("Map: " + name, TextUtils.tabTitle("Map", name, 20));
+    }
 }


### PR DESCRIPTION
## Summary
- Add `TextUtils.tabTitle(prefix, name, maxLen)` to consolidate the repeated tab title computation pattern (`"Prefix: " + TextUtils.truncate(name, maxLen)`) that was duplicated across all 5 ViewModels with tab titles
- Replace `HyperbolicViewModel.getNoteBadge()` inline badge resolution with `NoteDisplayHelper.resolveBadge()`, removing duplicated `BadgeRegistry` and `AttributeValue` imports
- Remove unused `DEFAULT_COLOR_HEX` constants from `MapViewModel` and `TreemapViewModel` (already delegated to `NoteDisplayHelper`)

Closes #161

## Test plan
- [x] New `TextUtilsTest` cases for `tabTitle()`: null name, empty name, short name, long name (truncated), exact-length name
- [x] All 821 existing tests pass (including `HyperbolicViewModelTest` badge tests)
- [x] Checkstyle clean, JaCoCo coverage thresholds met, ArchUnit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)