### PR TITLE
Add Color Scheme picker to View menu

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import com.embervault.adapter.in.ui.view.AttributeBrowserViewController;
+import com.embervault.adapter.in.ui.view.ColorSchemeMenuHelper;
 import com.embervault.adapter.in.ui.view.HyperbolicViewController;
 import com.embervault.adapter.in.ui.view.MapViewController;
 import com.embervault.adapter.in.ui.view.NoteEditorViewController;
@@ -58,10 +59,8 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
-import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.SplitPane;
-import javafx.scene.control.ToggleGroup;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
@@ -328,19 +327,12 @@ public class App extends Application {
         });
 
         // Color Scheme submenu
-        Menu colorSchemeMenu = new Menu("Color Scheme");
-        ToggleGroup schemeToggle = new ToggleGroup();
-        for (ColorScheme scheme
-                : ColorSchemeRegistry.getAllSchemes()) {
-            RadioMenuItem item = new RadioMenuItem(scheme.name());
-            item.setToggleGroup(schemeToggle);
-            if ("Standard".equals(scheme.name())) {
-                item.setSelected(true);
-            }
-            item.setOnAction(e ->
-                    ctx.colorSchemeApplier().accept(scheme));
-            colorSchemeMenu.getItems().add(item);
-        }
+        List<String> schemeNames = ColorSchemeRegistry.getAllSchemes()
+                .stream().map(ColorScheme::name).toList();
+        Menu colorSchemeMenu = ColorSchemeMenuHelper
+                .createColorSchemeMenu(schemeNames, "Standard",
+                        name -> ColorSchemeRegistry.getScheme(name)
+                                .ifPresent(ctx.colorSchemeApplier()));
 
         Menu viewMenu = new Menu("View");
         viewMenu.getItems().addAll(mapViewItem, outlineViewItem,

--- a/src/main/java/com/embervault/adapter/in/ui/view/ColorSchemeMenuHelper.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/ColorSchemeMenuHelper.java
@@ -1,0 +1,55 @@
+package com.embervault.adapter.in.ui.view;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import javafx.scene.control.Menu;
+import javafx.scene.control.RadioMenuItem;
+import javafx.scene.control.ToggleGroup;
+
+/**
+ * Shared helper that builds a "Color Scheme" submenu with a
+ * {@link RadioMenuItem} for each scheme name provided.
+ * The item matching {@code defaultName} is selected by default.
+ */
+public final class ColorSchemeMenuHelper {
+
+    private ColorSchemeMenuHelper() {
+        // utility class
+    }
+
+    /**
+     * Creates a "Color Scheme" {@link Menu} populated with one
+     * {@link RadioMenuItem} per scheme name.
+     *
+     * <p>All items share a single {@link ToggleGroup} so that
+     * exactly one scheme is active at a time. The item whose
+     * text equals {@code defaultName} is selected by default.</p>
+     *
+     * @param schemeNames      ordered list of scheme names
+     * @param defaultName      the name of the initially-selected scheme
+     * @param onSchemeSelected callback invoked with the selected
+     *                         scheme name when the user picks one
+     * @return the fully-wired Color Scheme submenu
+     */
+    public static Menu createColorSchemeMenu(
+            List<String> schemeNames,
+            String defaultName,
+            Consumer<String> onSchemeSelected) {
+        Menu menu = new Menu("Color Scheme");
+        ToggleGroup toggleGroup = new ToggleGroup();
+
+        for (String name : schemeNames) {
+            RadioMenuItem item = new RadioMenuItem(name);
+            item.setToggleGroup(toggleGroup);
+            if (name.equals(defaultName)) {
+                item.setSelected(true);
+            }
+            item.setOnAction(e ->
+                    onSchemeSelected.accept(name));
+            menu.getItems().add(item);
+        }
+
+        return menu;
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/ColorSchemeMenuHelperTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/ColorSchemeMenuHelperTest.java
@@ -1,0 +1,131 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.embervault.domain.ColorScheme;
+import com.embervault.domain.ColorSchemeRegistry;
+import javafx.scene.control.Menu;
+import javafx.scene.control.RadioMenuItem;
+import javafx.scene.control.ToggleGroup;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link ColorSchemeMenuHelper}.
+ *
+ * <p>Verifies that the menu items match the schemes in the
+ * {@link ColorSchemeRegistry} and that selection wiring works.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class ColorSchemeMenuHelperTest {
+
+    private static final List<String> SCHEME_NAMES =
+            ColorSchemeRegistry.getAllSchemes().stream()
+                    .map(ColorScheme::name).toList();
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @Test
+    @DisplayName("menu contains one RadioMenuItem per registry scheme")
+    void createColorSchemeMenu_matchesRegistryCount() {
+        Menu menu = ColorSchemeMenuHelper.createColorSchemeMenu(
+                SCHEME_NAMES, "Standard", name -> { });
+
+        assertEquals(SCHEME_NAMES.size(), menu.getItems().size(),
+                "Menu item count should match registry scheme count");
+    }
+
+    @Test
+    @DisplayName("menu item names match registry scheme names in order")
+    void createColorSchemeMenu_namesMatchRegistry() {
+        Menu menu = ColorSchemeMenuHelper.createColorSchemeMenu(
+                SCHEME_NAMES, "Standard", name -> { });
+
+        for (int i = 0; i < SCHEME_NAMES.size(); i++) {
+            assertEquals(SCHEME_NAMES.get(i),
+                    menu.getItems().get(i).getText(),
+                    "Item " + i + " name mismatch");
+        }
+    }
+
+    @Test
+    @DisplayName("all items are RadioMenuItems")
+    void createColorSchemeMenu_allRadioItems() {
+        Menu menu = ColorSchemeMenuHelper.createColorSchemeMenu(
+                SCHEME_NAMES, "Standard", name -> { });
+
+        for (var item : menu.getItems()) {
+            assertInstanceOf(RadioMenuItem.class, item,
+                    "All items should be RadioMenuItems");
+        }
+    }
+
+    @Test
+    @DisplayName("all items share the same ToggleGroup")
+    void createColorSchemeMenu_sharedToggleGroup() {
+        Menu menu = ColorSchemeMenuHelper.createColorSchemeMenu(
+                SCHEME_NAMES, "Standard", name -> { });
+
+        ToggleGroup group = ((RadioMenuItem) menu.getItems()
+                .get(0)).getToggleGroup();
+        assertNotNull(group, "First item should have a toggle group");
+        for (var item : menu.getItems()) {
+            assertEquals(group,
+                    ((RadioMenuItem) item).getToggleGroup(),
+                    "All items should share the same toggle group");
+        }
+    }
+
+    @Test
+    @DisplayName("Standard is selected by default")
+    void createColorSchemeMenu_standardSelectedByDefault() {
+        Menu menu = ColorSchemeMenuHelper.createColorSchemeMenu(
+                SCHEME_NAMES, "Standard", name -> { });
+
+        for (var item : menu.getItems()) {
+            RadioMenuItem radio = (RadioMenuItem) item;
+            if ("Standard".equals(radio.getText())) {
+                assertTrue(radio.isSelected(),
+                        "Standard should be selected by default");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("selecting item invokes callback with correct name")
+    void createColorSchemeMenu_callbackInvokedWithName() {
+        AtomicReference<String> received = new AtomicReference<>();
+        Menu menu = ColorSchemeMenuHelper.createColorSchemeMenu(
+                SCHEME_NAMES, "Standard", received::set);
+
+        // Fire the "Dark" item (index 1)
+        menu.getItems().get(1).fire();
+
+        assertNotNull(received.get(), "Callback should have been called");
+        assertEquals("Dark", received.get());
+    }
+
+    @Test
+    @DisplayName("menu title is 'Color Scheme'")
+    void createColorSchemeMenu_title() {
+        Menu menu = ColorSchemeMenuHelper.createColorSchemeMenu(
+                SCHEME_NAMES, "Standard", name -> { });
+
+        assertEquals("Color Scheme", menu.getText());
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted inline Color Scheme submenu construction from `App.java` into a reusable `ColorSchemeMenuHelper` (follows the same pattern as `ViewSwitchMenuHelper`)
- The helper builds a `Menu` with `RadioMenuItem`s in a `ToggleGroup`, wired to a selection callback
- Added 7 tests verifying menu items match `ColorSchemeRegistry` entries, toggle group wiring, default selection, and callback behavior
- All 834 tests pass, 0 checkstyle violations, ArchUnit rules satisfied

## Test plan
- [ ] Verify `mvn verify` passes (834 tests, 0 checkstyle violations)
- [ ] Verify `mvn verify -Pui-tests` passes (includes the new `@Tag("ui")` tests via TestFX)
- [ ] Manual: confirm Color Scheme submenu appears under View menu with 5 presets
- [ ] Manual: confirm selecting a scheme applies it to all views immediately
- [ ] Manual: confirm "Standard" is selected by default on startup

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)