### PR TITLE
Fix file open to match new save format

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -136,7 +136,11 @@ public class App extends Application {
                 sharedServices, windowManager,
                 outlineViewModel.selectedNoteIdProperty(),
                 refreshAll, stage,
-                searchViewModel::toggleVisible);
+                searchViewModel::toggleVisible,
+                newRootId -> {
+                    outlineViewModel.setBaseNoteId(newRootId);
+                    outlineViewModel.loadNotes();
+                });
         MenuBar menuBar = MenuBarFactory.create(winCtx);
         VBox topArea = new VBox(menuBar, searchView);
         BorderPane root = new BorderPane();

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -88,6 +88,7 @@ final class MenuBarFactory {
                 SharedServices svc = ctx.sharedServices();
                 ProjectFileManager.load(
                         dir.toPath(),
+                        svc.noteRepository(),
                         svc.noteService(),
                         svc.linkService(),
                         svc.stampService(),

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -86,13 +86,16 @@ final class MenuBarFactory {
             File dir = chooser.showDialog(ctx.ownerStage());
             if (dir != null) {
                 SharedServices svc = ctx.sharedServices();
-                ProjectFileManager.load(
+                UUID rootId = ProjectFileManager.load(
                         dir.toPath(),
                         svc.noteRepository(),
                         svc.noteService(),
                         svc.linkService(),
                         svc.stampService(),
                         svc.schemaRegistry());
+                if (ctx.onBaseNoteChanged() != null) {
+                    ctx.onBaseNoteChanged().accept(rootId);
+                }
                 ctx.refreshAll().run();
             }
         });

--- a/src/main/java/com/embervault/SharedServices.java
+++ b/src/main/java/com/embervault/SharedServices.java
@@ -10,6 +10,7 @@ import com.embervault.application.StampServiceImpl;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
+import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeSchemaRegistry;
 import com.embervault.domain.Project;
 
@@ -20,6 +21,7 @@ import com.embervault.domain.Project;
  * ensuring they operate on the same underlying data.</p>
  *
  * @param project         the current project with root note
+ * @param noteRepository  the note repository
  * @param noteService     the note service
  * @param linkService     the link service
  * @param stampService    the stamp service
@@ -27,6 +29,7 @@ import com.embervault.domain.Project;
  */
 public record SharedServices(
         Project project,
+        NoteRepository noteRepository,
         NoteService noteService,
         LinkService linkService,
         StampService stampService,
@@ -50,7 +53,8 @@ public record SharedServices(
         noteRepo.save(project.getRootNote());
         AttributeSchemaRegistry schemaRegistry =
                 new AttributeSchemaRegistry();
-        return new SharedServices(project, noteService, linkService,
+        return new SharedServices(project, noteRepo,
+                noteService, linkService,
                 stampService, schemaRegistry);
     }
 }

--- a/src/main/java/com/embervault/WindowContext.java
+++ b/src/main/java/com/embervault/WindowContext.java
@@ -1,6 +1,7 @@
 package com.embervault;
 
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import javafx.beans.property.ObjectProperty;
 import javafx.stage.Stage;
@@ -18,6 +19,8 @@ import javafx.stage.Stage;
  * @param refreshAll     callback to refresh all windows
  * @param ownerStage     this window's stage (for modal dialogs)
  * @param onFind         callback for Edit &gt; Find, or null
+ * @param onBaseNoteChanged callback when loaded project changes
+ *                          root note, or null
  */
 public record WindowContext(
         SharedServices sharedServices,
@@ -25,5 +28,6 @@ public record WindowContext(
         ObjectProperty<UUID> selectedNoteId,
         Runnable refreshAll,
         Stage ownerStage,
-        Runnable onFind) {
+        Runnable onFind,
+        Consumer<UUID> onBaseNoteChanged) {
 }

--- a/src/main/java/com/embervault/WindowFactory.java
+++ b/src/main/java/com/embervault/WindowFactory.java
@@ -107,7 +107,11 @@ public final class WindowFactory {
         WindowContext winCtx = new WindowContext(
                 services, windowManager,
                 mapVm.selectedNoteIdProperty(),
-                refreshAll, newStage, null);
+                refreshAll, newStage, null,
+                newRootId -> {
+                    mapVm.setBaseNoteId(newRootId);
+                    mapVm.loadNotes();
+                });
         javafx.scene.control.MenuBar menuBar =
                 MenuBarFactory.create(winCtx);
         BorderPane root = new BorderPane();

--- a/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/ProjectFileManager.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
+import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeSchemaRegistry;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Attributes;
@@ -111,54 +112,87 @@ public final class ProjectFileManager {
      * @param registry     the attribute schema registry
      * @return the loaded project root note ID
      */
-    public static UUID load(Path dir, NoteService noteService,
-            LinkService linkService, StampService stampService,
+    public static UUID load(Path dir,
+            NoteRepository noteRepository,
+            NoteService noteService,
+            LinkService linkService,
+            StampService stampService,
             AttributeSchemaRegistry registry) {
         try {
-            // Read project.yaml for root note ID
-            String projectYaml = Files.readString(
-                    dir.resolve("project.yaml"),
-                    StandardCharsets.UTF_8);
-            UUID rootNoteId = parseRootNoteId(projectYaml);
+            NoteFileDeserializer deserializer =
+                    new NoteFileDeserializer(registry);
 
-            // Load notes
+            // Find root note: .md file in base directory
+            Note rootNote = null;
+            try (var files = Files.list(dir)) {
+                for (Path f : files
+                        .filter(p -> p.toString()
+                                .endsWith(".md"))
+                        .toList()) {
+                    String content = Files.readString(f,
+                            StandardCharsets.UTF_8);
+                    UUID id = parseIdFromFrontMatter(
+                            content);
+                    rootNote = deserializer.deserialize(
+                            content, id);
+                    break;
+                }
+            }
+            if (rootNote == null) {
+                throw new IllegalArgumentException(
+                        "No root note .md in " + dir);
+            }
+            noteRepository.save(rootNote);
+            UUID rootId = rootNote.getId();
+
+            // Stamps from root note $Stamps attribute
+            rootNote.getAttribute(Attributes.STAMPS)
+                    .ifPresent(v -> {
+                        if (v
+                                instanceof
+                                AttributeValue.ListValue lv) {
+                            for (String e : lv.values()) {
+                                String[] parts =
+                                        e.split("\\|", 3);
+                                if (parts.length == 3) {
+                                    stampService.createStamp(
+                                            parts[1],
+                                            parts[2]);
+                                }
+                            }
+                        }
+                    });
+
+            // Child notes from notes/ subdirectory
             FileNoteRepository fileNotes =
                     new FileNoteRepository(dir, registry);
             for (Note note : fileNotes.findAll()) {
-                noteService.updateNote(note.getId(),
-                        note.getTitle(), note.getContent());
+                noteRepository.save(note);
             }
 
-            // Load links
-            FileLinkRepository fileLinks =
-                    new FileLinkRepository(dir);
-            // Links loaded automatically by constructor
-
-            // Load stamps
-            FileStampRepository fileStamps =
-                    new FileStampRepository(dir);
-            for (var stamp : fileStamps.findAll()) {
-                stampService.createStamp(
-                        stamp.name(), stamp.action());
+            // Links
+            if (Files.exists(dir.resolve("links.yaml"))) {
+                new FileLinkRepository(dir);
             }
 
             LOG.info("Project loaded from {}", dir);
-            return rootNoteId;
+            return rootId;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    private static UUID parseRootNoteId(String yaml) {
-        for (String line : yaml.split("\n")) {
-            if (line.startsWith("rootNoteId:")) {
-                String value = line.substring(
-                        "rootNoteId:".length()).trim();
-                value = value.replace("\"", "");
+    private static UUID parseIdFromFrontMatter(
+            String content) {
+        for (String line : content.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("id:")) {
+                String value = trimmed.substring(3).trim()
+                        .replace("\"", "");
                 return UUID.fromString(value);
             }
         }
         throw new IllegalArgumentException(
-                "No rootNoteId in project.yaml");
+                "No id in front matter");
     }
 }

--- a/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
+++ b/src/main/java/com/embervault/domain/AttributeSchemaRegistry.java
@@ -16,6 +16,7 @@ import static com.embervault.domain.Attributes.NAME;
 import static com.embervault.domain.Attributes.OUTLINE_ORDER;
 import static com.embervault.domain.Attributes.PROTOTYPE;
 import static com.embervault.domain.Attributes.SHAPE;
+import static com.embervault.domain.Attributes.STAMPS;
 import static com.embervault.domain.Attributes.SUBTITLE;
 import static com.embervault.domain.Attributes.TEXT;
 import static com.embervault.domain.Attributes.URL;
@@ -148,6 +149,10 @@ public final class AttributeSchemaRegistry {
                 new AttributeValue.SetValue(Set.of()));
         systemAttr(FLAGS, AttributeType.SET, new AttributeValue.SetValue(Set.of()));
         systemAttr(BADGE, AttributeType.STRING, new AttributeValue.StringValue(""));
+
+        // Project metadata
+        systemAttr(STAMPS, AttributeType.LIST,
+                new AttributeValue.ListValue(List.of()));
     }
 
     private void systemAttr(String name, AttributeType type, AttributeValue defaultValue) {

--- a/src/test/java/com/embervault/SharedServicesTest.java
+++ b/src/test/java/com/embervault/SharedServicesTest.java
@@ -36,7 +36,7 @@ class SharedServicesTest {
         Project project = new ProjectServiceImpl().createEmptyProject();
 
         SharedServices services = new SharedServices(
-                project, noteService, linkService,
+                project, noteRepo, noteService, linkService,
                 stampService, registry);
 
         assertNotNull(services.project());

--- a/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
@@ -151,28 +151,38 @@ class ProjectFileManagerTest {
                 ctx.noteService, ctx.linkService,
                 ctx.stampService, ctx.registry);
 
-        // Load into fresh services
-        var ctx2 = createContext();
-        ctx2.noteRepo.save(ctx2.project.getRootNote());
+        // Load into fresh services with fresh repo
+        InMemoryNoteRepository loadRepo =
+                new InMemoryNoteRepository();
+        NoteService loadNoteService =
+                new NoteServiceImpl(loadRepo);
+        StampService loadStampService =
+                new StampServiceImpl(
+                        new InMemoryStampRepository(),
+                        loadRepo);
+        LinkService loadLinkService = new LinkServiceImpl(
+                new InMemoryLinkRepository());
+
         UUID rootId = ProjectFileManager.load(projectDir,
-                ctx2.noteService, ctx2.linkService,
-                ctx2.stampService, ctx2.registry);
+                loadRepo, loadNoteService, loadLinkService,
+                loadStampService, ctx.registry);
 
         // Root note loaded
-        assertTrue(ctx2.noteService.getNote(rootId)
+        assertTrue(loadNoteService.getNote(rootId)
                         .isPresent(),
                 "Root note should be loaded");
         assertEquals("RoundTrip",
-                ctx2.noteService.getNote(rootId).get()
+                loadNoteService.getNote(rootId).get()
                         .getTitle());
 
         // Children loaded
         assertEquals(2,
-                ctx2.noteService.getChildren(rootId).size(),
+                loadNoteService.getChildren(rootId).size(),
                 "Should have 2 children");
 
         // Stamps loaded
-        assertFalse(ctx2.stampService.getAllStamps().isEmpty(),
+        assertFalse(
+                loadStampService.getAllStamps().isEmpty(),
                 "Stamps should be loaded");
     }
 
@@ -187,13 +197,15 @@ class ProjectFileManagerTest {
                 ctx.noteService, ctx.linkService,
                 ctx.stampService, ctx.registry);
 
-        var ctx2 = createContext();
-        ctx2.noteRepo.save(ctx2.project.getRootNote());
+        InMemoryNoteRepository loadRepo =
+                new InMemoryNoteRepository();
+        NoteService loadNoteService =
+                new NoteServiceImpl(loadRepo);
         UUID rootId = ProjectFileManager.load(projectDir,
-                ctx2.noteService, ctx2.linkService,
-                ctx2.stampService, ctx2.registry);
+                loadRepo, loadNoteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
 
-        assertTrue(ctx2.noteService.getNote(rootId)
+        assertTrue(loadNoteService.getNote(rootId)
                         .isPresent(),
                 "Should load root note from base dir");
     }

--- a/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.UUID;
 
 import com.embervault.application.LinkServiceImpl;
 import com.embervault.application.NoteServiceImpl;
@@ -131,6 +132,70 @@ class ProjectFileManagerTest {
         assertFalse(Files.exists(
                 projectDir.resolve("project.yaml")),
                 "project.yaml should not exist");
+    }
+
+    @Test
+    @DisplayName("round-trip save then load preserves data")
+    void roundTrip_saveThenLoad(@TempDir Path tmp) {
+        Path projectDir = tmp.resolve("RoundTrip");
+        var ctx = createContext();
+        ctx.noteRepo.save(ctx.project.getRootNote());
+        ctx.noteService.createChildNote(
+                ctx.project.getRootNote().getId(), "Child A");
+        ctx.noteService.createChildNote(
+                ctx.project.getRootNote().getId(), "Child B");
+        ctx.stampService.createStamp("Color:red",
+                "$Color=red");
+
+        ProjectFileManager.save(projectDir, ctx.project,
+                ctx.noteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
+
+        // Load into fresh services
+        var ctx2 = createContext();
+        ctx2.noteRepo.save(ctx2.project.getRootNote());
+        UUID rootId = ProjectFileManager.load(projectDir,
+                ctx2.noteService, ctx2.linkService,
+                ctx2.stampService, ctx2.registry);
+
+        // Root note loaded
+        assertTrue(ctx2.noteService.getNote(rootId)
+                        .isPresent(),
+                "Root note should be loaded");
+        assertEquals("RoundTrip",
+                ctx2.noteService.getNote(rootId).get()
+                        .getTitle());
+
+        // Children loaded
+        assertEquals(2,
+                ctx2.noteService.getChildren(rootId).size(),
+                "Should have 2 children");
+
+        // Stamps loaded
+        assertFalse(ctx2.stampService.getAllStamps().isEmpty(),
+                "Stamps should be loaded");
+    }
+
+    @Test
+    @DisplayName("load reads root note from base dir .md file")
+    void load_readsRootFromBaseDir(@TempDir Path tmp) {
+        Path projectDir = tmp.resolve("LoadTest");
+        var ctx = createContext();
+        ctx.noteRepo.save(ctx.project.getRootNote());
+
+        ProjectFileManager.save(projectDir, ctx.project,
+                ctx.noteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
+
+        var ctx2 = createContext();
+        ctx2.noteRepo.save(ctx2.project.getRootNote());
+        UUID rootId = ProjectFileManager.load(projectDir,
+                ctx2.noteService, ctx2.linkService,
+                ctx2.stampService, ctx2.registry);
+
+        assertTrue(ctx2.noteService.getNote(rootId)
+                        .isPresent(),
+                "Should load root note from base dir");
     }
 
     private TestContext createContext() {

--- a/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
@@ -16,6 +16,7 @@ import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
 import com.embervault.domain.AttributeSchemaRegistry;
+import com.embervault.domain.Note;
 import com.embervault.domain.Project;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -208,6 +209,68 @@ class ProjectFileManagerTest {
         assertTrue(loadNoteService.getNote(rootId)
                         .isPresent(),
                 "Should load root note from base dir");
+    }
+
+    @Test
+    @DisplayName("round-trip preserves grandchildren")
+    void roundTrip_preservesGrandchildren(@TempDir Path tmp) {
+        Path projectDir = tmp.resolve("Deep");
+        var ctx = createContext();
+        ctx.noteRepo.save(ctx.project.getRootNote());
+        UUID rootId = ctx.project.getRootNote().getId();
+        Note child = ctx.noteService.createChildNote(
+                rootId, "Child");
+        ctx.noteService.createChildNote(
+                child.getId(), "Grandchild A");
+        ctx.noteService.createChildNote(
+                child.getId(), "Grandchild B");
+
+        ProjectFileManager.save(projectDir, ctx.project,
+                ctx.noteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
+
+        InMemoryNoteRepository loadRepo =
+                new InMemoryNoteRepository();
+        NoteService loadNoteService =
+                new NoteServiceImpl(loadRepo);
+        UUID loadedRoot = ProjectFileManager.load(projectDir,
+                loadRepo, loadNoteService,
+                new LinkServiceImpl(
+                        new InMemoryLinkRepository()),
+                new StampServiceImpl(
+                        new InMemoryStampRepository(),
+                        loadRepo),
+                ctx.registry);
+
+        // Child loaded
+        assertEquals(1,
+                loadNoteService.getChildren(loadedRoot)
+                        .size(),
+                "Root should have 1 child");
+        Note loadedChild =
+                loadNoteService.getChildren(loadedRoot)
+                        .get(0);
+        assertEquals("Child", loadedChild.getTitle());
+
+        // Grandchildren loaded with correct container
+        var grandchildren = loadNoteService.getChildren(
+                loadedChild.getId());
+        assertEquals(2, grandchildren.size(),
+                "Child should have 2 grandchildren");
+        // Verify container attribute is set
+        for (Note gc : grandchildren) {
+            var container = gc.getAttribute(
+                    com.embervault.domain.Attributes
+                            .CONTAINER);
+            assertTrue(container.isPresent(),
+                    "Grandchild should have $Container");
+            assertEquals(loadedChild.getId().toString(),
+                    ((com.embervault.domain.AttributeValue
+                            .StringValue) container.get())
+                            .value(),
+                    "Grandchild $Container should be "
+                            + "child's ID");
+        }
     }
 
     private TestContext createContext() {

--- a/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/ProjectFileManagerTest.java
@@ -273,6 +273,85 @@ class ProjectFileManagerTest {
         }
     }
 
+    @Test
+    @DisplayName("saved grandchild files contain $Container")
+    void save_grandchildFileContainsContainer(
+            @TempDir Path tmp) throws Exception {
+        Path projectDir = tmp.resolve("ContainerTest");
+        var ctx = createContext();
+        ctx.noteRepo.save(ctx.project.getRootNote());
+        UUID rootId = ctx.project.getRootNote().getId();
+        Note child = ctx.noteService.createChildNote(
+                rootId, "Child");
+        Note gc = ctx.noteService.createChildNote(
+                child.getId(), "GC");
+
+        ProjectFileManager.save(projectDir, ctx.project,
+                ctx.noteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
+
+        // Read the grandchild file and verify $Container
+        String shard = gc.getId().toString().substring(0, 8);
+        Path gcFile = projectDir.resolve("notes")
+                .resolve(shard)
+                .resolve(gc.getId() + ".md");
+        assertTrue(Files.exists(gcFile),
+                "Grandchild file should exist: " + gcFile);
+        String content = Files.readString(gcFile);
+        assertTrue(content.contains("$Container"),
+                "File should contain $Container:\n"
+                        + content);
+        assertTrue(content.contains(
+                child.getId().toString()),
+                "File $Container should reference child ID");
+    }
+
+    @Test
+    @DisplayName("loaded notes have correct $Container chain")
+    void load_notesHaveContainerChain(@TempDir Path tmp) {
+        Path projectDir = tmp.resolve("Chain");
+        var ctx = createContext();
+        ctx.noteRepo.save(ctx.project.getRootNote());
+        UUID rootId = ctx.project.getRootNote().getId();
+        Note child = ctx.noteService.createChildNote(
+                rootId, "Child");
+        Note gc = ctx.noteService.createChildNote(
+                child.getId(), "GC");
+
+        ProjectFileManager.save(projectDir, ctx.project,
+                ctx.noteService, ctx.linkService,
+                ctx.stampService, ctx.registry);
+
+        // Load
+        InMemoryNoteRepository loadRepo =
+                new InMemoryNoteRepository();
+        NoteService loadSvc = new NoteServiceImpl(loadRepo);
+        UUID loadedRoot = ProjectFileManager.load(projectDir,
+                loadRepo, loadSvc,
+                new LinkServiceImpl(
+                        new InMemoryLinkRepository()),
+                new StampServiceImpl(
+                        new InMemoryStampRepository(),
+                        loadRepo),
+                ctx.registry);
+
+        // Verify all notes exist
+        assertEquals(3, loadRepo.findAll().size(),
+                "Should have root + child + grandchild");
+
+        // Verify chain: root → child → gc
+        var children = loadSvc.getChildren(loadedRoot);
+        assertEquals(1, children.size(),
+                "Root should have 1 child");
+        assertEquals("Child", children.get(0).getTitle());
+
+        var gcs = loadSvc.getChildren(
+                children.get(0).getId());
+        assertEquals(1, gcs.size(),
+                "Child should have 1 grandchild");
+        assertEquals("GC", gcs.get(0).getTitle());
+    }
+
     private TestContext createContext() {
         InMemoryNoteRepository noteRepo =
                 new InMemoryNoteRepository();


### PR DESCRIPTION
## Summary
Rewrite `ProjectFileManager.load()` to read the new save format:
- Root note from `<title>.md` in base directory (no project.yaml)
- Stamps from `$Stamps` ListValue attribute on root note (no stamps.yaml)
- Child notes from `notes/<shard>/<uuid>.md`
- Register `$Stamps` as LIST type in `AttributeSchemaRegistry`
- Add `noteRepository` to `SharedServices` record for direct note saving during load

## TDD
- RED: round-trip and base-dir load tests fail (load expects old format)
- GREEN: rewrite load() with front matter ID parsing, direct repo saves, $Stamps parsing

## Test plan
- [x] `mvn verify` passes — all 895 tests
- [x] Round-trip save→load preserves root note, children, stamps
- [x] Checkstyle clean

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)