### PR TITLE
Fix view switching: wire setOnViewSwitch before initViewModel

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -73,9 +73,14 @@ public class App extends Application {
         OutlineViewModel outlineViewModel = new OutlineViewModel(
                 rootNoteTitle, noteService);
         outlineViewModel.setBaseNoteId(project.getRootNote().getId());
-        Parent outlineView = loadView("OutlineView.fxml", c ->
-                ((OutlineViewController) c)
-                        .initViewModel(outlineViewModel));
+        var paneHolder = new ViewPaneContext[1];
+        Parent outlineView = loadView("OutlineView.fxml", c -> {
+            OutlineViewController ctrl = (OutlineViewController) c;
+            ctrl.setOnViewSwitch(name ->
+                    paneHolder[0].switchView(
+                            ViewType.valueOf(name)));
+            ctrl.initViewModel(outlineViewModel);
+        });
 
         // Search
         SearchViewModel searchViewModel = new SearchViewModel(noteService);
@@ -106,6 +111,7 @@ public class App extends Application {
                 outlineViewModel.tabTitleProperty(), outlineView,
                 project.getRootNote().getId(),
                 outlineViewModel::loadNotes);
+        paneHolder[0] = outlinePane;
         Runnable localRefresh = () -> {
             outlinePane.refreshCurrentView();
             UUID selId = selectedNoteVm.selectedNoteIdProperty().get();

--- a/src/main/java/com/embervault/WindowFactory.java
+++ b/src/main/java/com/embervault/WindowFactory.java
@@ -58,8 +58,14 @@ public final class WindowFactory {
         MapViewModel mapVm = new MapViewModel(
                 rootNoteTitle, noteService);
         mapVm.setBaseNoteId(project.getRootNote().getId());
-        Parent mapView = loadView("MapView.fxml",
-                c -> ((MapViewController) c).initViewModel(mapVm));
+        var paneHolder = new ViewPaneContext[1];
+        Parent mapView = loadView("MapView.fxml", c -> {
+            MapViewController ctrl = (MapViewController) c;
+            ctrl.setOnViewSwitch(name ->
+                    paneHolder[0].switchView(
+                            ViewType.valueOf(name)));
+            ctrl.initViewModel(mapVm);
+        });
         SelectedNoteViewModel selectedNoteVm =
                 new SelectedNoteViewModel(noteService);
         FXMLLoader textPaneLoader = new FXMLLoader(
@@ -75,6 +81,7 @@ public final class WindowFactory {
                 mapVm.tabTitleProperty(), mapView,
                 project.getRootNote().getId(),
                 mapVm::loadNotes);
+        paneHolder[0] = mapPane;
         Runnable localRefresh = () -> {
             mapPane.refreshCurrentView();
             UUID selId = selectedNoteVm.selectedNoteIdProperty().get();


### PR DESCRIPTION
## Summary
The context menu with "Switch to Map/Outline/Treemap/..." items is built during `initViewModel()` — specifically when the controller calls `createContextMenu()` which uses `ViewSwitchMenuHelper.createViewSwitchItems(currentType, onViewSwitch)`. If `onViewSwitch` is null at that point, the menu items get no action handler and clicking them does nothing.

**Root cause:** `setOnViewSwitch` was never called on the initial controllers created in `App.start()` and `WindowFactory.openNewWindow()`. PR #190 tried to fix this by calling it *after* `initViewModel`, but by then the context menu was already built with null callbacks.

**Fix:** Wire `setOnViewSwitch` *before* `initViewModel` using a deferred `ViewPaneContext[]` holder. The lambda captures the array reference; the array slot is filled when the `ViewPaneContext` is created (after `loadView` returns). By the time the user clicks a menu item, the holder is populated.

## Changes
- `App.start()`: wire `setOnViewSwitch` on OutlineViewController before `initViewModel`, fill `paneHolder[0]` after ViewPaneContext creation
- `WindowFactory.openNewWindow()`: same pattern for MapViewController

## Test plan
- [x] `mvn verify` passes
- [x] Checkstyle clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)