### PR TITLE
Store stamps in root note and set name to directory on save

### DIFF
--- a/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
@@ -11,6 +11,8 @@ import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
 import com.embervault.domain.AttributeSchemaRegistry;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
 import com.embervault.domain.Note;
 import com.embervault.domain.Project;
 import org.slf4j.Logger;
@@ -79,11 +81,19 @@ public final class ProjectFileManager {
                 }
             }
 
-            // Stamps
-            FileStampRepository stampRepo =
-                    new FileStampRepository(dir);
-            for (var stamp : stampService.getAllStamps()) {
-                stampRepo.save(stamp);
+            // Stamps stored as $Stamps attribute on root note
+            java.util.List<String> stampEntries =
+                    stampService.getAllStamps().stream()
+                            .map(s -> s.id() + "|"
+                                    + s.name() + "|"
+                                    + s.action())
+                            .toList();
+            if (!stampEntries.isEmpty()) {
+                project.getRootNote().setAttribute(
+                        Attributes.STAMPS,
+                        new AttributeValue.ListValue(
+                                stampEntries));
+                noteRepo.save(project.getRootNote());
             }
 
             LOG.info("Project saved to {}", dir);

--- a/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
@@ -46,6 +46,11 @@ public final class ProjectFileManager {
         try {
             Files.createDirectories(dir);
 
+            // Set root note name to directory name
+            String dirName = dir.getFileName().toString();
+            project.getRootNote().update(dirName,
+                    project.getRootNote().getContent());
+
             // project.yaml
             String projectYaml = "id: \""
                     + project.getId() + "\"\n"

--- a/src/main/java/com/embervault/domain/Attributes.java
+++ b/src/main/java/com/embervault/domain/Attributes.java
@@ -48,6 +48,9 @@ public final class Attributes {
     // Web
     public static final String URL = "$URL";
 
+    // Project metadata
+    public static final String STAMPS = "$Stamps";
+
     private Attributes() {
         // utility class
     }

--- a/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
@@ -1,12 +1,12 @@
 package com.embervault.adapter.out.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
-import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
-import com.embervault.adapter.out.persistence.InMemoryStampRepository;
 import com.embervault.application.LinkServiceImpl;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.ProjectServiceImpl;
@@ -50,5 +50,47 @@ class ProjectFileManagerTest {
 
         assertEquals("My Project",
                 project.getRootNote().getTitle());
+    }
+
+    @Test
+    @DisplayName("save stores stamps in root note, "
+            + "not stamps.yaml")
+    void save_storesStampsInRootNote(@TempDir Path tmp) {
+        Path projectDir = tmp.resolve("TestProject");
+        InMemoryNoteRepository noteRepo =
+                new InMemoryNoteRepository();
+        NoteService noteService =
+                new NoteServiceImpl(noteRepo);
+        LinkService linkService = new LinkServiceImpl(
+                new InMemoryLinkRepository());
+        StampService stampService = new StampServiceImpl(
+                new InMemoryStampRepository(), noteRepo);
+        Project project =
+                new ProjectServiceImpl().createEmptyProject();
+        noteRepo.save(project.getRootNote());
+        AttributeSchemaRegistry registry =
+                new AttributeSchemaRegistry();
+
+        stampService.createStamp("Color:red", "$Color=red");
+        stampService.createStamp("Mark Done",
+                "$Checked=true");
+
+        ProjectFileManager.save(projectDir, project,
+                noteService, linkService, stampService,
+                registry);
+
+        // stamps.yaml should NOT exist
+        assertFalse(Files.exists(
+                projectDir.resolve("stamps.yaml")),
+                "stamps.yaml should not exist");
+
+        // Root note should contain stamps in its file
+        Path rootFile = projectDir.resolve("notes")
+                .resolve(project.getRootNote().getId()
+                        .toString().substring(0, 8))
+                .resolve(project.getRootNote().getId()
+                        + ".md");
+        assertTrue(Files.exists(rootFile),
+                "Root note file should exist");
     }
 }

--- a/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
@@ -1,0 +1,54 @@
+package com.embervault.adapter.out.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+
+import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.adapter.out.persistence.InMemoryStampRepository;
+import com.embervault.application.LinkServiceImpl;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.ProjectServiceImpl;
+import com.embervault.application.StampServiceImpl;
+import com.embervault.application.port.in.LinkService;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.application.port.in.StampService;
+import com.embervault.domain.AttributeSchemaRegistry;
+import com.embervault.domain.Project;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link ProjectFileManager}.
+ */
+class ProjectFileManagerTest {
+
+    @Test
+    @DisplayName("save sets root note name to directory name")
+    void save_setsRootNoteNameToDirectoryName(
+            @TempDir Path tmp) {
+        Path projectDir = tmp.resolve("My Project");
+        InMemoryNoteRepository noteRepo =
+                new InMemoryNoteRepository();
+        NoteService noteService =
+                new NoteServiceImpl(noteRepo);
+        LinkService linkService = new LinkServiceImpl(
+                new InMemoryLinkRepository());
+        StampService stampService = new StampServiceImpl(
+                new InMemoryStampRepository(), noteRepo);
+        Project project =
+                new ProjectServiceImpl().createEmptyProject();
+        noteRepo.save(project.getRootNote());
+        AttributeSchemaRegistry registry =
+                new AttributeSchemaRegistry();
+
+        ProjectFileManager.save(projectDir, project,
+                noteService, linkService, stampService,
+                registry);
+
+        assertEquals("My Project",
+                project.getRootNote().getTitle());
+    }
+}


### PR DESCRIPTION
## Summary
- **#212**: On save, root note `$Name` is set to the target directory name
- **#208**: Stamps stored as `$Stamps` ListValue attribute on root note instead of separate stamps.yaml
  - Format: `"id|name|action"` entries in a ListValue
  - No separate stamps.yaml file generated on save
- Add `Attributes.STAMPS` constant

## TDD
- RED: test save sets root note name (failed) → GREEN: added rename in save
- RED: test no stamps.yaml exists after save (failed) → GREEN: store as root note attribute

## Test plan
- [x] `mvn verify` passes
- [x] 2 new tests in ProjectFileManagerTest
- [x] Checkstyle clean

Closes #208
Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)