### PR TITLE
Enforce 80% instruction / 40% branch coverage with no exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,10 +304,6 @@
                                     </limits>
                                 </rule>
                             </rules>
-                            <excludes>
-                                <exclude>com/embervault/App.class</exclude>
-                                <exclude>com/embervault/adapter/in/ui/view/**</exclude>
-                            </excludes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary
- Remove JaCoCo exclusions for `App.class` and `adapter.in.ui.view/**`
- All packages now meet 80% instruction / 40% branch thresholds without exclusions
- JaCoCo config already uses INSTRUCTION counter (not LINE) at 0.80 and BRANCH at 0.40

## Test plan
- [x] `mvn verify` passes with no exclusions
- [x] Coverage checks met across all packages

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)