### PR TITLE
Undo/Redo with Memento Pattern (fixes #220)

### DIFF
--- a/src/main/java/com/embervault/application/UndoRedoService.java
+++ b/src/main/java/com/embervault/application/UndoRedoService.java
@@ -1,0 +1,79 @@
+package com.embervault.application;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.Note;
+import com.embervault.domain.NoteMemento;
+
+/**
+ * Manages undo/redo stacks using the Memento pattern.
+ *
+ * <p>Before each mutation, callers record the note's current state via
+ * {@link #recordChange(Note)}. Undo restores the most recent memento
+ * and pushes the current state onto the redo stack.</p>
+ */
+public class UndoRedoService {
+
+    private static final int MAX_STACK_SIZE = 50;
+
+    private final Deque<NoteMemento> undoStack = new ArrayDeque<>();
+    private final Deque<NoteMemento> redoStack = new ArrayDeque<>();
+
+    /**
+     * Records the current state of a note before it is mutated.
+     *
+     * @param note the note about to be changed
+     */
+    public void recordChange(Note note) {
+        undoStack.push(NoteMemento.capture(note));
+        redoStack.clear();
+        if (undoStack.size() > MAX_STACK_SIZE) {
+            undoStack.removeLast();
+        }
+    }
+
+    /**
+     * Undoes the most recent change by restoring the note from the
+     * top memento and pushing the current state onto the redo stack.
+     *
+     * @param repository the repository to retrieve and save the note
+     */
+    public void undo(NoteRepository repository) {
+        if (undoStack.isEmpty()) {
+            return;
+        }
+        NoteMemento memento = undoStack.pop();
+        Note note = repository.findById(memento.getNoteId()).orElseThrow();
+        redoStack.push(NoteMemento.capture(note));
+        memento.restore(note);
+        repository.save(note);
+    }
+
+    /**
+     * Redoes the most recently undone change.
+     *
+     * @param repository the repository to retrieve and save the note
+     */
+    public void redo(NoteRepository repository) {
+        if (redoStack.isEmpty()) {
+            return;
+        }
+        NoteMemento memento = redoStack.pop();
+        Note note = repository.findById(memento.getNoteId()).orElseThrow();
+        undoStack.push(NoteMemento.capture(note));
+        memento.restore(note);
+        repository.save(note);
+    }
+
+    /** Returns whether there are changes that can be undone. */
+    public boolean canUndo() {
+        return !undoStack.isEmpty();
+    }
+
+    /** Returns whether there are changes that can be redone. */
+    public boolean canRedo() {
+        return !redoStack.isEmpty();
+    }
+}

--- a/src/main/java/com/embervault/domain/NoteMemento.java
+++ b/src/main/java/com/embervault/domain/NoteMemento.java
@@ -1,0 +1,67 @@
+package com.embervault.domain;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * An immutable snapshot of a note's state at a point in time.
+ *
+ * <p>Captures the note's id, attribute map, and prototype id so the
+ * note can be restored to this exact state later (Memento pattern).</p>
+ */
+public final class NoteMemento {
+
+    private final UUID noteId;
+    private final AttributeMap attributeSnapshot;
+    private final UUID prototypeId;
+
+    private NoteMemento(UUID noteId, AttributeMap attributeSnapshot,
+            UUID prototypeId) {
+        this.noteId = Objects.requireNonNull(noteId);
+        this.attributeSnapshot = Objects.requireNonNull(attributeSnapshot);
+        this.prototypeId = prototypeId;
+    }
+
+    /**
+     * Captures an immutable snapshot of the given note's current state.
+     *
+     * @param note the note to snapshot
+     * @return a memento holding a copy of the note's attributes
+     */
+    public static NoteMemento capture(Note note) {
+        return new NoteMemento(
+                note.getId(),
+                new AttributeMap(note.getAttributes()),
+                note.getPrototypeId().orElse(null));
+    }
+
+    /**
+     * Restores the given note to the state captured in this memento.
+     *
+     * <p>Replaces all attributes on the note with the snapshotted values.
+     * The note's id is not changed.</p>
+     *
+     * @param note the note to restore (must have the same id)
+     */
+    public void restore(Note note) {
+        if (!note.getId().equals(noteId)) {
+            throw new IllegalArgumentException(
+                    "Cannot restore memento for note " + noteId
+                    + " onto note " + note.getId());
+        }
+        // Clear current attributes and replace with snapshot
+        AttributeMap current = note.getAttributes();
+        for (String key : current.localEntries().keySet().toArray(String[]::new)) {
+            current.remove(key);
+        }
+        for (var entry : attributeSnapshot.localEntries().entrySet()) {
+            current.set(entry.getKey(), entry.getValue());
+        }
+        note.setPrototypeId(prototypeId);
+    }
+
+    /** Returns the id of the note this memento was captured from. */
+    public UUID getNoteId() {
+        return noteId;
+    }
+}

--- a/src/test/java/com/embervault/application/UndoRedoServiceTest.java
+++ b/src/test/java/com/embervault/application/UndoRedoServiceTest.java
@@ -1,0 +1,154 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UndoRedoService}.
+ */
+class UndoRedoServiceTest {
+
+    private UndoRedoService undoRedoService;
+    private NoteService noteService;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        undoRedoService = new UndoRedoService();
+    }
+
+    @Test
+    @DisplayName("initially canUndo and canRedo are false")
+    void initialState() {
+        assertFalse(undoRedoService.canUndo());
+        assertFalse(undoRedoService.canRedo());
+    }
+
+    @Test
+    @DisplayName("after recording a change, canUndo is true")
+    void recordChange_enablesUndo() {
+        Note note = noteService.createNote("Title", "Content");
+        undoRedoService.recordChange(note);
+
+        assertTrue(undoRedoService.canUndo());
+        assertFalse(undoRedoService.canRedo());
+    }
+
+    @Test
+    @DisplayName("undo restores note to previous state")
+    void undo_restoresPreviousState() {
+        Note note = noteService.createNote("Original", "Content");
+
+        // Record state before mutation
+        undoRedoService.recordChange(note);
+
+        // Mutate
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed"));
+        repository.save(note);
+
+        assertEquals("Changed", note.getTitle());
+
+        // Undo
+        undoRedoService.undo(repository);
+
+        Note restored = repository.findById(note.getId()).orElseThrow();
+        assertEquals("Original", restored.getTitle());
+    }
+
+    @Test
+    @DisplayName("redo re-applies an undone change")
+    void redo_reappliesChange() {
+        Note note = noteService.createNote("Original", "Content");
+        undoRedoService.recordChange(note);
+
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed"));
+        repository.save(note);
+
+        undoRedoService.undo(repository);
+        assertTrue(undoRedoService.canRedo());
+
+        undoRedoService.redo(repository);
+
+        Note result = repository.findById(note.getId()).orElseThrow();
+        assertEquals("Changed", result.getTitle());
+    }
+
+    @Test
+    @DisplayName("new change after undo clears redo stack")
+    void newChange_clearsRedoStack() {
+        Note note = noteService.createNote("Original", "Content");
+        undoRedoService.recordChange(note);
+
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed"));
+        repository.save(note);
+
+        undoRedoService.undo(repository);
+        assertTrue(undoRedoService.canRedo());
+
+        // New change should clear redo
+        undoRedoService.recordChange(note);
+        assertFalse(undoRedoService.canRedo());
+    }
+
+    @Test
+    @DisplayName("multiple undos work in reverse order")
+    void multipleUndos_reverseOrder() {
+        Note note = noteService.createNote("First", "Content");
+
+        undoRedoService.recordChange(note);
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Second"));
+        repository.save(note);
+
+        undoRedoService.recordChange(note);
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Third"));
+        repository.save(note);
+
+        undoRedoService.undo(repository);
+        assertEquals("Second",
+                repository.findById(note.getId()).orElseThrow().getTitle());
+
+        undoRedoService.undo(repository);
+        assertEquals("First",
+                repository.findById(note.getId()).orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("undo stack respects max size limit")
+    void undoStack_respectsMaxSize() {
+        Note note = noteService.createNote("Start", "Content");
+
+        // Push more than the max (default 50)
+        for (int i = 0; i < 60; i++) {
+            undoRedoService.recordChange(note);
+            note.setAttribute(Attributes.NAME,
+                    new AttributeValue.StringValue("Change " + i));
+            repository.save(note);
+        }
+
+        // Should still be able to undo, but only up to max
+        int undoCount = 0;
+        while (undoRedoService.canUndo()) {
+            undoRedoService.undo(repository);
+            undoCount++;
+        }
+
+        assertTrue(undoCount <= 50);
+    }
+}

--- a/src/test/java/com/embervault/domain/NoteMementoTest.java
+++ b/src/test/java/com/embervault/domain/NoteMementoTest.java
@@ -1,0 +1,56 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link NoteMemento} — immutable snapshots of note state.
+ */
+class NoteMementoTest {
+
+    @Test
+    @DisplayName("memento captures note attributes and can restore them")
+    void captureAndRestore() {
+        Note note = Note.create("Original Title", "Original content");
+        UUID noteId = note.getId();
+
+        NoteMemento memento = NoteMemento.capture(note);
+
+        // Mutate the note after capture
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed Title"));
+        note.setAttribute(Attributes.TEXT,
+                new AttributeValue.StringValue("Changed content"));
+
+        assertEquals("Changed Title", note.getTitle());
+
+        // Restore from memento
+        memento.restore(note);
+
+        assertEquals("Original Title", note.getTitle());
+        assertEquals("Original content", note.getContent());
+        assertEquals(noteId, note.getId());
+    }
+
+    @Test
+    @DisplayName("memento holds an independent copy of attributes")
+    void mementoIsIndependentCopy() {
+        Note note = Note.create("Title", "Content");
+
+        NoteMemento memento = NoteMemento.capture(note);
+
+        // Mutate original note — memento should be unaffected
+        note.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+
+        memento.restore(note);
+
+        // The color we added after capture should be gone
+        assertEquals(java.util.Optional.empty(),
+                note.getAttribute(Attributes.COLOR));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `NoteMemento` domain class — immutable snapshot of note state (attributes + prototype id)
- Adds `UndoRedoService` in application layer — manages undo/redo stacks with Memento pattern
- Undo restores previous state, redo re-applies, new actions clear redo stack
- Stack capped at 50 entries to bound memory usage
- Pure TDD: every feature started with a failing test

## Test plan
- [x] Unit tests for NoteMemento capture/restore
- [x] Unit tests for memento independence (mutations don't affect snapshot)
- [x] Unit tests for UndoRedoService initial state
- [x] Unit tests for undo restoring previous state
- [x] Unit tests for redo re-applying undone changes
- [x] Unit tests for new action clearing redo stack
- [x] Unit tests for multiple undos in reverse order
- [x] Unit tests for stack size limits
- [x] All existing tests still pass

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)