### PR TITLE
Extract NoteNodeFactory from controllers for testable node creation

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactory.java
@@ -1,6 +1,8 @@
 package com.embervault.adapter.in.ui.view;
 
+import javafx.scene.Cursor;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
 import javafx.scene.shape.Line;
 
 /**
@@ -23,5 +25,15 @@ final class HyperbolicNodeFactory {
         line.setStrokeWidth(1.0);
         line.setMouseTransparent(true);
         return line;
+    }
+
+    static Circle createNodeCircle(
+            double cx, double cy, double radius, String colorHex) {
+        Circle circle = new Circle(cx, cy, radius);
+        circle.setFill(Color.web(colorHex));
+        circle.setStroke(Color.WHITE);
+        circle.setStrokeWidth(NORMAL_STROKE_WIDTH);
+        circle.setCursor(Cursor.HAND);
+        return circle;
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactory.java
@@ -1,9 +1,12 @@
 package com.embervault.adapter.in.ui.view;
 
 import javafx.scene.Cursor;
+import javafx.scene.control.Label;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Line;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
 
 /**
  * Factory for creating Hyperbolic view JavaFX nodes.
@@ -15,6 +18,7 @@ final class HyperbolicNodeFactory {
 
     static final double NORMAL_STROKE_WIDTH = 1.5;
     private static final double EDGE_OPACITY = 0.3;
+    private static final double LABEL_FONT_SIZE = 12.0;
 
     private HyperbolicNodeFactory() { }
 
@@ -35,5 +39,18 @@ final class HyperbolicNodeFactory {
         circle.setStrokeWidth(NORMAL_STROKE_WIDTH);
         circle.setCursor(Cursor.HAND);
         return circle;
+    }
+
+    static Label createNodeLabel(
+            String text, double cx, double cy, double radius) {
+        Label label = new Label(text);
+        label.setFont(Font.font("System", FontWeight.BOLD,
+                LABEL_FONT_SIZE));
+        label.setTextFill(Color.WHITE);
+        label.setMouseTransparent(true);
+        label.setLayoutX(cx - radius);
+        label.setLayoutY(cy - LABEL_FONT_SIZE / 2);
+        label.setMaxWidth(radius * 2);
+        return label;
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactory.java
@@ -1,0 +1,27 @@
+package com.embervault.adapter.in.ui.view;
+
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Line;
+
+/**
+ * Factory for creating Hyperbolic view JavaFX nodes.
+ *
+ * <p>Extracts node construction logic from {@link HyperbolicViewController}
+ * so it can be tested without a full scene graph.</p>
+ */
+final class HyperbolicNodeFactory {
+
+    static final double NORMAL_STROKE_WIDTH = 1.5;
+    private static final double EDGE_OPACITY = 0.3;
+
+    private HyperbolicNodeFactory() { }
+
+    static Line createEdgeLine(
+            double x1, double y1, double x2, double y2) {
+        Line line = new Line(x1, y1, x2, y2);
+        line.setStroke(Color.gray(0.6, EDGE_OPACITY));
+        line.setStrokeWidth(1.0);
+        line.setMouseTransparent(true);
+        return line;
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
@@ -40,7 +40,6 @@ public class HyperbolicViewController {
     private static final Logger LOG = LoggerFactory.getLogger(HyperbolicViewController.class);
     private static final double SMALL_NODE_THRESHOLD = 12.0;
     private static final double BACK_BUTTON_PADDING = 5.0;
-    private static final double EDGE_OPACITY = 0.3;
     private static final double LABEL_FONT_SIZE = 12.0;
     private static final double SELECTED_STROKE_WIDTH = 3.0;
     private static final double NORMAL_STROKE_WIDTH = 1.5;
@@ -187,10 +186,8 @@ public class HyperbolicViewController {
             double[] src = positionMap.get(edge.sourceId());
             double[] dst = positionMap.get(edge.destinationId());
             if (src != null && dst != null) {
-                Line line = new Line(src[0], src[1], dst[0], dst[1]);
-                line.setStroke(Color.gray(0.6, EDGE_OPACITY));
-                line.setStrokeWidth(1.0);
-                line.setMouseTransparent(true);
+                Line line = HyperbolicNodeFactory.createEdgeLine(
+                        src[0], src[1], dst[0], dst[1]);
                 hyperbolicCanvas.getChildren().add(line);
             }
         }

--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
@@ -12,7 +12,6 @@ import com.embervault.adapter.in.ui.viewmodel.HyperbolicViewModel;
 import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
-import javafx.scene.Cursor;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
@@ -197,11 +196,8 @@ public class HyperbolicViewController {
             double nx = centerX + node.x();
             double ny = centerY + node.y();
 
-            Circle circle = new Circle(nx, ny, node.displayRadius());
-            circle.setFill(Color.web("#4A90D9"));
-            circle.setStroke(Color.WHITE);
-            circle.setStrokeWidth(NORMAL_STROKE_WIDTH);
-            circle.setCursor(Cursor.HAND);
+            Circle circle = HyperbolicNodeFactory.createNodeCircle(
+                    nx, ny, node.displayRadius(), "#4A90D9");
             circle.setUserData(node.noteId());
 
             // Click to select

--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
@@ -22,8 +22,6 @@ import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Line;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +37,6 @@ public class HyperbolicViewController {
     private static final Logger LOG = LoggerFactory.getLogger(HyperbolicViewController.class);
     private static final double SMALL_NODE_THRESHOLD = 12.0;
     private static final double BACK_BUTTON_PADDING = 5.0;
-    private static final double LABEL_FONT_SIZE = 12.0;
     private static final double SELECTED_STROKE_WIDTH = 3.0;
     private static final double NORMAL_STROKE_WIDTH = 1.5;
 
@@ -228,13 +225,8 @@ public class HyperbolicViewController {
                 String title = noteTitle(node.noteId());
                 String badge = noteBadge(node.noteId());
                 String labelText = badge.isEmpty() ? title : badge + " " + title;
-                Label label = new Label(labelText);
-                label.setFont(Font.font("System", FontWeight.BOLD, LABEL_FONT_SIZE));
-                label.setTextFill(Color.WHITE);
-                label.setMouseTransparent(true);
-                label.setLayoutX(nx - node.displayRadius());
-                label.setLayoutY(ny - LABEL_FONT_SIZE / 2);
-                label.setMaxWidth(node.displayRadius() * 2);
+                Label label = HyperbolicNodeFactory.createNodeLabel(
+                        labelText, nx, ny, node.displayRadius());
                 hyperbolicCanvas.getChildren().add(label);
             } else {
                 // Tooltip for small nodes

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -17,7 +17,6 @@ import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
@@ -281,13 +280,8 @@ public class MapViewController {
         ZoomTier tier = viewModel.getCurrentTier();
         String borderColor = currentColors != null
                 ? currentColors.borderColor() : "#000000";
-        ZoomTierRenderer renderer = tier.createRenderer();
-        StackPane notePane = renderer.render(item, borderColor);
-
-        notePane.setUserData(item.getId());
-        notePane.setLayoutX(item.getXpos());
-        notePane.setLayoutY(item.getYpos());
-        notePane.setCursor(Cursor.HAND);
+        StackPane notePane = NoteNodeFactory.createRenderedNotePane(
+                item, tier, borderColor);
         final boolean[] dragging = enableDrag(notePane, item);
         notePane.setOnMouseClicked(event -> {
             if (event.getClickCount() == 2

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -23,7 +23,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
-import javafx.scene.effect.DropShadow;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
@@ -34,7 +33,6 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
-import javafx.scene.text.Font;
 import javafx.scene.transform.Scale;
 import javafx.util.Duration;
 import org.slf4j.Logger;
@@ -46,7 +44,6 @@ public class MapViewController {
     private static final Logger LOG = LoggerFactory.getLogger(MapViewController.class);
     private static final double SELECTED_BORDER_WIDTH = 3.0;
     private static final double NORMAL_BORDER_WIDTH = 1.0;
-    private static final double BADGE_FONT_SIZE = 16.0;
 
     private static final double BACK_BUTTON_PADDING = 5.0;
     private static final double SCROLL_ZOOM_FACTOR = 1.1;
@@ -304,7 +301,9 @@ public class MapViewController {
                 && notePane.getChildren().get(2) instanceof Label badgeLabel) {
             badgeLabel.setText(badge != null ? badge : "");
         } else if (tier.isShowBadge() && badge != null && !badge.isEmpty()) {
-            notePane.getChildren().add(createBadgeLabel(badge, item));
+            notePane.getChildren().add(
+                    NoteNodeFactory.createBadgeLabel(
+                            badge, item.getColorHex()));
         }
         if (item.getId().equals(viewModel.selectedNoteIdProperty().get())) {
             if (notePane.getChildren().get(0) instanceof Rectangle rect) {
@@ -393,16 +392,6 @@ public class MapViewController {
         return dragging;
     }
 
-    private Label createBadgeLabel(String badge, NoteDisplayItem item) {
-        Label l = new Label(badge);
-        l.setFont(Font.font(BADGE_FONT_SIZE));
-        l.setTextFill(Color.web(ViewColorConfig.contrastTextColor(item.getColorHex())));
-        l.setEffect(new DropShadow(2, Color.gray(0.3, 0.6)));
-        l.setMouseTransparent(true);
-        StackPane.setAlignment(l, Pos.TOP_RIGHT);
-        StackPane.setMargin(l, new Insets(2, 4, 0, 0));
-        return l;
-    }
 
     /** Checks if target is a descendant of ancestor. */
     private static boolean isDescendantOf(Object target, Node ancestor) {

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -267,44 +267,8 @@ public class MapViewController {
     }
 
     private void updateNoteNode(StackPane notePane, NoteDisplayItem item) {
-        notePane.setLayoutX(item.getXpos());
-        notePane.setLayoutY(item.getYpos());
-        if (notePane.getChildren().get(0) instanceof Rectangle rect) {
-            rect.setWidth(item.getWidth());
-            rect.setHeight(item.getHeight());
-            rect.setFill(Color.web(item.getColorHex()));
-        }
-        if (notePane.getChildren().size() > 1
-                && notePane.getChildren().get(1) instanceof VBox textBox) {
-            textBox.setMaxWidth(item.getWidth());
-            textBox.setMaxHeight(item.getHeight());
-            if (textBox.getClip() instanceof Rectangle clip) {
-                clip.setWidth(item.getWidth());
-                clip.setHeight(item.getHeight());
-            }
-            if (!textBox.getChildren().isEmpty()
-                    && textBox.getChildren().get(0) instanceof Label titleLabel) {
-                titleLabel.setText(item.getTitle());
-                titleLabel.setMaxWidth(item.getWidth() - 8);
-            }
-            if (textBox.getChildren().size() > 1
-                    && textBox.getChildren().get(1)
-                            instanceof Label contentLabel) {
-                contentLabel.setText(
-                        item.getContent() != null ? item.getContent() : "");
-                contentLabel.setMaxWidth(item.getWidth() - 8);
-            }
-        }
-        String badge = item.getBadge();
-        ZoomTier tier = viewModel.getCurrentTier();
-        if (notePane.getChildren().size() > 2
-                && notePane.getChildren().get(2) instanceof Label badgeLabel) {
-            badgeLabel.setText(badge != null ? badge : "");
-        } else if (tier.isShowBadge() && badge != null && !badge.isEmpty()) {
-            notePane.getChildren().add(
-                    NoteNodeFactory.createBadgeLabel(
-                            badge, item.getColorHex()));
-        }
+        NoteNodeFactory.updateNoteNode(
+                notePane, item, viewModel.getCurrentTier());
         if (item.getId().equals(viewModel.selectedNoteIdProperty().get())) {
             if (notePane.getChildren().get(0) instanceof Rectangle rect) {
                 rect.setStrokeWidth(SELECTED_BORDER_WIDTH);

--- a/src/main/java/com/embervault/adapter/in/ui/view/NoteNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/NoteNodeFactory.java
@@ -5,6 +5,7 @@ import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
 import com.embervault.adapter.in.ui.viewmodel.ZoomTier;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.control.Label;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.layout.StackPane;
@@ -80,5 +81,17 @@ final class NoteNodeFactory {
             notePane.getChildren().add(
                     createBadgeLabel(badge, item.getColorHex()));
         }
+    }
+
+    static StackPane createRenderedNotePane(
+            NoteDisplayItem item, ZoomTier tier,
+            String borderColor) {
+        ZoomTierRenderer renderer = tier.createRenderer();
+        StackPane notePane = renderer.render(item, borderColor);
+        notePane.setUserData(item.getId());
+        notePane.setLayoutX(item.getXpos());
+        notePane.setLayoutY(item.getYpos());
+        notePane.setCursor(Cursor.HAND);
+        return notePane;
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/view/NoteNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/NoteNodeFactory.java
@@ -1,0 +1,35 @@
+package com.embervault.adapter.in.ui.view;
+
+import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.effect.DropShadow;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+
+/**
+ * Factory for creating Map view JavaFX nodes.
+ *
+ * <p>Extracts node construction logic from {@link MapViewController}
+ * so it can be tested without a full scene graph.</p>
+ */
+final class NoteNodeFactory {
+
+    private static final double BADGE_FONT_SIZE = 16.0;
+
+    private NoteNodeFactory() { }
+
+    static Label createBadgeLabel(String badge, String colorHex) {
+        Label l = new Label(badge);
+        l.setFont(Font.font(BADGE_FONT_SIZE));
+        l.setTextFill(Color.web(
+                ViewColorConfig.contrastTextColor(colorHex)));
+        l.setEffect(new DropShadow(2, Color.gray(0.3, 0.6)));
+        l.setMouseTransparent(true);
+        StackPane.setAlignment(l, Pos.TOP_RIGHT);
+        StackPane.setMargin(l, new Insets(2, 4, 0, 0));
+        return l;
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/NoteNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/NoteNodeFactory.java
@@ -1,12 +1,16 @@
 package com.embervault.adapter.in.ui.view;
 
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
 import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
+import com.embervault.adapter.in.ui.viewmodel.ZoomTier;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 
 /**
@@ -31,5 +35,50 @@ final class NoteNodeFactory {
         StackPane.setAlignment(l, Pos.TOP_RIGHT);
         StackPane.setMargin(l, new Insets(2, 4, 0, 0));
         return l;
+    }
+
+    static void updateNoteNode(
+            StackPane notePane, NoteDisplayItem item, ZoomTier tier) {
+        notePane.setLayoutX(item.getXpos());
+        notePane.setLayoutY(item.getYpos());
+        if (notePane.getChildren().get(0) instanceof Rectangle rect) {
+            rect.setWidth(item.getWidth());
+            rect.setHeight(item.getHeight());
+            rect.setFill(Color.web(item.getColorHex()));
+        }
+        if (notePane.getChildren().size() > 1
+                && notePane.getChildren().get(1)
+                        instanceof VBox textBox) {
+            textBox.setMaxWidth(item.getWidth());
+            textBox.setMaxHeight(item.getHeight());
+            if (textBox.getClip() instanceof Rectangle clip) {
+                clip.setWidth(item.getWidth());
+                clip.setHeight(item.getHeight());
+            }
+            if (!textBox.getChildren().isEmpty()
+                    && textBox.getChildren().get(0)
+                            instanceof Label titleLabel) {
+                titleLabel.setText(item.getTitle());
+                titleLabel.setMaxWidth(item.getWidth() - 8);
+            }
+            if (textBox.getChildren().size() > 1
+                    && textBox.getChildren().get(1)
+                            instanceof Label contentLabel) {
+                contentLabel.setText(
+                        item.getContent() != null
+                                ? item.getContent() : "");
+                contentLabel.setMaxWidth(item.getWidth() - 8);
+            }
+        }
+        String badge = item.getBadge();
+        if (notePane.getChildren().size() > 2
+                && notePane.getChildren().get(2)
+                        instanceof Label badgeLabel) {
+            badgeLabel.setText(badge != null ? badge : "");
+        } else if (tier.isShowBadge()
+                && badge != null && !badge.isEmpty()) {
+            notePane.getChildren().add(
+                    createBadgeLabel(badge, item.getColorHex()));
+        }
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/view/TreemapNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TreemapNodeFactory.java
@@ -1,5 +1,18 @@
 package com.embervault.adapter.in.ui.view;
 
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.TreemapRect;
+import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
+import javafx.scene.text.TextAlignment;
+
 /**
  * Factory for creating Treemap view JavaFX nodes.
  *
@@ -12,8 +25,60 @@ final class TreemapNodeFactory {
     static final double RECT_PADDING = 2.0;
     static final double NORMAL_BORDER_WIDTH = 1.0;
     private static final int MAX_LABEL_LENGTH = 30;
+    private static final double MIN_BADGE_WIDTH = 30;
+    private static final double MIN_BADGE_HEIGHT = 20;
 
     private TreemapNodeFactory() { }
+
+    static StackPane createTreemapCell(
+            NoteDisplayItem item, TreemapRect tr, String borderColor) {
+        double rectWidth = Math.max(0, tr.width() - RECT_PADDING * 2);
+        double rectHeight = Math.max(0, tr.height() - RECT_PADDING * 2);
+
+        Rectangle rect = new Rectangle(rectWidth, rectHeight);
+        rect.setFill(Color.web(item.getColorHex()));
+        rect.setStroke(Color.web(borderColor));
+        rect.setStrokeWidth(NORMAL_BORDER_WIDTH);
+        rect.setArcWidth(4);
+        rect.setArcHeight(4);
+
+        String labelText = truncateLabel(item.getTitle(), rectWidth);
+        Label titleLabel = new Label(labelText);
+        titleLabel.setFont(Font.font("System", FontWeight.BOLD,
+                TITLE_FONT_SIZE));
+        titleLabel.setTextFill(Color.web(
+                ViewColorConfig.contrastTextColor(item.getColorHex())));
+        titleLabel.setTextAlignment(TextAlignment.CENTER);
+        titleLabel.setAlignment(Pos.CENTER);
+        titleLabel.setMaxWidth(rectWidth - 4);
+        titleLabel.setMaxHeight(rectHeight - 4);
+        titleLabel.setWrapText(true);
+        titleLabel.setPadding(new Insets(2));
+        titleLabel.setMouseTransparent(true);
+
+        Rectangle clip = new Rectangle(rectWidth, rectHeight);
+        StackPane notePane = new StackPane(rect, titleLabel);
+
+        String badge = item.getBadge();
+        if (badge != null && !badge.isEmpty()
+                && rectWidth > MIN_BADGE_WIDTH
+                && rectHeight > MIN_BADGE_HEIGHT) {
+            Label badgeLabel = new Label(badge);
+            badgeLabel.setFont(Font.font("System", TITLE_FONT_SIZE));
+            badgeLabel.setMouseTransparent(true);
+            badgeLabel.setPadding(new Insets(2, 4, 0, 0));
+            StackPane.setAlignment(badgeLabel, Pos.TOP_RIGHT);
+            notePane.getChildren().add(badgeLabel);
+        }
+
+        notePane.setClip(clip);
+        notePane.setUserData(item.getId());
+        notePane.setAlignment(Pos.CENTER);
+        notePane.setLayoutX(tr.x() + RECT_PADDING);
+        notePane.setLayoutY(tr.y() + RECT_PADDING);
+
+        return notePane;
+    }
 
     static String truncateLabel(String title, double availableWidth) {
         double charsPerWidth = availableWidth / (TITLE_FONT_SIZE * 0.6);

--- a/src/main/java/com/embervault/adapter/in/ui/view/TreemapNodeFactory.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TreemapNodeFactory.java
@@ -1,0 +1,29 @@
+package com.embervault.adapter.in.ui.view;
+
+/**
+ * Factory for creating Treemap view JavaFX nodes.
+ *
+ * <p>Extracts node construction logic from {@link TreemapViewController}
+ * so it can be tested without a full scene graph.</p>
+ */
+final class TreemapNodeFactory {
+
+    static final double TITLE_FONT_SIZE = 13.0;
+    static final double RECT_PADDING = 2.0;
+    static final double NORMAL_BORDER_WIDTH = 1.0;
+    private static final int MAX_LABEL_LENGTH = 30;
+
+    private TreemapNodeFactory() { }
+
+    static String truncateLabel(String title, double availableWidth) {
+        double charsPerWidth = availableWidth / (TITLE_FONT_SIZE * 0.6);
+        int maxChars = Math.min(MAX_LABEL_LENGTH, (int) charsPerWidth);
+        if (maxChars <= 0) {
+            return "";
+        }
+        if (title.length() <= maxChars) {
+            return title;
+        }
+        return title.substring(0, maxChars) + "\u2026";
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
@@ -13,12 +13,9 @@ import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
-import javafx.geometry.Insets;
-import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
-import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
@@ -26,9 +23,6 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
-import javafx.scene.text.TextAlignment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +38,6 @@ public class TreemapViewController {
     private static final Logger LOG = LoggerFactory.getLogger(TreemapViewController.class);
     private static final double SELECTED_BORDER_WIDTH = 3.0;
     private static final double NORMAL_BORDER_WIDTH = 1.0;
-    private static final double TITLE_FONT_SIZE = 13.0;
-    private static final double RECT_PADDING = 2.0;
     private static final double BACK_BUTTON_PADDING = 5.0;
 
     @FXML private Pane treemapCanvas;
@@ -162,51 +154,10 @@ public class TreemapViewController {
     }
 
     private StackPane createNoteNode(NoteDisplayItem item, TreemapRect tr) {
-        double rectWidth = Math.max(0, tr.width() - RECT_PADDING * 2);
-        double rectHeight = Math.max(0, tr.height() - RECT_PADDING * 2);
-
-        Rectangle rect = new Rectangle(rectWidth, rectHeight);
-        rect.setFill(Color.web(item.getColorHex()));
-        rect.setStroke(currentColors != null
-                ? Color.web(currentColors.borderColor()) : Color.BLACK);
-        rect.setStrokeWidth(NORMAL_BORDER_WIDTH);
-        rect.setArcWidth(4);
-        rect.setArcHeight(4);
-
-        String labelText = TreemapNodeFactory.truncateLabel(
-                item.getTitle(), rectWidth);
-        Label titleLabel = new Label(labelText);
-        titleLabel.setFont(Font.font("System", FontWeight.BOLD,
-                TITLE_FONT_SIZE));
-        titleLabel.setTextFill(Color.web(
-                ViewColorConfig.contrastTextColor(item.getColorHex())));
-        titleLabel.setTextAlignment(TextAlignment.CENTER);
-        titleLabel.setAlignment(Pos.CENTER);
-        titleLabel.setMaxWidth(rectWidth - 4);
-        titleLabel.setMaxHeight(rectHeight - 4);
-        titleLabel.setWrapText(true);
-        titleLabel.setPadding(new Insets(2));
-        titleLabel.setMouseTransparent(true);
-
-        Rectangle clip = new Rectangle(rectWidth, rectHeight);
-        StackPane notePane = new StackPane(rect, titleLabel);
-
-        // Badge in top-right corner if space permits
-        String badge = item.getBadge();
-        if (badge != null && !badge.isEmpty() && rectWidth > 30 && rectHeight > 20) {
-            Label badgeLabel = new Label(badge);
-            badgeLabel.setFont(Font.font("System", TITLE_FONT_SIZE));
-            badgeLabel.setMouseTransparent(true);
-            badgeLabel.setPadding(new Insets(2, 4, 0, 0));
-            StackPane.setAlignment(badgeLabel, Pos.TOP_RIGHT);
-            notePane.getChildren().add(badgeLabel);
-        }
-
-        notePane.setClip(clip);
-        notePane.setUserData(item.getId());
-        notePane.setAlignment(Pos.CENTER);
-        notePane.setLayoutX(tr.x() + RECT_PADDING);
-        notePane.setLayoutY(tr.y() + RECT_PADDING);
+        String borderColor = currentColors != null
+                ? currentColors.borderColor() : "#000000";
+        StackPane notePane = TreemapNodeFactory.createTreemapCell(
+                item, tr, borderColor);
 
         // Click to select
         notePane.setOnMousePressed(event -> {
@@ -225,6 +176,8 @@ public class TreemapViewController {
 
         // Highlight if currently selected
         if (item.getId().equals(viewModel.selectedNoteIdProperty().get())) {
+            Rectangle rect =
+                    (Rectangle) notePane.getChildren().get(0);
             rect.setStrokeWidth(SELECTED_BORDER_WIDTH);
             rect.setStroke(currentColors != null
                     ? Color.web(currentColors.selectionColor())

--- a/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
@@ -47,7 +47,6 @@ public class TreemapViewController {
     private static final double TITLE_FONT_SIZE = 13.0;
     private static final double RECT_PADDING = 2.0;
     private static final double BACK_BUTTON_PADDING = 5.0;
-    private static final int MAX_LABEL_LENGTH = 30;
 
     @FXML private Pane treemapCanvas;
 
@@ -174,7 +173,8 @@ public class TreemapViewController {
         rect.setArcWidth(4);
         rect.setArcHeight(4);
 
-        String labelText = truncateLabel(item.getTitle(), rectWidth);
+        String labelText = TreemapNodeFactory.truncateLabel(
+                item.getTitle(), rectWidth);
         Label titleLabel = new Label(labelText);
         titleLabel.setFont(Font.font("System", FontWeight.BOLD,
                 TITLE_FONT_SIZE));
@@ -234,18 +234,6 @@ public class TreemapViewController {
         return notePane;
     }
 
-    private String truncateLabel(String title, double availableWidth) {
-        double charsPerWidth = availableWidth / (TITLE_FONT_SIZE * 0.6);
-        int maxChars = Math.min(MAX_LABEL_LENGTH,
-                (int) charsPerWidth);
-        if (maxChars <= 0) {
-            return "";
-        }
-        if (title.length() <= maxChars) {
-            return title;
-        }
-        return title.substring(0, maxChars) + "\u2026";
-    }
 
     private void highlightSelected(StackPane selected) {
         Color borderCol = currentColors != null

--- a/src/test/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactoryTest.java
@@ -1,0 +1,61 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Line;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link HyperbolicNodeFactory}.
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class HyperbolicNodeFactoryTest {
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @Nested
+    @DisplayName("createEdgeLine")
+    class CreateEdgeLineTests {
+
+        @Test
+        @DisplayName("creates line with correct coordinates")
+        void createEdgeLine_shouldSetCoordinates() {
+            Line line = HyperbolicNodeFactory.createEdgeLine(
+                    10, 20, 30, 40);
+            assertEquals(10, line.getStartX());
+            assertEquals(20, line.getStartY());
+            assertEquals(30, line.getEndX());
+            assertEquals(40, line.getEndY());
+        }
+
+        @Test
+        @DisplayName("line is mouse transparent")
+        void createEdgeLine_shouldBeMouseTransparent() {
+            Line line = HyperbolicNodeFactory.createEdgeLine(
+                    0, 0, 100, 100);
+            assertTrue(line.isMouseTransparent());
+        }
+
+        @Test
+        @DisplayName("line has gray stroke")
+        void createEdgeLine_shouldHaveGrayStroke() {
+            Line line = HyperbolicNodeFactory.createEdgeLine(
+                    0, 0, 100, 100);
+            assertEquals(1.0, line.getStrokeWidth());
+            assertTrue(line.getStroke() instanceof Color);
+        }
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactoryTest.java
@@ -3,7 +3,9 @@ package com.embervault.adapter.in.ui.view;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import javafx.scene.Cursor;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
 import javafx.scene.shape.Line;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.DisplayName;
@@ -56,6 +58,47 @@ class HyperbolicNodeFactoryTest {
                     0, 0, 100, 100);
             assertEquals(1.0, line.getStrokeWidth());
             assertTrue(line.getStroke() instanceof Color);
+        }
+    }
+
+    @Nested
+    @DisplayName("createNodeCircle")
+    class CreateNodeCircleTests {
+
+        @Test
+        @DisplayName("creates circle at specified position with radius")
+        void createNodeCircle_shouldSetPositionAndRadius() {
+            Circle circle = HyperbolicNodeFactory.createNodeCircle(
+                    100, 200, 15, "#4A90D9");
+            assertEquals(100, circle.getCenterX());
+            assertEquals(200, circle.getCenterY());
+            assertEquals(15, circle.getRadius());
+        }
+
+        @Test
+        @DisplayName("circle fill uses provided color hex")
+        void createNodeCircle_shouldUseFillColor() {
+            Circle circle = HyperbolicNodeFactory.createNodeCircle(
+                    0, 0, 10, "#FF0000");
+            assertEquals(Color.web("#FF0000"), circle.getFill());
+        }
+
+        @Test
+        @DisplayName("circle has white stroke")
+        void createNodeCircle_shouldHaveWhiteStroke() {
+            Circle circle = HyperbolicNodeFactory.createNodeCircle(
+                    0, 0, 10, "#4A90D9");
+            assertEquals(Color.WHITE, circle.getStroke());
+            assertEquals(HyperbolicNodeFactory.NORMAL_STROKE_WIDTH,
+                    circle.getStrokeWidth());
+        }
+
+        @Test
+        @DisplayName("circle cursor is HAND")
+        void createNodeCircle_shouldHaveHandCursor() {
+            Circle circle = HyperbolicNodeFactory.createNodeCircle(
+                    0, 0, 10, "#4A90D9");
+            assertEquals(Cursor.HAND, circle.getCursor());
         }
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/HyperbolicNodeFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javafx.scene.Cursor;
+import javafx.scene.control.Label;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Line;
@@ -99,6 +100,51 @@ class HyperbolicNodeFactoryTest {
             Circle circle = HyperbolicNodeFactory.createNodeCircle(
                     0, 0, 10, "#4A90D9");
             assertEquals(Cursor.HAND, circle.getCursor());
+        }
+    }
+
+    @Nested
+    @DisplayName("createNodeLabel")
+    class CreateNodeLabelTests {
+
+        @Test
+        @DisplayName("creates label with specified text")
+        void createNodeLabel_shouldSetText() {
+            Label label = HyperbolicNodeFactory.createNodeLabel(
+                    "Test Note", 100, 200, 20);
+            assertEquals("Test Note", label.getText());
+        }
+
+        @Test
+        @DisplayName("label is mouse transparent")
+        void createNodeLabel_shouldBeMouseTransparent() {
+            Label label = HyperbolicNodeFactory.createNodeLabel(
+                    "Test", 100, 200, 20);
+            assertTrue(label.isMouseTransparent());
+        }
+
+        @Test
+        @DisplayName("label has white text fill")
+        void createNodeLabel_shouldHaveWhiteFill() {
+            Label label = HyperbolicNodeFactory.createNodeLabel(
+                    "Test", 100, 200, 20);
+            assertEquals(Color.WHITE, label.getTextFill());
+        }
+
+        @Test
+        @DisplayName("label position is relative to circle center")
+        void createNodeLabel_shouldPositionRelativeToCircle() {
+            Label label = HyperbolicNodeFactory.createNodeLabel(
+                    "Test", 100, 200, 20);
+            assertEquals(80, label.getLayoutX()); // cx - radius
+        }
+
+        @Test
+        @DisplayName("label maxWidth is 2x radius")
+        void createNodeLabel_shouldSetMaxWidth() {
+            Label label = HyperbolicNodeFactory.createNodeLabel(
+                    "Test", 100, 200, 25);
+            assertEquals(50, label.getMaxWidth()); // radius * 2
         }
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/view/NoteNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/NoteNodeFactoryTest.java
@@ -1,0 +1,73 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.effect.DropShadow;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link NoteNodeFactory}.
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class NoteNodeFactoryTest {
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @Nested
+    @DisplayName("createBadgeLabel")
+    class CreateBadgeLabelTests {
+
+        @Test
+        @DisplayName("creates label with badge text")
+        void createBadgeLabel_shouldSetText() {
+            Label label = NoteNodeFactory.createBadgeLabel(
+                    "\u2605", "#AABBCC");
+            assertEquals("\u2605", label.getText());
+        }
+
+        @Test
+        @DisplayName("label has drop shadow effect")
+        void createBadgeLabel_shouldHaveDropShadow() {
+            Label label = NoteNodeFactory.createBadgeLabel(
+                    "\u2605", "#AABBCC");
+            assertInstanceOf(DropShadow.class, label.getEffect());
+        }
+
+        @Test
+        @DisplayName("label is mouse transparent")
+        void createBadgeLabel_shouldBeMouseTransparent() {
+            Label label = NoteNodeFactory.createBadgeLabel(
+                    "\u2605", "#AABBCC");
+            assertTrue(label.isMouseTransparent());
+        }
+
+        @Test
+        @DisplayName("label is aligned TOP_RIGHT with margin")
+        void createBadgeLabel_shouldAlignTopRight() {
+            Label label = NoteNodeFactory.createBadgeLabel(
+                    "\u2605", "#AABBCC");
+            assertEquals(Pos.TOP_RIGHT,
+                    StackPane.getAlignment(label));
+            Insets margin = StackPane.getMargin(label);
+            assertEquals(2, margin.getTop());
+            assertEquals(4, margin.getRight());
+        }
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/NoteNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/NoteNodeFactoryTest.java
@@ -4,12 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.ZoomTier;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -68,6 +76,101 @@ class NoteNodeFactoryTest {
             Insets margin = StackPane.getMargin(label);
             assertEquals(2, margin.getTop());
             assertEquals(4, margin.getRight());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateNoteNode")
+    class UpdateNoteNodeTests {
+
+        private NoteDisplayItem originalItem;
+        private StackPane notePane;
+
+        @BeforeEach
+        void setUp() {
+            originalItem = new NoteDisplayItem(
+                    UUID.randomUUID(), "Original", "Content",
+                    10, 20, 200, 150, "#AABBCC", false, "");
+            ZoomTierRenderer renderer =
+                    ZoomTier.NORMAL.createRenderer();
+            notePane = renderer.render(originalItem, "#000000");
+        }
+
+        @Test
+        @DisplayName("updates position to new coordinates")
+        void updateNoteNode_shouldUpdatePosition() {
+            NoteDisplayItem updated = new NoteDisplayItem(
+                    originalItem.getId(), "Original", "Content",
+                    50, 60, 200, 150, "#AABBCC", false, "");
+            NoteNodeFactory.updateNoteNode(
+                    notePane, updated, ZoomTier.NORMAL);
+            assertEquals(50, notePane.getLayoutX());
+            assertEquals(60, notePane.getLayoutY());
+        }
+
+        @Test
+        @DisplayName("updates rectangle dimensions and fill")
+        void updateNoteNode_shouldUpdateRectangle() {
+            NoteDisplayItem updated = new NoteDisplayItem(
+                    originalItem.getId(), "Original", "Content",
+                    10, 20, 300, 250, "#FF0000", false, "");
+            NoteNodeFactory.updateNoteNode(
+                    notePane, updated, ZoomTier.NORMAL);
+            Rectangle rect =
+                    (Rectangle) notePane.getChildren().get(0);
+            assertEquals(300, rect.getWidth());
+            assertEquals(250, rect.getHeight());
+            assertEquals(Color.web("#FF0000"), rect.getFill());
+        }
+
+        @Test
+        @DisplayName("updates title label text")
+        void updateNoteNode_shouldUpdateTitle() {
+            NoteDisplayItem updated = new NoteDisplayItem(
+                    originalItem.getId(), "New Title", "Content",
+                    10, 20, 200, 150, "#AABBCC", false, "");
+            NoteNodeFactory.updateNoteNode(
+                    notePane, updated, ZoomTier.NORMAL);
+            VBox textBox =
+                    (VBox) notePane.getChildren().get(1);
+            Label titleLabel =
+                    (Label) textBox.getChildren().get(0);
+            assertEquals("New Title", titleLabel.getText());
+        }
+
+        @Test
+        @DisplayName("adds badge when tier shows badges")
+        void updateNoteNode_shouldAddBadge() {
+            NoteDisplayItem updated = new NoteDisplayItem(
+                    originalItem.getId(), "Original", "Content",
+                    10, 20, 200, 150, "#AABBCC", false, "\u2605");
+            NoteNodeFactory.updateNoteNode(
+                    notePane, updated, ZoomTier.NORMAL);
+            assertTrue(notePane.getChildren().size() > 2,
+                    "Expected badge label to be added");
+            Label badge =
+                    (Label) notePane.getChildren().get(2);
+            assertEquals("\u2605", badge.getText());
+        }
+
+        @Test
+        @DisplayName("updates existing badge text")
+        void updateNoteNode_shouldUpdateExistingBadge() {
+            // First add a badge
+            NoteDisplayItem withBadge = new NoteDisplayItem(
+                    originalItem.getId(), "Original", "Content",
+                    10, 20, 200, 150, "#AABBCC", false, "\u2605");
+            NoteNodeFactory.updateNoteNode(
+                    notePane, withBadge, ZoomTier.NORMAL);
+            // Now update the badge
+            NoteDisplayItem newBadge = new NoteDisplayItem(
+                    originalItem.getId(), "Original", "Content",
+                    10, 20, 200, 150, "#AABBCC", false, "\u2713");
+            NoteNodeFactory.updateNoteNode(
+                    notePane, newBadge, ZoomTier.NORMAL);
+            Label badge =
+                    (Label) notePane.getChildren().get(2);
+            assertEquals("\u2713", badge.getText());
         }
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/view/NoteNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/NoteNodeFactoryTest.java
@@ -2,6 +2,7 @@ package com.embervault.adapter.in.ui.view;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
@@ -10,6 +11,7 @@ import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
 import com.embervault.adapter.in.ui.viewmodel.ZoomTier;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.control.Label;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.layout.StackPane;
@@ -171,6 +173,71 @@ class NoteNodeFactoryTest {
             Label badge =
                     (Label) notePane.getChildren().get(2);
             assertEquals("\u2713", badge.getText());
+        }
+    }
+
+    @Nested
+    @DisplayName("createRenderedNotePane")
+    class CreateRenderedNotePaneTests {
+
+        @Test
+        @DisplayName("delegates rendering to ZoomTierRenderer")
+        void createRenderedNotePane_shouldDelegateToRenderer() {
+            NoteDisplayItem item = new NoteDisplayItem(
+                    UUID.randomUUID(), "Test", "Content",
+                    10, 20, 200, 150, "#AABBCC", false, "");
+            StackPane pane = NoteNodeFactory.createRenderedNotePane(
+                    item, ZoomTier.NORMAL, "#000000");
+            assertNotNull(pane);
+            assertInstanceOf(Rectangle.class,
+                    pane.getChildren().get(0));
+        }
+
+        @Test
+        @DisplayName("sets layoutX and layoutY from item position")
+        void createRenderedNotePane_shouldSetPosition() {
+            NoteDisplayItem item = new NoteDisplayItem(
+                    UUID.randomUUID(), "Test", "",
+                    50, 75, 200, 150, "#AABBCC", false, "");
+            StackPane pane = NoteNodeFactory.createRenderedNotePane(
+                    item, ZoomTier.NORMAL, "#000000");
+            assertEquals(50, pane.getLayoutX());
+            assertEquals(75, pane.getLayoutY());
+        }
+
+        @Test
+        @DisplayName("sets userData to item id")
+        void createRenderedNotePane_shouldSetUserData() {
+            UUID id = UUID.randomUUID();
+            NoteDisplayItem item = new NoteDisplayItem(
+                    id, "Test", "",
+                    0, 0, 200, 150, "#AABBCC", false, "");
+            StackPane pane = NoteNodeFactory.createRenderedNotePane(
+                    item, ZoomTier.NORMAL, "#000000");
+            assertEquals(id, pane.getUserData());
+        }
+
+        @Test
+        @DisplayName("sets cursor to HAND")
+        void createRenderedNotePane_shouldSetCursor() {
+            NoteDisplayItem item = new NoteDisplayItem(
+                    UUID.randomUUID(), "Test", "",
+                    0, 0, 200, 150, "#AABBCC", false, "");
+            StackPane pane = NoteNodeFactory.createRenderedNotePane(
+                    item, ZoomTier.NORMAL, "#000000");
+            assertEquals(Cursor.HAND, pane.getCursor());
+        }
+
+        @Test
+        @DisplayName("OVERVIEW tier renders rectangle only")
+        void createRenderedNotePane_overviewShouldBeMinimal() {
+            NoteDisplayItem item = new NoteDisplayItem(
+                    UUID.randomUUID(), "Test", "",
+                    0, 0, 200, 150, "#AABBCC", false, "");
+            StackPane pane = NoteNodeFactory.createRenderedNotePane(
+                    item, ZoomTier.OVERVIEW, "#000000");
+            assertEquals(1, pane.getChildren().size(),
+                    "OVERVIEW should only have Rectangle");
         }
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/view/TreemapNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/TreemapNodeFactoryTest.java
@@ -1,8 +1,20 @@
 package com.embervault.adapter.in.ui.view;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.NoteDisplayItem;
+import com.embervault.adapter.in.ui.viewmodel.TreemapRect;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -39,8 +51,12 @@ class TreemapNodeFactoryTest {
         void truncateLabel_shouldTruncateWithEllipsis() {
             String result = TreemapNodeFactory.truncateLabel(
                     "This is a very long title that should be truncated", 50);
-            assertTrue(result.endsWith("\u2026"));
-            assertTrue(result.length() < "This is a very long title that should be truncated".length());
+            assertTrue(result.endsWith("\u2026"),
+                    "Expected ellipsis at end");
+            assertTrue(result.length()
+                    < "This is a very long title that should be truncated"
+                            .length(),
+                    "Expected truncation");
         }
 
         @Test
@@ -55,13 +71,109 @@ class TreemapNodeFactoryTest {
         void truncateLabel_shouldRespectMaxLength() {
             String longTitle = "A".repeat(50);
             String result = TreemapNodeFactory.truncateLabel(longTitle, 1000);
-            // MAX_LABEL_LENGTH is 30, so should truncate
-            assertTrue(result.length() <= 31); // 30 chars + ellipsis
-            assertTrue(result.endsWith("\u2026"));
+            assertTrue(result.length() <= 31,
+                    "Expected max 31 chars (30 + ellipsis)");
+            assertTrue(result.endsWith("\u2026"),
+                    "Expected ellipsis at end");
+        }
+    }
+
+    @Nested
+    @DisplayName("createTreemapCell")
+    class CreateTreemapCellTests {
+
+        private static final String BORDER_COLOR = "#000000";
+        private NoteDisplayItem item;
+        private TreemapRect rect;
+
+        @BeforeEach
+        void setUp() {
+            UUID id = UUID.randomUUID();
+            item = new NoteDisplayItem(
+                    id, "Test Note", "",
+                    0, 0, 200, 150, "#AABBCC", false, "");
+            rect = new TreemapRect(id, 10, 20, 200, 150);
         }
 
-        private void assertTrue(boolean condition) {
-            org.junit.jupiter.api.Assertions.assertTrue(condition);
+        @Test
+        @DisplayName("creates StackPane with Rectangle and title Label")
+        void createTreemapCell_shouldCreateRectAndTitle() {
+            StackPane pane = TreemapNodeFactory.createTreemapCell(
+                    item, rect, BORDER_COLOR);
+            assertNotNull(pane);
+            assertTrue(pane.getChildren().size() >= 2,
+                    "Expected at least Rectangle + Label");
+            assertInstanceOf(Rectangle.class,
+                    pane.getChildren().get(0));
+            assertInstanceOf(Label.class,
+                    pane.getChildren().get(1));
+        }
+
+        @Test
+        @DisplayName("rectangle uses item color and border color")
+        void createTreemapCell_shouldUseItemColor() {
+            StackPane pane = TreemapNodeFactory.createTreemapCell(
+                    item, rect, BORDER_COLOR);
+            Rectangle r = (Rectangle) pane.getChildren().get(0);
+            assertEquals(Color.web("#AABBCC"), r.getFill());
+            assertEquals(Color.web(BORDER_COLOR), r.getStroke());
+        }
+
+        @Test
+        @DisplayName("sets position from TreemapRect with padding")
+        void createTreemapCell_shouldSetPosition() {
+            StackPane pane = TreemapNodeFactory.createTreemapCell(
+                    item, rect, BORDER_COLOR);
+            assertEquals(10 + TreemapNodeFactory.RECT_PADDING,
+                    pane.getLayoutX());
+            assertEquals(20 + TreemapNodeFactory.RECT_PADDING,
+                    pane.getLayoutY());
+        }
+
+        @Test
+        @DisplayName("sets userData to item id")
+        void createTreemapCell_shouldSetUserData() {
+            StackPane pane = TreemapNodeFactory.createTreemapCell(
+                    item, rect, BORDER_COLOR);
+            assertEquals(item.getId(), pane.getUserData());
+        }
+
+        @Test
+        @DisplayName("badge label added when badge present and space sufficient")
+        void createTreemapCell_shouldAddBadgeWhenPresent() {
+            NoteDisplayItem badgeItem = new NoteDisplayItem(
+                    UUID.randomUUID(), "Test", "",
+                    0, 0, 200, 150, "#AABBCC", false, "\u2605");
+            TreemapRect bigRect = new TreemapRect(
+                    badgeItem.getId(), 0, 0, 200, 150);
+            StackPane pane = TreemapNodeFactory.createTreemapCell(
+                    badgeItem, bigRect, BORDER_COLOR);
+            assertEquals(3, pane.getChildren().size(),
+                    "Expected Rectangle + Title + Badge");
+            Label badge = (Label) pane.getChildren().get(2);
+            assertEquals("\u2605", badge.getText());
+        }
+
+        @Test
+        @DisplayName("badge omitted when rectangle too small")
+        void createTreemapCell_shouldOmitBadgeWhenTooSmall() {
+            NoteDisplayItem badgeItem = new NoteDisplayItem(
+                    UUID.randomUUID(), "Test", "",
+                    0, 0, 20, 15, "#AABBCC", false, "\u2605");
+            TreemapRect smallRect = new TreemapRect(
+                    badgeItem.getId(), 0, 0, 20, 15);
+            StackPane pane = TreemapNodeFactory.createTreemapCell(
+                    badgeItem, smallRect, BORDER_COLOR);
+            assertEquals(2, pane.getChildren().size(),
+                    "Expected only Rectangle + Title, no badge");
+        }
+
+        @Test
+        @DisplayName("clip rectangle matches cell dimensions")
+        void createTreemapCell_shouldSetClip() {
+            StackPane pane = TreemapNodeFactory.createTreemapCell(
+                    item, rect, BORDER_COLOR);
+            assertInstanceOf(Rectangle.class, pane.getClip());
         }
     }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/view/TreemapNodeFactoryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/TreemapNodeFactoryTest.java
@@ -1,0 +1,67 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javafx.stage.Stage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+/**
+ * Tests for {@link TreemapNodeFactory}.
+ */
+@Tag("ui")
+@ExtendWith(ApplicationExtension.class)
+class TreemapNodeFactoryTest {
+
+    @Start
+    private void start(Stage stage) {
+        stage.show();
+    }
+
+    @Nested
+    @DisplayName("truncateLabel")
+    class TruncateLabelTests {
+
+        @Test
+        @DisplayName("returns full title when it fits within width")
+        void truncateLabel_shouldReturnFullTitle() {
+            String result = TreemapNodeFactory.truncateLabel("Hello", 200);
+            assertEquals("Hello", result);
+        }
+
+        @Test
+        @DisplayName("truncates with ellipsis when title exceeds width")
+        void truncateLabel_shouldTruncateWithEllipsis() {
+            String result = TreemapNodeFactory.truncateLabel(
+                    "This is a very long title that should be truncated", 50);
+            assertTrue(result.endsWith("\u2026"));
+            assertTrue(result.length() < "This is a very long title that should be truncated".length());
+        }
+
+        @Test
+        @DisplayName("returns empty string when width is zero")
+        void truncateLabel_shouldReturnEmptyForZeroWidth() {
+            String result = TreemapNodeFactory.truncateLabel("Hello", 0);
+            assertEquals("", result);
+        }
+
+        @Test
+        @DisplayName("respects max label length even with wide width")
+        void truncateLabel_shouldRespectMaxLength() {
+            String longTitle = "A".repeat(50);
+            String result = TreemapNodeFactory.truncateLabel(longTitle, 1000);
+            // MAX_LABEL_LENGTH is 30, so should truncate
+            assertTrue(result.length() <= 31); // 30 chars + ellipsis
+            assertTrue(result.endsWith("\u2026"));
+        }
+
+        private void assertTrue(boolean condition) {
+            org.junit.jupiter.api.Assertions.assertTrue(condition);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `TreemapNodeFactory` from `TreemapViewController` (`truncateLabel`, `createTreemapCell`)
- Extract `HyperbolicNodeFactory` from `HyperbolicViewController` (`createEdgeLine`, `createNodeCircle`, `createNodeLabel`)
- Extract `NoteNodeFactory` from `MapViewController` (`createBadgeLabel`, `updateNoteNode`, `createRenderedNotePane`)
- Controllers now delegate to factories for visual node construction, keeping only event wiring and selection highlighting

## Line count reductions
- MapViewController: 500 → 393 (-107)
- TreemapViewController: 271 → 222 (-49)
- HyperbolicViewController: 307 → 292 (-15)

## Test plan
- [x] All 1074 tests pass (`mvn verify -Pui-tests`)
- [x] JaCoCo coverage thresholds met
- [x] Checkstyle clean
- [x] Each factory has focused unit tests (16 TDD commits)
- [x] Existing controller tests still pass after extraction

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)