### PR TITLE
Fix view switching: wire setOnViewSwitch on initial controllers

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -73,9 +73,11 @@ public class App extends Application {
         OutlineViewModel outlineViewModel = new OutlineViewModel(
                 rootNoteTitle, noteService);
         outlineViewModel.setBaseNoteId(project.getRootNote().getId());
-        Parent outlineView = loadView("OutlineView.fxml", c ->
-                ((OutlineViewController) c)
-                        .initViewModel(outlineViewModel));
+        var outlineCtrl = new OutlineViewController[1];
+        Parent outlineView = loadView("OutlineView.fxml", c -> {
+            outlineCtrl[0] = (OutlineViewController) c;
+            outlineCtrl[0].initViewModel(outlineViewModel);
+        });
 
         // Search
         SearchViewModel searchViewModel = new SearchViewModel(noteService);
@@ -106,6 +108,8 @@ public class App extends Application {
                 outlineViewModel.tabTitleProperty(), outlineView,
                 project.getRootNote().getId(),
                 outlineViewModel::loadNotes);
+        outlineCtrl[0].setOnViewSwitch(name ->
+                outlinePane.switchView(ViewType.valueOf(name)));
         Runnable localRefresh = () -> {
             outlinePane.refreshCurrentView();
             UUID selId = selectedNoteVm.selectedNoteIdProperty().get();

--- a/src/main/java/com/embervault/WindowFactory.java
+++ b/src/main/java/com/embervault/WindowFactory.java
@@ -58,8 +58,11 @@ public final class WindowFactory {
         MapViewModel mapVm = new MapViewModel(
                 rootNoteTitle, noteService);
         mapVm.setBaseNoteId(project.getRootNote().getId());
-        Parent mapView = loadView("MapView.fxml",
-                c -> ((MapViewController) c).initViewModel(mapVm));
+        var mapCtrl = new MapViewController[1];
+        Parent mapView = loadView("MapView.fxml", c -> {
+            mapCtrl[0] = (MapViewController) c;
+            mapCtrl[0].initViewModel(mapVm);
+        });
         SelectedNoteViewModel selectedNoteVm =
                 new SelectedNoteViewModel(noteService);
         FXMLLoader textPaneLoader = new FXMLLoader(
@@ -75,6 +78,8 @@ public final class WindowFactory {
                 mapVm.tabTitleProperty(), mapView,
                 project.getRootNote().getId(),
                 mapVm::loadNotes);
+        mapCtrl[0].setOnViewSwitch(name ->
+                mapPane.switchView(ViewType.valueOf(name)));
         Runnable localRefresh = () -> {
             mapPane.refreshCurrentView();
             UUID selId = selectedNoteVm.selectedNoteIdProperty().get();


### PR DESCRIPTION
## Summary
The initial controllers created in `App.start()` and `WindowFactory.openNewWindow()` were never getting `setOnViewSwitch()` called. This meant the "Switch to Map/Outline/Treemap/..." context menu items in the controller's own context menu did nothing — clicking them had no effect because `onViewSwitch` was null.

**Root cause:** Controllers are created before their `ViewPaneContext` exists, and the wiring was only done inside `ViewPaneContext.doSwitchView()` (which runs on subsequent switches, not the initial one).

**Fix:** Capture the controller reference during FXML loading and wire `setOnViewSwitch` immediately after the `ViewPaneContext` is created — in both `App.start()` (OutlineViewController) and `WindowFactory.openNewWindow()` (MapViewController).

## Test plan
- [x] `mvn verify` passes (all logic tests)
- [x] Checkstyle clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)