### PR TITLE
Eliminate project.yaml: root note in base directory

### DIFF
--- a/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
@@ -50,38 +50,11 @@ public final class ProjectFileManager {
 
             // Set root note name to directory name
             String dirName = dir.getFileName().toString();
-            project.getRootNote().update(dirName,
-                    project.getRootNote().getContent());
+            Note rootNote = project.getRootNote();
+            rootNote.update(dirName, rootNote.getContent());
+            UUID rootId = rootNote.getId();
 
-            // project.yaml
-            String projectYaml = "id: \""
-                    + project.getId() + "\"\n"
-                    + "name: \"" + project.getName() + "\"\n"
-                    + "rootNoteId: \""
-                    + project.getRootNote().getId() + "\"\n";
-            Files.writeString(dir.resolve("project.yaml"),
-                    projectYaml, StandardCharsets.UTF_8);
-
-            // Notes
-            FileNoteRepository noteRepo =
-                    new FileNoteRepository(dir, registry);
-            for (Note note : noteService.getAllNotes()) {
-                noteRepo.save(note);
-            }
-
-            // Links
-            FileLinkRepository linkRepo =
-                    new FileLinkRepository(dir);
-            // Links are already loaded; save via the repo
-            UUID rootId = project.getRootNote().getId();
-            for (Note note : noteService.getAllNotes()) {
-                for (var link : linkService
-                        .getLinksFrom(note.getId())) {
-                    linkRepo.save(link);
-                }
-            }
-
-            // Stamps stored as $Stamps attribute on root note
+            // Stamps stored as $Stamps on root note
             java.util.List<String> stampEntries =
                     stampService.getAllStamps().stream()
                             .map(s -> s.id() + "|"
@@ -89,11 +62,36 @@ public final class ProjectFileManager {
                                     + s.action())
                             .toList();
             if (!stampEntries.isEmpty()) {
-                project.getRootNote().setAttribute(
-                        Attributes.STAMPS,
+                rootNote.setAttribute(Attributes.STAMPS,
                         new AttributeValue.ListValue(
                                 stampEntries));
-                noteRepo.save(project.getRootNote());
+            }
+
+            // Root note → base directory as <title>.md
+            NoteFileSerializer serializer =
+                    new NoteFileSerializer();
+            Files.writeString(
+                    dir.resolve(dirName + ".md"),
+                    serializer.serialize(rootNote),
+                    StandardCharsets.UTF_8);
+
+            // Other notes → notes/<shard>/<uuid>.md
+            FileNoteRepository noteRepo =
+                    new FileNoteRepository(dir, registry);
+            for (Note note : noteService.getAllNotes()) {
+                if (!note.getId().equals(rootId)) {
+                    noteRepo.save(note);
+                }
+            }
+
+            // Links
+            FileLinkRepository linkRepo =
+                    new FileLinkRepository(dir);
+            for (Note note : noteService.getAllNotes()) {
+                for (var link : linkService
+                        .getLinksFrom(note.getId())) {
+                    linkRepo.save(link);
+                }
             }
 
             LOG.info("Project saved to {}", dir);

--- a/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
@@ -84,13 +84,77 @@ class ProjectFileManagerTest {
                 projectDir.resolve("stamps.yaml")),
                 "stamps.yaml should not exist");
 
-        // Root note should contain stamps in its file
-        Path rootFile = projectDir.resolve("notes")
-                .resolve(project.getRootNote().getId()
-                        .toString().substring(0, 8))
-                .resolve(project.getRootNote().getId()
-                        + ".md");
-        assertTrue(Files.exists(rootFile),
-                "Root note file should exist");
+        // Root note file should exist (in base dir)
+        assertTrue(Files.exists(
+                projectDir.resolve("TestProject.md")),
+                "Root note file should exist in base dir");
     }
+
+    @Test
+    @DisplayName("save creates root note in base dir, "
+            + "not notes/")
+    void save_rootNoteInBaseDir(@TempDir Path tmp) {
+        Path projectDir = tmp.resolve("MyProject");
+        var ctx = createContext();
+        ctx.noteRepo.save(ctx.project.getRootNote());
+
+        ProjectFileManager.save(projectDir, ctx.project,
+                ctx.noteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
+
+        // Root note in base directory
+        assertTrue(Files.exists(
+                projectDir.resolve("MyProject.md")),
+                "Root note should be in base directory");
+
+        // Root note should NOT be under notes/
+        String shard = ctx.project.getRootNote().getId()
+                .toString().substring(0, 8);
+        assertFalse(Files.exists(
+                projectDir.resolve("notes").resolve(shard)
+                        .resolve(ctx.project.getRootNote()
+                                .getId() + ".md")),
+                "Root note should NOT be under notes/");
+    }
+
+    @Test
+    @DisplayName("save does not create project.yaml")
+    void save_noProjectYaml(@TempDir Path tmp) {
+        Path projectDir = tmp.resolve("NoYaml");
+        var ctx = createContext();
+        ctx.noteRepo.save(ctx.project.getRootNote());
+
+        ProjectFileManager.save(projectDir, ctx.project,
+                ctx.noteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
+
+        assertFalse(Files.exists(
+                projectDir.resolve("project.yaml")),
+                "project.yaml should not exist");
+    }
+
+    private TestContext createContext() {
+        InMemoryNoteRepository noteRepo =
+                new InMemoryNoteRepository();
+        NoteService noteService =
+                new NoteServiceImpl(noteRepo);
+        LinkService linkService = new LinkServiceImpl(
+                new InMemoryLinkRepository());
+        StampService stampService = new StampServiceImpl(
+                new InMemoryStampRepository(), noteRepo);
+        Project project =
+                new ProjectServiceImpl().createEmptyProject();
+        AttributeSchemaRegistry registry =
+                new AttributeSchemaRegistry();
+        return new TestContext(noteRepo, noteService,
+                linkService, stampService, project, registry);
+    }
+
+    private record TestContext(
+            InMemoryNoteRepository noteRepo,
+            NoteService noteService,
+            LinkService linkService,
+            StampService stampService,
+            Project project,
+            AttributeSchemaRegistry registry) { }
 }


### PR DESCRIPTION
## Summary
- Root note saved as `<title>.md` directly in the base save directory
- No `project.yaml` file generated
- Other notes remain in `notes/<shard>/<uuid>.md`
- Root note is identified by being the `.md` file in the base directory (not under `notes/`)

## File structure after save
```
my-project/
├── My Project.md          # root note (named after $Name)
├── notes/
│   ├── f9e8d7c6/
│   │   └── f9e8d7c6-....md
│   └── ...
├── links.yaml
```

## TDD
- RED: 3 failing tests (root in base dir, no project.yaml, not under notes/)
- GREEN: updated ProjectFileManager.save() to write root note separately

## Test plan
- [x] `mvn verify` passes
- [x] 4 tests in ProjectFileManagerTest all pass
- [x] Checkstyle clean

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)