### PR TITLE
Fix context menu view switching on view pane

### DIFF
--- a/src/main/java/com/embervault/ViewPaneContext.java
+++ b/src/main/java/com/embervault/ViewPaneContext.java
@@ -56,6 +56,7 @@ public final class ViewPaneContext {
     private ViewType currentViewType;
     private UUID baseNoteId;
     private Runnable currentViewRefresh = () -> { };
+    private ContextMenu labelContextMenu;
 
     /**
      * Creates a new ViewPaneContext with the given initial state.
@@ -87,9 +88,16 @@ public final class ViewPaneContext {
         label.textProperty().bind(titleProperty);
         label.setStyle(
                 "-fx-font-weight: bold; -fx-padding: 4 8;");
-        label.setContextMenu(buildContextMenu());
+        this.labelContextMenu = buildContextMenu();
+        label.setContextMenu(labelContextMenu);
 
         this.container = new VBox(label, initialView);
+        container.setOnContextMenuRequested(event -> {
+            if (event.getTarget() != label) {
+                labelContextMenu.show(container,
+                        event.getScreenX(), event.getScreenY());
+            }
+        });
         VBox.setVgrow(initialView, Priority.ALWAYS);
     }
 
@@ -260,7 +268,8 @@ public final class ViewPaneContext {
 
         label.textProperty().bind(newTitleProp);
         currentViewType = newType;
-        label.setContextMenu(buildContextMenu());
+        labelContextMenu = buildContextMenu();
+        label.setContextMenu(labelContextMenu);
     }
 
     private ContextMenu buildContextMenu() {

--- a/src/test/java/com/embervault/ViewPaneContextTest.java
+++ b/src/test/java/com/embervault/ViewPaneContextTest.java
@@ -246,4 +246,23 @@ class ViewPaneContextTest {
         assertTrue(paneContext.getLabel().getText()
                 .startsWith("Treemap:"));
     }
+
+    @Test
+    @DisplayName("container has context menu request handler")
+    void container_shouldHaveContextMenuHandler() {
+        VBox container = paneContext.getContainer();
+        assertNotNull(container.getOnContextMenuRequested(),
+                "Container should handle context menu requests");
+    }
+
+    @Test
+    @DisplayName("context menu item action triggers view switch")
+    void contextMenuItem_shouldTriggerSwitch() {
+        ContextMenu menu = paneContext.getLabel()
+                .getContextMenu();
+        // Fire the OUTLINE menu item action (index 1)
+        menu.getItems().get(1).fire();
+        assertEquals(ViewType.OUTLINE,
+                paneContext.getCurrentViewType());
+    }
 }


### PR DESCRIPTION
## Summary
- Context menu was only attached to the title label, not the view content area
- Users right-clicking on the canvas (Map, Outline, etc.) got no menu
- Now the container VBox handles `onContextMenuRequested` and shows the view-switching menu
- Added test for context menu item action triggering view switch

## Test plan
- [x] All 1135 tests pass (`mvn verify -Pui-tests`)
- [x] New test: container has context menu request handler
- [x] New test: context menu item action triggers view switch
- [x] Checkstyle clean, coverage met

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)