### PR TITLE
Extract event handlers from controllers into named testable methods

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -25,7 +25,9 @@ import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
+import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
@@ -106,24 +108,9 @@ public class MapViewController {
             }
         });
 
-        mapCanvas.setOnScroll(event -> {
-            double factor = event.getDeltaY() > 0
-                    ? SCROLL_ZOOM_FACTOR : 1.0 / SCROLL_ZOOM_FACTOR;
-            double newZoom = viewModel.zoomLevelProperty().get() * factor;
-            zoomScale.setPivotX(event.getX());
-            zoomScale.setPivotY(event.getY());
-            viewModel.setZoomLevel(newZoom);
-            event.consume();
-        });
+        mapCanvas.setOnScroll(this::handleScrollZoom);
 
-        mapCanvas.setOnKeyPressed(event -> {
-            if (event.getCode() == KeyCode.ENTER) {
-                viewModel.createChildNote("Untitled");
-            } else if (event.getCode() == KeyCode.ESCAPE
-                    && viewModel.canNavigateBackProperty().get()) {
-                viewModel.navigateBack();
-            }
-        });
+        mapCanvas.setOnKeyPressed(this::handleKeyPress);
 
         ContextMenu contextMenu = createContextMenu();
         mapCanvas.setOnContextMenuRequested(event -> {
@@ -139,6 +126,27 @@ public class MapViewController {
     /** Returns the associated ViewModel. */
     public MapViewModel getViewModel() {
         return viewModel;
+    }
+
+    /** Handles scroll-to-zoom, adjusting zoom level toward the cursor position. */
+    void handleScrollZoom(ScrollEvent event) {
+        double factor = event.getDeltaY() > 0
+                ? SCROLL_ZOOM_FACTOR : 1.0 / SCROLL_ZOOM_FACTOR;
+        double newZoom = viewModel.zoomLevelProperty().get() * factor;
+        zoomScale.setPivotX(event.getX());
+        zoomScale.setPivotY(event.getY());
+        viewModel.setZoomLevel(newZoom);
+        event.consume();
+    }
+
+    /** Handles key presses: Enter creates a note, Escape navigates back. */
+    void handleKeyPress(KeyEvent event) {
+        if (event.getCode() == KeyCode.ENTER) {
+            viewModel.createChildNote("Untitled");
+        } else if (event.getCode() == KeyCode.ESCAPE
+                && viewModel.canNavigateBackProperty().get()) {
+            viewModel.navigateBack();
+        }
     }
 
     private ContextMenu createContextMenu() {
@@ -431,8 +439,7 @@ public class MapViewController {
         });
         notePane.setOnMouseReleased(event -> {
             if (dragging[0]) {
-                viewModel.updateNotePosition(
-                        item.getId(), notePane.getLayoutX(), notePane.getLayoutY());
+                viewModel.updateNotePosition(item.getId(), notePane.getLayoutX(), notePane.getLayoutY());
                 event.consume();
             }
         });
@@ -451,26 +458,21 @@ public class MapViewController {
     }
 
     /** Checks if target is a descendant of ancestor. */
-    private static boolean isDescendantOf(Object target, javafx.scene.Node ancestor) {
-        if (!(target instanceof javafx.scene.Node node)) {
+    private static boolean isDescendantOf(Object target, Node ancestor) {
+        if (!(target instanceof Node node)) {
             return false;
         }
-        javafx.scene.Node current = node.getParent();
-        while (current != null) {
-            if (current == ancestor) {
+        for (Node cur = node.getParent(); cur != null; cur = cur.getParent()) {
+            if (cur == ancestor) {
                 return true;
             }
-            current = current.getParent();
         }
         return false;
     }
 
     private void highlightSelected(StackPane selected) {
-        Color borderCol = currentColors != null
-                ? Color.web(currentColors.borderColor()) : Color.BLACK;
-        Color selCol = currentColors != null
-                ? Color.web(currentColors.selectionColor())
-                : Color.DODGERBLUE;
+        Color borderCol = currentColors != null ? Color.web(currentColors.borderColor()) : Color.BLACK;
+        Color selCol = currentColors != null ? Color.web(currentColors.selectionColor()) : Color.DODGERBLUE;
         for (Node child : mapCanvas.getChildren()) {
             if (child instanceof StackPane sp && !sp.getChildren().isEmpty()
                     && sp.getChildren().get(0) instanceof Rectangle r) {
@@ -485,10 +487,7 @@ public class MapViewController {
         }
     }
 
-    /**
-     * Applies a color scheme to the map view.
-     * @param colors the view color config to apply
-     */
+    /** Applies a color scheme to the map view. */
     public void applyColorScheme(ViewColorConfig colors) {
         this.currentColors = colors;
         mapCanvas.setStyle("-fx-background-color: "

--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -83,25 +83,14 @@ public class OutlineViewController {
 
         // Selection listener
         outlineTreeView.getSelectionModel().selectedItemProperty()
-                .addListener((obs, oldVal, newVal) -> {
-                    if (newVal != null && newVal.getValue() != null) {
-                        viewModel.selectNote(newVal.getValue().getId());
-                    } else {
-                        viewModel.selectNote(null);
-                    }
-                });
+                .addListener((obs, oldVal, newVal) ->
+                        handleTreeSelection(newVal));
 
         // Event filter to intercept Tab/Shift+Tab before TreeView handles them
         outlineTreeView.addEventFilter(KeyEvent.KEY_PRESSED, this::handleTreeKeyFilter);
 
         // Key handling: Escape navigates back
-        outlineTreeView.setOnKeyPressed(event -> {
-            if (event.getCode() == KeyCode.ESCAPE
-                    && viewModel.canNavigateBackProperty().get()) {
-                viewModel.navigateBack();
-                event.consume();
-            }
-        });
+        outlineTreeView.setOnKeyPressed(this::handleTreeKeyPress);
 
         // Context menu
         outlineTreeView.setContextMenu(createContextMenu());
@@ -110,6 +99,24 @@ public class OutlineViewController {
     /** Returns the associated ViewModel. */
     public OutlineViewModel getViewModel() {
         return viewModel;
+    }
+
+    /** Handles key presses on the tree view: Escape navigates back. */
+    void handleTreeKeyPress(KeyEvent event) {
+        if (event.getCode() == KeyCode.ESCAPE
+                && viewModel.canNavigateBackProperty().get()) {
+            viewModel.navigateBack();
+            event.consume();
+        }
+    }
+
+    /** Handles tree selection changes, updating the ViewModel selection. */
+    void handleTreeSelection(TreeItem<NoteDisplayItem> newVal) {
+        if (newVal != null && newVal.getValue() != null) {
+            viewModel.selectNote(newVal.getValue().getId());
+        } else {
+            viewModel.selectNote(null);
+        }
     }
 
     private void handleTreeKeyFilter(KeyEvent event) {

--- a/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
@@ -118,6 +118,16 @@ public class TreemapViewController {
         return viewModel;
     }
 
+    /** Handles a single click on a treemap cell, selecting the note. */
+    void handleCellClick(NoteDisplayItem item) {
+        viewModel.selectNote(item.getId());
+    }
+
+    /** Handles a double-click on a treemap cell, drilling down into the note. */
+    void handleCellDoubleClick(NoteDisplayItem item) {
+        viewModel.drillDown(item.getId());
+    }
+
     private ContextMenu createContextMenu() {
         MenuItem createNote = new MenuItem("Create Note");
         createNote.setOnAction(e -> viewModel.createChildNote("Untitled"));
@@ -200,7 +210,7 @@ public class TreemapViewController {
 
         // Click to select
         notePane.setOnMousePressed(event -> {
-            viewModel.selectNote(item.getId());
+            handleCellClick(item);
             highlightSelected(notePane);
         });
 
@@ -208,7 +218,7 @@ public class TreemapViewController {
         notePane.setOnMouseClicked(event -> {
             if (event.getClickCount() == 2
                     && event.getButton() == MouseButton.PRIMARY) {
-                viewModel.drillDown(item.getId());
+                handleCellDoubleClick(item);
                 event.consume();
             }
         });

--- a/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerHandlerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MapViewControllerHandlerTest.java
@@ -1,0 +1,201 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.ScrollEvent;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for extracted event handler methods in {@link MapViewController}.
+ *
+ * <p>Verifies that {@code handleScrollZoom} and {@code handleKeyPress}
+ * can be called directly with synthetic events, without needing a
+ * TestFX robot.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class MapViewControllerHandlerTest {
+
+    private MapViewController controller;
+    private MapViewModel viewModel;
+    private NoteService noteService;
+    private Pane mapCanvas;
+    private UUID parentId;
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        SimpleStringProperty noteTitle = new SimpleStringProperty("Test");
+        viewModel = new MapViewModel(noteTitle, noteService);
+
+        parentId = noteService.createNote("Parent", "").getId();
+        viewModel.setBaseNoteId(parentId);
+
+        controller = new MapViewController();
+        mapCanvas = new Pane();
+
+        try {
+            var field = MapViewController.class.getDeclaredField("mapCanvas");
+            field.setAccessible(true);
+            field.set(controller, mapCanvas);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+
+        controller.initViewModel(viewModel);
+    }
+
+    // --- handleScrollZoom tests ---
+
+    @Test
+    @DisplayName("handleScrollZoom zooms in when deltaY is positive")
+    void handleScrollZoom_positiveDeltaY_zoomsIn() {
+        double initialZoom = viewModel.zoomLevelProperty().get();
+        ScrollEvent event = createScrollEvent(1.0, 100, 100);
+
+        controller.handleScrollZoom(event);
+
+        assertTrue(viewModel.zoomLevelProperty().get() > initialZoom,
+                "Zoom level should increase on positive scroll");
+    }
+
+    @Test
+    @DisplayName("handleScrollZoom zooms out when deltaY is negative")
+    void handleScrollZoom_negativeDeltaY_zoomsOut() {
+        double initialZoom = viewModel.zoomLevelProperty().get();
+        ScrollEvent event = createScrollEvent(-1.0, 100, 100);
+
+        controller.handleScrollZoom(event);
+
+        assertTrue(viewModel.zoomLevelProperty().get() < initialZoom,
+                "Zoom level should decrease on negative scroll");
+    }
+
+    @Test
+    @DisplayName("handleScrollZoom applies correct zoom factor (1.1x)")
+    void handleScrollZoom_appliesCorrectFactor() {
+        viewModel.setZoomLevel(1.0);
+        ScrollEvent event = createScrollEvent(1.0, 50, 50);
+
+        controller.handleScrollZoom(event);
+
+        assertEquals(1.1, viewModel.zoomLevelProperty().get(), 0.01,
+                "Zoom should multiply by 1.1 on scroll up");
+    }
+
+    @Test
+    @DisplayName("handleScrollZoom applies inverse factor on scroll down")
+    void handleScrollZoom_appliesInverseFactorOnScrollDown() {
+        viewModel.setZoomLevel(1.0);
+        ScrollEvent event = createScrollEvent(-1.0, 50, 50);
+
+        controller.handleScrollZoom(event);
+
+        assertEquals(1.0 / 1.1, viewModel.zoomLevelProperty().get(), 0.01,
+                "Zoom should divide by 1.1 on scroll down");
+    }
+
+    // --- handleKeyPress tests ---
+
+    @Test
+    @DisplayName("handleKeyPress with ENTER creates a child note")
+    void handleKeyPress_enter_createsChildNote() {
+        int initialCount = viewModel.getNoteItems().size();
+        KeyEvent event = createKeyEvent(KeyCode.ENTER);
+
+        controller.handleKeyPress(event);
+
+        assertEquals(initialCount + 1, viewModel.getNoteItems().size(),
+                "ENTER should create a new child note");
+    }
+
+    @Test
+    @DisplayName("handleKeyPress with ESCAPE navigates back when possible")
+    void handleKeyPress_escape_navigatesBack() {
+        // First drill down so we can navigate back
+        NoteDisplayItem child = viewModel.createChildNote("Child");
+        viewModel.drillDown(child.getId());
+        assertTrue(viewModel.canNavigateBackProperty().get(),
+                "Should be able to navigate back after drill-down");
+
+        KeyEvent event = createKeyEvent(KeyCode.ESCAPE);
+
+        controller.handleKeyPress(event);
+
+        assertFalse(viewModel.canNavigateBackProperty().get(),
+                "ESCAPE should navigate back to root");
+    }
+
+    @Test
+    @DisplayName("handleKeyPress with ESCAPE does nothing at root level")
+    void handleKeyPress_escape_doesNothingAtRoot() {
+        assertFalse(viewModel.canNavigateBackProperty().get());
+
+        KeyEvent event = createKeyEvent(KeyCode.ESCAPE);
+        controller.handleKeyPress(event);
+
+        // Should not throw and state should be unchanged
+        assertFalse(viewModel.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("handleKeyPress with unrelated key does nothing")
+    void handleKeyPress_unrelatedKey_doesNothing() {
+        int initialCount = viewModel.getNoteItems().size();
+        KeyEvent event = createKeyEvent(KeyCode.A);
+
+        controller.handleKeyPress(event);
+
+        assertEquals(initialCount, viewModel.getNoteItems().size(),
+                "Pressing 'A' should not create notes");
+    }
+
+    // --- Helper methods ---
+
+    private ScrollEvent createScrollEvent(double deltaY, double x,
+            double y) {
+        return new ScrollEvent(
+                ScrollEvent.SCROLL,
+                x, y, x, y,
+                false, false, false, false,
+                false, false,
+                0, deltaY,
+                0, 0,
+                ScrollEvent.HorizontalTextScrollUnits.NONE, 0,
+                ScrollEvent.VerticalTextScrollUnits.NONE, 0,
+                0, null);
+    }
+
+    private KeyEvent createKeyEvent(KeyCode code) {
+        return new KeyEvent(
+                KeyEvent.KEY_PRESSED,
+                "", "", code,
+                false, false, false, false);
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerHandlerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerHandlerTest.java
@@ -1,0 +1,169 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for extracted event handler methods in {@link OutlineViewController}.
+ *
+ * <p>Verifies that {@code handleTreeKeyPress} and {@code handleTreeSelection}
+ * can be called directly without needing a TestFX robot.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class OutlineViewControllerHandlerTest {
+
+    private OutlineViewController controller;
+    private OutlineViewModel viewModel;
+    private NoteService noteService;
+    private UUID parentId;
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+
+        parentId = noteService.createNote("Parent", "").getId();
+        SimpleStringProperty noteTitle = new SimpleStringProperty("Parent");
+        viewModel = new OutlineViewModel(noteTitle, noteService);
+        viewModel.setBaseNoteId(parentId);
+
+        controller = new OutlineViewController();
+        TreeView<NoteDisplayItem> treeView = new TreeView<>();
+        VBox outlineRoot = new VBox(treeView);
+
+        injectField("outlineTreeView", treeView);
+        injectField("outlineRoot", outlineRoot);
+
+        controller.initViewModel(viewModel);
+    }
+
+    // --- handleTreeKeyPress tests ---
+
+    @Test
+    @DisplayName("handleTreeKeyPress with ESCAPE navigates back when possible")
+    void handleTreeKeyPress_escape_navigatesBack() {
+        NoteDisplayItem child = viewModel.createChildNote(parentId, "Child");
+        viewModel.drillDown(child.getId());
+        assertTrue(viewModel.canNavigateBackProperty().get(),
+                "Should be able to navigate back after drill-down");
+
+        KeyEvent event = createKeyEvent(KeyCode.ESCAPE);
+
+        controller.handleTreeKeyPress(event);
+
+        assertFalse(viewModel.canNavigateBackProperty().get(),
+                "ESCAPE should navigate back to root");
+    }
+
+    @Test
+    @DisplayName("handleTreeKeyPress with ESCAPE does nothing at root level")
+    void handleTreeKeyPress_escape_doesNothingAtRoot() {
+        assertFalse(viewModel.canNavigateBackProperty().get());
+
+        KeyEvent event = createKeyEvent(KeyCode.ESCAPE);
+        controller.handleTreeKeyPress(event);
+
+        assertFalse(viewModel.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("handleTreeKeyPress with unrelated key does nothing")
+    void handleTreeKeyPress_unrelatedKey_doesNothing() {
+        KeyEvent event = createKeyEvent(KeyCode.A);
+
+        controller.handleTreeKeyPress(event);
+
+        // Should not throw; no state change
+        assertFalse(viewModel.canNavigateBackProperty().get());
+    }
+
+    // --- handleTreeSelection tests ---
+
+    @Test
+    @DisplayName("handleTreeSelection selects note from tree item")
+    void handleTreeSelection_selectsNote() {
+        NoteDisplayItem item = viewModel.createChildNote(parentId, "Selected");
+        TreeItem<NoteDisplayItem> treeItem = new TreeItem<>(item);
+
+        controller.handleTreeSelection(treeItem);
+
+        assertEquals(item.getId(),
+                viewModel.selectedNoteIdProperty().get(),
+                "Selection should match the tree item's note");
+    }
+
+    @Test
+    @DisplayName("handleTreeSelection clears selection when tree item is null")
+    void handleTreeSelection_nullTreeItem_clearsSelection() {
+        NoteDisplayItem item = viewModel.createChildNote(parentId, "Selected");
+        viewModel.selectNote(item.getId());
+
+        controller.handleTreeSelection(null);
+
+        assertNull(viewModel.selectedNoteIdProperty().get(),
+                "Null tree item should clear selection");
+    }
+
+    @Test
+    @DisplayName("handleTreeSelection clears selection when tree item value is null")
+    void handleTreeSelection_nullValue_clearsSelection() {
+        NoteDisplayItem item = viewModel.createChildNote(parentId, "Selected");
+        viewModel.selectNote(item.getId());
+        TreeItem<NoteDisplayItem> emptyItem = new TreeItem<>(null);
+
+        controller.handleTreeSelection(emptyItem);
+
+        assertNull(viewModel.selectedNoteIdProperty().get(),
+                "Null-valued tree item should clear selection");
+    }
+
+    // --- Helper methods ---
+
+    private KeyEvent createKeyEvent(KeyCode code) {
+        return new KeyEvent(
+                KeyEvent.KEY_PRESSED,
+                "", "", code,
+                false, false, false, false);
+    }
+
+    private void injectField(String fieldName, Object value) {
+        try {
+            var field = OutlineViewController.class
+                    .getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(controller, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/TreemapViewControllerHandlerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/TreemapViewControllerHandlerTest.java
@@ -1,0 +1,151 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for extracted event handler methods in {@link TreemapViewController}.
+ *
+ * <p>Verifies that {@code handleCellClick} and {@code handleCellDoubleClick}
+ * can be called directly without needing a TestFX robot.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class TreemapViewControllerHandlerTest {
+
+    private TreemapViewController controller;
+    private TreemapViewModel viewModel;
+    private NoteService noteService;
+    private Pane treemapCanvas;
+    private UUID parentId;
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+
+        parentId = noteService.createNote("Parent", "").getId();
+        SimpleStringProperty noteTitle = new SimpleStringProperty("Parent");
+        viewModel = new TreemapViewModel(noteTitle, noteService);
+        viewModel.setBaseNoteId(parentId);
+
+        controller = new TreemapViewController();
+        treemapCanvas = new Pane();
+
+        injectField("treemapCanvas", treemapCanvas);
+        controller.initViewModel(viewModel);
+    }
+
+    // --- handleCellClick tests ---
+
+    @Test
+    @DisplayName("handleCellClick selects the given note")
+    void handleCellClick_selectsNote() {
+        NoteDisplayItem item = viewModel.createChildNote("Clickable");
+
+        controller.handleCellClick(item);
+
+        assertEquals(item.getId(),
+                viewModel.selectedNoteIdProperty().get(),
+                "handleCellClick should select the note");
+    }
+
+    @Test
+    @DisplayName("handleCellClick updates selection when clicking different note")
+    void handleCellClick_updatesSelection() {
+        NoteDisplayItem first = viewModel.createChildNote("First");
+        NoteDisplayItem second = viewModel.createChildNote("Second");
+
+        controller.handleCellClick(first);
+        assertEquals(first.getId(),
+                viewModel.selectedNoteIdProperty().get());
+
+        controller.handleCellClick(second);
+        assertEquals(second.getId(),
+                viewModel.selectedNoteIdProperty().get(),
+                "Selection should update to second note");
+    }
+
+    // --- handleCellDoubleClick tests ---
+
+    @Test
+    @DisplayName("handleCellDoubleClick drills down into the note")
+    void handleCellDoubleClick_drillsDown() {
+        NoteDisplayItem container = viewModel.createChildNote("Container");
+        noteService.createChildNote(container.getId(), "Grandchild");
+
+        assertFalse(viewModel.canNavigateBackProperty().get(),
+                "Should start at root");
+
+        controller.handleCellDoubleClick(container);
+
+        assertTrue(viewModel.canNavigateBackProperty().get(),
+                "handleCellDoubleClick should drill down");
+    }
+
+    @Test
+    @DisplayName("handleCellDoubleClick changes base to drilled note's children")
+    void handleCellDoubleClick_changesBaseNote() {
+        NoteDisplayItem container = viewModel.createChildNote("Container");
+        noteService.createChildNote(container.getId(), "GrandchildA");
+        noteService.createChildNote(container.getId(), "GrandchildB");
+
+        controller.handleCellDoubleClick(container);
+
+        assertEquals(2, viewModel.getNoteItems().size(),
+                "After drill-down, should show grandchildren");
+    }
+
+    @Test
+    @DisplayName("handleCellDoubleClick then navigateBack restores original state")
+    void handleCellDoubleClick_thenBack_restoresState() {
+        NoteDisplayItem container = viewModel.createChildNote("Container");
+        viewModel.createChildNote("Sibling");
+        noteService.createChildNote(container.getId(), "Grandchild");
+
+        int originalCount = viewModel.getNoteItems().size();
+
+        controller.handleCellDoubleClick(container);
+        viewModel.navigateBack();
+
+        assertEquals(originalCount, viewModel.getNoteItems().size(),
+                "After drill-down + back, should restore original notes");
+    }
+
+    // --- Helper methods ---
+
+    private void injectField(String fieldName, Object value) {
+        try {
+            var field = TreemapViewController.class
+                    .getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(controller, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract inline lambda event handlers from MapViewController, OutlineViewController, and TreemapViewController into named package-private methods
- Add 19 new tests across 3 test classes that call handlers directly with synthetic events (no TestFX robot needed for logic testing)
- All files remain at/under 500-line checkstyle limit

### Extracted methods
| Controller | Method | Replaces |
|---|---|---|
| MapViewController | `handleScrollZoom(ScrollEvent)` | inline scroll lambda with zoom factor calculation |
| MapViewController | `handleKeyPress(KeyEvent)` | inline key press lambda with Enter/Escape dispatch |
| OutlineViewController | `handleTreeKeyPress(KeyEvent)` | inline key press lambda for Escape navigation |
| OutlineViewController | `handleTreeSelection(TreeItem)` | inline selection change listener |
| TreemapViewController | `handleCellClick(NoteDisplayItem)` | inline mouse press handler for selection |
| TreemapViewController | `handleCellDoubleClick(NoteDisplayItem)` | inline mouse click handler for drill-down |

## Test plan
- [x] 19 new handler tests pass (8 MapViewController, 6 OutlineViewController, 5 TreemapViewController)
- [x] All existing UI tests pass (`mvn verify -Pui-tests`)
- [x] Checkstyle clean (0 violations)
- [x] JaCoCo coverage thresholds met
- [x] ArchUnit architecture rules pass

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)