### PR TITLE
Extract ZoomTierRenderer strategy for per-tier rendering

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -28,14 +28,11 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
-import javafx.scene.text.TextAlignment;
 import javafx.scene.transform.Scale;
 import javafx.util.Duration;
 import org.slf4j.Logger;
@@ -47,13 +44,10 @@ public class MapViewController {
     private static final Logger LOG = LoggerFactory.getLogger(MapViewController.class);
     private static final double SELECTED_BORDER_WIDTH = 3.0;
     private static final double NORMAL_BORDER_WIDTH = 1.0;
-    private static final double TITLE_FONT_SIZE = 14.0;
-    private static final double CONTENT_FONT_SIZE = 11.0;
     private static final double BADGE_FONT_SIZE = 16.0;
 
     private static final double BACK_BUTTON_PADDING = 5.0;
     private static final double SCROLL_ZOOM_FACTOR = 1.1;
-    private static final double DETAILED_CONTENT_FONT_SIZE = 14.0;
     private static final double ZOOM_PERCENTAGE = 100.0;
 
     @FXML private Pane mapCanvas;
@@ -314,64 +308,11 @@ public class MapViewController {
 
     private StackPane createNoteNode(NoteDisplayItem item) {
         ZoomTier tier = viewModel.getCurrentTier();
-        Rectangle rect = new Rectangle(item.getWidth(), item.getHeight());
-        rect.setFill(Color.web(item.getColorHex()));
-        rect.setStroke(currentColors != null
-                ? Color.web(currentColors.borderColor()) : Color.BLACK);
-        rect.setStrokeWidth(NORMAL_BORDER_WIDTH);
-        rect.setArcWidth(4);
-        rect.setArcHeight(4);
+        String borderColor = currentColors != null
+                ? currentColors.borderColor() : "#000000";
+        ZoomTierRenderer renderer = tier.createRenderer();
+        StackPane notePane = renderer.render(item, borderColor);
 
-        StackPane notePane;
-        if (!tier.isShowTitle()) {
-            notePane = new StackPane(rect);
-            notePane.setAlignment(Pos.TOP_LEFT);
-        } else {
-            double fontSize = tier.getTitleFontSize();
-            Label titleLabel = new Label(item.getTitle());
-            titleLabel.setFont(Font.font("System", FontWeight.BOLD, fontSize));
-            titleLabel.setTextFill(Color.web(
-                    ViewColorConfig.contrastTextColor(item.getColorHex())));
-            titleLabel.setTextAlignment(TextAlignment.LEFT);
-            titleLabel.setAlignment(Pos.TOP_LEFT);
-            titleLabel.setMaxWidth(item.getWidth() - 8);
-            titleLabel.setWrapText(true);
-            titleLabel.setMouseTransparent(false);
-            titleLabel.setPadding(new Insets(4, 4, 2, 4));
-            VBox textBox = new VBox(titleLabel);
-            if (tier.isShowContent()) {
-                String content = item.getContent();
-                if (content != null && !content.isEmpty()) {
-                    double contentSize = tier == ZoomTier.DETAILED
-                            ? DETAILED_CONTENT_FONT_SIZE : CONTENT_FONT_SIZE;
-                    Label contentLabel = new Label(content);
-                    contentLabel.setFont(Font.font("System", contentSize));
-                    contentLabel.setTextFill(Color.web(
-                            ViewColorConfig.contrastTextColor(
-                                    item.getColorHex())));
-                    contentLabel.setTextAlignment(TextAlignment.LEFT);
-                    contentLabel.setAlignment(Pos.TOP_LEFT);
-                    contentLabel.setMaxWidth(item.getWidth() - 8);
-                    contentLabel.setMaxHeight(Double.MAX_VALUE);
-                    contentLabel.setWrapText(true);
-                    contentLabel.setMouseTransparent(true);
-                    contentLabel.setPadding(new Insets(0, 4, 4, 4));
-                    VBox.setVgrow(contentLabel, Priority.ALWAYS);
-                    textBox.getChildren().add(contentLabel);
-                }
-            }
-            textBox.setMaxWidth(item.getWidth());
-            textBox.setMaxHeight(item.getHeight());
-            textBox.setAlignment(Pos.TOP_LEFT);
-            Rectangle clip = new Rectangle(item.getWidth(), item.getHeight());
-            textBox.setClip(clip);
-            notePane = new StackPane(rect, textBox);
-            notePane.setAlignment(Pos.TOP_LEFT);
-            String badge = item.getBadge();
-            if (tier.isShowBadge() && badge != null && !badge.isEmpty()) {
-                notePane.getChildren().add(createBadgeLabel(badge, item));
-            }
-        }
         notePane.setUserData(item.getId());
         notePane.setLayoutX(item.getXpos());
         notePane.setLayoutY(item.getYpos());
@@ -381,12 +322,15 @@ public class MapViewController {
             if (event.getClickCount() == 2
                     && event.getButton() == MouseButton.PRIMARY
                     && !dragging[0]) {
-                if (tier.isShowTitle() && notePane.getChildren().size() > 1) {
+                if (tier.isShowTitle()
+                        && notePane.getChildren().size() > 1) {
                     VBox tb = (VBox) notePane.getChildren().get(1);
                     Label tl = (Label) tb.getChildren().get(0);
-                    Rectangle rc = (Rectangle) notePane.getChildren().get(0);
+                    Rectangle rc =
+                            (Rectangle) notePane.getChildren().get(0);
                     if (event.getTarget() == tl
-                            || isDescendantOf(event.getTarget(), tl)) {
+                            || isDescendantOf(
+                                    event.getTarget(), tl)) {
                         InlineEditHelper.startInlineEdit(
                                 notePane, tl, rc, item, viewModel,
                                 mapCanvas);
@@ -399,7 +343,10 @@ public class MapViewController {
                 event.consume();
             }
         });
-        if (item.getId().equals(viewModel.selectedNoteIdProperty().get())) {
+        if (item.getId().equals(
+                viewModel.selectedNoteIdProperty().get())) {
+            Rectangle rect =
+                    (Rectangle) notePane.getChildren().get(0);
             rect.setStrokeWidth(SELECTED_BORDER_WIDTH);
             rect.setStroke(currentColors != null
                     ? Color.web(currentColors.selectionColor())

--- a/src/main/java/com/embervault/adapter/in/ui/view/ZoomTierRenderer.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/ZoomTierRenderer.java
@@ -1,0 +1,207 @@
+package com.embervault.adapter.in.ui.view;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.effect.DropShadow;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
+import javafx.scene.text.TextAlignment;
+
+/**
+ * Strategy interface for rendering a note at a specific zoom tier.
+ *
+ * <p>Each implementation produces a {@link StackPane} containing the
+ * visual elements appropriate for that tier. The caller is responsible
+ * for wiring event handlers on the returned pane.</p>
+ */
+public sealed interface ZoomTierRenderer
+        permits ZoomTierRenderer.OverviewRenderer,
+                ZoomTierRenderer.TitlesOnlyRenderer,
+                ZoomTierRenderer.NormalRenderer,
+                ZoomTierRenderer.DetailedRenderer {
+
+    /** Normal border width for note rectangles. */
+    double NORMAL_BORDER_WIDTH = 1.0;
+
+    /** Badge font size. */
+    double BADGE_FONT_SIZE = 16.0;
+
+    /**
+     * Renders a note display item as a StackPane.
+     *
+     * @param item        the note to render
+     * @param borderColor the border color hex string
+     * @return a StackPane containing the rendered note
+     */
+    StackPane render(NoteDisplayItem item, String borderColor);
+
+    /** Zoom &lt; 0.4: colored rectangles only, no text. */
+    record OverviewRenderer() implements ZoomTierRenderer {
+
+        @Override
+        public StackPane render(NoteDisplayItem item,
+                String borderColor) {
+            Rectangle rect = createRect(item, borderColor);
+            StackPane pane = new StackPane(rect);
+            pane.setAlignment(Pos.TOP_LEFT);
+            return pane;
+        }
+    }
+
+    /** 0.4 &le; zoom &lt; 0.8: title text only, compact font, badge. */
+    record TitlesOnlyRenderer() implements ZoomTierRenderer {
+
+        private static final int TITLE_FONT_SIZE = 10;
+
+        @Override
+        public StackPane render(NoteDisplayItem item,
+                String borderColor) {
+            Rectangle rect = createRect(item, borderColor);
+            Label titleLabel = createTitleLabel(
+                    item, TITLE_FONT_SIZE);
+            VBox textBox = createTextBox(item, titleLabel);
+            StackPane pane = new StackPane(rect, textBox);
+            pane.setAlignment(Pos.TOP_LEFT);
+            addBadgeIfPresent(pane, item);
+            return pane;
+        }
+    }
+
+    /** 0.8 &le; zoom &lt; 1.5: title (bold) + truncated content + badge. */
+    record NormalRenderer() implements ZoomTierRenderer {
+
+        private static final int TITLE_FONT_SIZE = 14;
+        private static final double CONTENT_FONT_SIZE = 11.0;
+
+        @Override
+        public StackPane render(NoteDisplayItem item,
+                String borderColor) {
+            Rectangle rect = createRect(item, borderColor);
+            Label titleLabel = createTitleLabel(
+                    item, TITLE_FONT_SIZE);
+            VBox textBox = createTextBox(item, titleLabel);
+            addContentIfPresent(textBox, item, CONTENT_FONT_SIZE);
+            StackPane pane = new StackPane(rect, textBox);
+            pane.setAlignment(Pos.TOP_LEFT);
+            addBadgeIfPresent(pane, item);
+            return pane;
+        }
+    }
+
+    /** Zoom &ge; 1.5: larger fonts, more content visible, badge. */
+    record DetailedRenderer() implements ZoomTierRenderer {
+
+        private static final int TITLE_FONT_SIZE = 18;
+        private static final double CONTENT_FONT_SIZE = 14.0;
+
+        @Override
+        public StackPane render(NoteDisplayItem item,
+                String borderColor) {
+            Rectangle rect = createRect(item, borderColor);
+            Label titleLabel = createTitleLabel(
+                    item, TITLE_FONT_SIZE);
+            VBox textBox = createTextBox(item, titleLabel);
+            addContentIfPresent(textBox, item, CONTENT_FONT_SIZE);
+            StackPane pane = new StackPane(rect, textBox);
+            pane.setAlignment(Pos.TOP_LEFT);
+            addBadgeIfPresent(pane, item);
+            return pane;
+        }
+    }
+
+    // ---- shared helper methods ----
+
+    /** Creates the background rectangle for a note. */
+    private static Rectangle createRect(NoteDisplayItem item,
+            String borderColor) {
+        Rectangle rect = new Rectangle(
+                item.getWidth(), item.getHeight());
+        rect.setFill(Color.web(item.getColorHex()));
+        rect.setStroke(Color.web(borderColor));
+        rect.setStrokeWidth(NORMAL_BORDER_WIDTH);
+        rect.setArcWidth(4);
+        rect.setArcHeight(4);
+        return rect;
+    }
+
+    /** Creates a bold title label with contrast text color. */
+    private static Label createTitleLabel(NoteDisplayItem item,
+            double fontSize) {
+        Label label = new Label(item.getTitle());
+        label.setFont(Font.font(
+                "System", FontWeight.BOLD, fontSize));
+        label.setTextFill(Color.web(
+                ViewColorConfig.contrastTextColor(
+                        item.getColorHex())));
+        label.setTextAlignment(TextAlignment.LEFT);
+        label.setAlignment(Pos.TOP_LEFT);
+        label.setMaxWidth(item.getWidth() - 8);
+        label.setWrapText(true);
+        label.setMouseTransparent(false);
+        label.setPadding(new Insets(4, 4, 2, 4));
+        return label;
+    }
+
+    /** Creates a clipped VBox containing the title label. */
+    private static VBox createTextBox(NoteDisplayItem item,
+            Label titleLabel) {
+        VBox textBox = new VBox(titleLabel);
+        textBox.setMaxWidth(item.getWidth());
+        textBox.setMaxHeight(item.getHeight());
+        textBox.setAlignment(Pos.TOP_LEFT);
+        Rectangle clip = new Rectangle(
+                item.getWidth(), item.getHeight());
+        textBox.setClip(clip);
+        return textBox;
+    }
+
+    /** Adds a content label to the text box if content is present. */
+    private static void addContentIfPresent(VBox textBox,
+            NoteDisplayItem item, double contentFontSize) {
+        String content = item.getContent();
+        if (content != null && !content.isEmpty()) {
+            Label contentLabel = new Label(content);
+            contentLabel.setFont(
+                    Font.font("System", contentFontSize));
+            contentLabel.setTextFill(Color.web(
+                    ViewColorConfig.contrastTextColor(
+                            item.getColorHex())));
+            contentLabel.setTextAlignment(TextAlignment.LEFT);
+            contentLabel.setAlignment(Pos.TOP_LEFT);
+            contentLabel.setMaxWidth(item.getWidth() - 8);
+            contentLabel.setMaxHeight(Double.MAX_VALUE);
+            contentLabel.setWrapText(true);
+            contentLabel.setMouseTransparent(true);
+            contentLabel.setPadding(new Insets(0, 4, 4, 4));
+            VBox.setVgrow(contentLabel, Priority.ALWAYS);
+            textBox.getChildren().add(contentLabel);
+        }
+    }
+
+    /** Adds a badge label to the pane if the item has a badge. */
+    private static void addBadgeIfPresent(StackPane pane,
+            NoteDisplayItem item) {
+        String badge = item.getBadge();
+        if (badge != null && !badge.isEmpty()) {
+            Label label = new Label(badge);
+            label.setFont(Font.font(BADGE_FONT_SIZE));
+            label.setTextFill(Color.web(
+                    ViewColorConfig.contrastTextColor(
+                            item.getColorHex())));
+            label.setEffect(
+                    new DropShadow(2, Color.gray(0.3, 0.6)));
+            label.setMouseTransparent(true);
+            StackPane.setAlignment(label, Pos.TOP_RIGHT);
+            StackPane.setMargin(label, new Insets(2, 4, 0, 0));
+            pane.getChildren().add(label);
+        }
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ZoomTier.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ZoomTier.java
@@ -1,5 +1,7 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import com.embervault.adapter.in.ui.view.ZoomTierRenderer;
+
 /**
  * Defines semantic zoom tiers for the Map view.
  *
@@ -56,6 +58,22 @@ public enum ZoomTier {
     /** Returns the title font size for this tier, or 0 if no title is shown. */
     public int getTitleFontSize() {
         return titleFontSize;
+    }
+
+    /**
+     * Creates the appropriate renderer for this zoom tier.
+     *
+     * @return a new ZoomTierRenderer for this tier
+     */
+    public ZoomTierRenderer createRenderer() {
+        return switch (this) {
+            case OVERVIEW -> new ZoomTierRenderer.OverviewRenderer();
+            case TITLES_ONLY ->
+                    new ZoomTierRenderer.TitlesOnlyRenderer();
+            case NORMAL -> new ZoomTierRenderer.NormalRenderer();
+            case DETAILED ->
+                    new ZoomTierRenderer.DetailedRenderer();
+        };
     }
 
     /**

--- a/src/test/java/com/embervault/adapter/in/ui/view/ZoomTierRendererTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/ZoomTierRendererTest.java
@@ -1,0 +1,327 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.view.ZoomTierRenderer.DetailedRenderer;
+import com.embervault.adapter.in.ui.view.ZoomTierRenderer.NormalRenderer;
+import com.embervault.adapter.in.ui.view.ZoomTierRenderer.OverviewRenderer;
+import com.embervault.adapter.in.ui.view.ZoomTierRenderer.TitlesOnlyRenderer;
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.ZoomTier;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.shape.Rectangle;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link ZoomTierRenderer} and its implementations.
+ *
+ * <p>Each renderer is tested in isolation without requiring
+ * MapViewController or a canvas.</p>
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class ZoomTierRendererTest {
+
+    private static final String BORDER_COLOR = "#000000";
+    private NoteDisplayItem item;
+    private NoteDisplayItem itemWithBadge;
+    private NoteDisplayItem itemWithContent;
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        item = new NoteDisplayItem(
+                UUID.randomUUID(), "Test Title", "",
+                10, 20, 200, 150, "#AABBCC", false, "");
+        itemWithBadge = new NoteDisplayItem(
+                UUID.randomUUID(), "Badged", "Some content",
+                10, 20, 200, 150, "#AABBCC", false, "\u2B50");
+        itemWithContent = new NoteDisplayItem(
+                UUID.randomUUID(), "Content Title", "Hello world",
+                10, 20, 200, 150, "#AABBCC", false, "");
+    }
+
+    @Nested
+    @DisplayName("OverviewRenderer")
+    class OverviewRendererTests {
+
+        @Test
+        @DisplayName("renders rectangle only, no text or badge")
+        void render_shouldReturnRectangleOnly() {
+            StackPane result = new OverviewRenderer()
+                    .render(item, BORDER_COLOR);
+
+            assertEquals(1, result.getChildren().size(),
+                    "OVERVIEW should have only a Rectangle");
+            assertInstanceOf(Rectangle.class,
+                    result.getChildren().get(0));
+        }
+
+        @Test
+        @DisplayName("rectangle uses item dimensions and color")
+        void render_shouldUseItemDimensions() {
+            StackPane result = new OverviewRenderer()
+                    .render(item, BORDER_COLOR);
+
+            Rectangle rect = (Rectangle) result.getChildren().get(0);
+            assertEquals(200, rect.getWidth());
+            assertEquals(150, rect.getHeight());
+        }
+
+        @Test
+        @DisplayName("badge is not rendered even when present")
+        void render_shouldIgnoreBadge() {
+            StackPane result = new OverviewRenderer()
+                    .render(itemWithBadge, BORDER_COLOR);
+
+            assertEquals(1, result.getChildren().size(),
+                    "OVERVIEW should not render badge");
+        }
+    }
+
+    @Nested
+    @DisplayName("TitlesOnlyRenderer")
+    class TitlesOnlyRendererTests {
+
+        @Test
+        @DisplayName("renders rectangle and title label, no content")
+        void render_shouldRenderTitleOnly() {
+            StackPane result = new TitlesOnlyRenderer()
+                    .render(itemWithContent, BORDER_COLOR);
+
+            assertInstanceOf(Rectangle.class,
+                    result.getChildren().get(0));
+            VBox textBox = findTextBox(result);
+            assertNotNull(textBox, "Should have a text VBox");
+            assertEquals(1, textBox.getChildren().size(),
+                    "Should have only title label, no content");
+            assertInstanceOf(Label.class,
+                    textBox.getChildren().get(0));
+            Label title = (Label) textBox.getChildren().get(0);
+            assertEquals("Content Title", title.getText());
+        }
+
+        @Test
+        @DisplayName("title font size is 10pt (compact)")
+        void render_shouldUseCompactFont() {
+            StackPane result = new TitlesOnlyRenderer()
+                    .render(item, BORDER_COLOR);
+
+            VBox textBox = findTextBox(result);
+            Label title = (Label) textBox.getChildren().get(0);
+            assertEquals(10.0, title.getFont().getSize(), 0.1);
+        }
+
+        @Test
+        @DisplayName("badge is rendered when present")
+        void render_shouldShowBadge() {
+            StackPane result = new TitlesOnlyRenderer()
+                    .render(itemWithBadge, BORDER_COLOR);
+
+            Label badge = findBadgeLabel(result);
+            assertNotNull(badge, "Badge should be rendered");
+            assertEquals("\u2B50", badge.getText());
+        }
+
+        @Test
+        @DisplayName("badge is not rendered when empty")
+        void render_shouldNotShowEmptyBadge() {
+            StackPane result = new TitlesOnlyRenderer()
+                    .render(item, BORDER_COLOR);
+
+            Label badge = findBadgeLabel(result);
+            assertNull(badge,
+                    "Badge should not be present for empty badge");
+        }
+    }
+
+    @Nested
+    @DisplayName("NormalRenderer")
+    class NormalRendererTests {
+
+        @Test
+        @DisplayName("renders rectangle, title, and content")
+        void render_shouldRenderTitleAndContent() {
+            StackPane result = new NormalRenderer()
+                    .render(itemWithContent, BORDER_COLOR);
+
+            assertInstanceOf(Rectangle.class,
+                    result.getChildren().get(0));
+            VBox textBox = findTextBox(result);
+            assertNotNull(textBox);
+            assertTrue(textBox.getChildren().size() >= 2,
+                    "Should have title and content labels");
+        }
+
+        @Test
+        @DisplayName("title font size is 14pt bold")
+        void render_shouldUseBoldFont() {
+            StackPane result = new NormalRenderer()
+                    .render(item, BORDER_COLOR);
+
+            VBox textBox = findTextBox(result);
+            Label title = (Label) textBox.getChildren().get(0);
+            assertEquals(14.0, title.getFont().getSize(), 0.1);
+        }
+
+        @Test
+        @DisplayName("content font size is 11pt")
+        void render_contentFontSize() {
+            StackPane result = new NormalRenderer()
+                    .render(itemWithContent, BORDER_COLOR);
+
+            VBox textBox = findTextBox(result);
+            Label content = (Label) textBox.getChildren().get(1);
+            assertEquals(11.0, content.getFont().getSize(), 0.1);
+        }
+
+        @Test
+        @DisplayName("badge is rendered when present")
+        void render_shouldShowBadge() {
+            StackPane result = new NormalRenderer()
+                    .render(itemWithBadge, BORDER_COLOR);
+
+            Label badge = findBadgeLabel(result);
+            assertNotNull(badge);
+            assertEquals("\u2B50", badge.getText());
+        }
+
+        @Test
+        @DisplayName("no content label when content is empty")
+        void render_shouldSkipEmptyContent() {
+            StackPane result = new NormalRenderer()
+                    .render(item, BORDER_COLOR);
+
+            VBox textBox = findTextBox(result);
+            assertEquals(1, textBox.getChildren().size(),
+                    "Should only have title when content is empty");
+        }
+    }
+
+    @Nested
+    @DisplayName("DetailedRenderer")
+    class DetailedRendererTests {
+
+        @Test
+        @DisplayName("renders rectangle, title, and content")
+        void render_shouldRenderTitleAndContent() {
+            StackPane result = new DetailedRenderer()
+                    .render(itemWithContent, BORDER_COLOR);
+
+            VBox textBox = findTextBox(result);
+            assertNotNull(textBox);
+            assertTrue(textBox.getChildren().size() >= 2,
+                    "Should have title and content labels");
+        }
+
+        @Test
+        @DisplayName("title font size is 18pt")
+        void render_shouldUseLargerTitleFont() {
+            StackPane result = new DetailedRenderer()
+                    .render(item, BORDER_COLOR);
+
+            VBox textBox = findTextBox(result);
+            Label title = (Label) textBox.getChildren().get(0);
+            assertEquals(18.0, title.getFont().getSize(), 0.1);
+        }
+
+        @Test
+        @DisplayName("content font size is 14pt (larger than normal)")
+        void render_shouldUseLargerContentFont() {
+            StackPane result = new DetailedRenderer()
+                    .render(itemWithContent, BORDER_COLOR);
+
+            VBox textBox = findTextBox(result);
+            Label content = (Label) textBox.getChildren().get(1);
+            assertEquals(14.0, content.getFont().getSize(), 0.1);
+        }
+
+        @Test
+        @DisplayName("badge is rendered when present")
+        void render_shouldShowBadge() {
+            StackPane result = new DetailedRenderer()
+                    .render(itemWithBadge, BORDER_COLOR);
+
+            Label badge = findBadgeLabel(result);
+            assertNotNull(badge);
+            assertEquals("\u2B50", badge.getText());
+            assertEquals(Pos.TOP_RIGHT,
+                    StackPane.getAlignment(badge));
+        }
+    }
+
+    @Nested
+    @DisplayName("ZoomTier.createRenderer()")
+    class ZoomTierCreateRendererTests {
+
+        @Test
+        @DisplayName("OVERVIEW creates OverviewRenderer")
+        void overview_createsOverviewRenderer() {
+            assertInstanceOf(OverviewRenderer.class,
+                    ZoomTier.OVERVIEW.createRenderer());
+        }
+
+        @Test
+        @DisplayName("TITLES_ONLY creates TitlesOnlyRenderer")
+        void titlesOnly_createsTitlesOnlyRenderer() {
+            assertInstanceOf(TitlesOnlyRenderer.class,
+                    ZoomTier.TITLES_ONLY.createRenderer());
+        }
+
+        @Test
+        @DisplayName("NORMAL creates NormalRenderer")
+        void normal_createsNormalRenderer() {
+            assertInstanceOf(NormalRenderer.class,
+                    ZoomTier.NORMAL.createRenderer());
+        }
+
+        @Test
+        @DisplayName("DETAILED creates DetailedRenderer")
+        void detailed_createsDetailedRenderer() {
+            assertInstanceOf(DetailedRenderer.class,
+                    ZoomTier.DETAILED.createRenderer());
+        }
+    }
+
+    /** Finds the VBox child within a StackPane. */
+    private VBox findTextBox(StackPane pane) {
+        for (Node child : pane.getChildren()) {
+            if (child instanceof VBox vbox) {
+                return vbox;
+            }
+        }
+        return null;
+    }
+
+    /** Finds a direct Label child of a StackPane (badge). */
+    private Label findBadgeLabel(StackPane pane) {
+        for (Node child : pane.getChildren()) {
+            if (child instanceof Label label) {
+                return label;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted per-zoom-tier rendering logic from `MapViewController.createNoteNode()` into a sealed `ZoomTierRenderer` interface with four record implementations: `OverviewRenderer`, `TitlesOnlyRenderer`, `NormalRenderer`, `DetailedRenderer`
- Added `ZoomTier.createRenderer()` factory method that returns the appropriate renderer for each tier
- MapViewController now delegates to `renderer.render(item, borderColor)` and only handles event wiring, reducing the controller from 500 to 447 lines

## Test plan
- [x] New `ZoomTierRendererTest` with nested test classes for each renderer (OverviewRenderer, TitlesOnlyRenderer, NormalRenderer, DetailedRenderer)
- [x] Tests verify node structure, font sizes, badge presence/absence without canvas or debounce
- [x] Tests for `ZoomTier.createRenderer()` mapping correctness
- [x] All 834 existing tests pass
- [x] Checkstyle clean

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)