### PR TITLE
Timeline View (fixes #223)

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineItem.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineItem.java
@@ -1,0 +1,14 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A note to be placed on the timeline.
+ *
+ * @param id    the note id
+ * @param start the start date (required)
+ * @param end   the end date (nullable — point-in-time if null)
+ */
+record TimelineItem(UUID id, Instant start, Instant end) {
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineLayout.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineLayout.java
@@ -1,0 +1,96 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Timeline layout algorithm: maps items with dates to positioned rectangles.
+ *
+ * <p>Items are placed on a horizontal axis proportional to their date
+ * within the overall time range. Date-range items get proportional width;
+ * point-in-time items get a fixed marker width. Overlapping items are
+ * stacked vertically.</p>
+ */
+final class TimelineLayout {
+
+    private static final double ITEM_HEIGHT = 30.0;
+    private static final double ITEM_GAP = 4.0;
+    private static final double MARKER_WIDTH = 8.0;
+    private static final double PADDING = 20.0;
+
+    private TimelineLayout() {
+    }
+
+    /**
+     * Computes timeline positions for the given items.
+     *
+     * @param items      the items to lay out
+     * @param totalWidth the total available width
+     * @param totalHeight the total available height
+     * @return positioned rectangles
+     */
+    static List<TimelineRect> layout(List<TimelineItem> items,
+            double totalWidth, double totalHeight) {
+        if (items.isEmpty()) {
+            return List.of();
+        }
+
+        // Determine time range
+        Instant earliest = items.stream()
+                .map(TimelineItem::start)
+                .min(Comparator.naturalOrder()).orElseThrow();
+        Instant latest = items.stream()
+                .map(i -> i.end() != null ? i.end() : i.start())
+                .max(Comparator.naturalOrder()).orElseThrow();
+
+        long rangeMillis = latest.toEpochMilli() - earliest.toEpochMilli();
+        if (rangeMillis == 0) {
+            rangeMillis = 1; // avoid division by zero for same-date items
+        }
+
+        double usableWidth = totalWidth - 2 * PADDING;
+
+        // Sort by start date, then lay out with overlap detection
+        List<TimelineItem> sorted = items.stream()
+                .sorted(Comparator.comparing(TimelineItem::start))
+                .toList();
+
+        List<TimelineRect> result = new ArrayList<>();
+        // Track the rightmost x extent at each row for overlap detection
+        List<Double> rowExtents = new ArrayList<>();
+
+        for (TimelineItem item : sorted) {
+            double x = PADDING + (item.start().toEpochMilli()
+                    - earliest.toEpochMilli())
+                    / (double) rangeMillis * usableWidth;
+            double w;
+            if (item.end() != null) {
+                w = (item.end().toEpochMilli()
+                        - item.start().toEpochMilli())
+                        / (double) rangeMillis * usableWidth;
+                w = Math.max(w, MARKER_WIDTH);
+            } else {
+                w = MARKER_WIDTH;
+            }
+
+            // Find first row where this item fits without overlap
+            int row = 0;
+            while (row < rowExtents.size()
+                    && rowExtents.get(row) > x) {
+                row++;
+            }
+            if (row >= rowExtents.size()) {
+                rowExtents.add(0.0);
+            }
+            rowExtents.set(row, x + w + ITEM_GAP);
+
+            double y = row * (ITEM_HEIGHT + ITEM_GAP);
+            result.add(new TimelineRect(item.id(), x, y, w,
+                    ITEM_HEIGHT));
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineRect.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineRect.java
@@ -1,0 +1,15 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.UUID;
+
+/**
+ * A positioned rectangle on the timeline.
+ *
+ * @param id     the note id
+ * @param x      the x-coordinate
+ * @param y      the y-coordinate
+ * @param width  the width (positive for date ranges, fixed for point-in-time)
+ * @param height the height
+ */
+record TimelineRect(UUID id, double x, double y, double width, double height) {
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TimelineViewModel.java
@@ -1,0 +1,59 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+
+/**
+ * ViewModel for the Timeline view.
+ *
+ * <p>Provides a static method to filter notes by a selected date attribute,
+ * producing {@link TimelineItem}s suitable for layout.</p>
+ */
+public final class TimelineViewModel {
+
+    private TimelineViewModel() {
+    }
+
+    /**
+     * Filters notes that have the given date attribute, producing TimelineItems.
+     *
+     * <p>If the date attribute is {@code $StartDate} and the note also has
+     * {@code $EndDate}, the item includes both for date-range rendering.
+     * Otherwise the item is point-in-time.</p>
+     *
+     * @param notes         the notes to filter
+     * @param dateAttribute the attribute name to use (e.g., Attributes.CREATED)
+     * @return timeline items for notes with the given date attribute
+     */
+    public static List<TimelineItem> filterByDate(List<Note> notes,
+            String dateAttribute) {
+        if (notes.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<TimelineItem> items = new ArrayList<>();
+        for (Note note : notes) {
+            note.getAttribute(dateAttribute)
+                    .filter(v -> v instanceof AttributeValue.DateValue)
+                    .map(v -> ((AttributeValue.DateValue) v).value())
+                    .ifPresent(start -> {
+                        Instant end = null;
+                        if (Attributes.START_DATE.equals(dateAttribute)) {
+                            end = note.getAttribute(Attributes.END_DATE)
+                                    .filter(v -> v
+                                            instanceof AttributeValue.DateValue)
+                                    .map(v -> ((AttributeValue.DateValue) v)
+                                            .value())
+                                    .orElse(null);
+                        }
+                        items.add(new TimelineItem(note.getId(), start, end));
+                    });
+        }
+        return Collections.unmodifiableList(items);
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/TimelineLayoutTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/TimelineLayoutTest.java
@@ -1,0 +1,103 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TimelineLayout} — maps notes with dates to positioned rectangles.
+ */
+class TimelineLayoutTest {
+
+    private static final double WIDTH = 800.0;
+    private static final double HEIGHT = 400.0;
+    private static final Instant BASE = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test
+    @DisplayName("empty items returns empty result")
+    void emptyItems() {
+        List<TimelineRect> rects = TimelineLayout.layout(List.of(),
+                WIDTH, HEIGHT);
+        assertTrue(rects.isEmpty());
+    }
+
+    @Test
+    @DisplayName("single item is placed within the bounds")
+    void singleItem() {
+        UUID id = UUID.randomUUID();
+        TimelineItem item = new TimelineItem(id, BASE, null);
+
+        List<TimelineRect> rects = TimelineLayout.layout(List.of(item),
+                WIDTH, HEIGHT);
+
+        assertEquals(1, rects.size());
+        TimelineRect rect = rects.getFirst();
+        assertEquals(id, rect.id());
+        assertTrue(rect.x() >= 0 && rect.x() <= WIDTH);
+        assertTrue(rect.y() >= 0);
+    }
+
+    @Test
+    @DisplayName("earlier dates are placed to the left of later dates")
+    void ordering() {
+        UUID early = UUID.randomUUID();
+        UUID late = UUID.randomUUID();
+        TimelineItem earlyItem = new TimelineItem(early, BASE, null);
+        TimelineItem lateItem = new TimelineItem(late,
+                BASE.plus(30, ChronoUnit.DAYS), null);
+
+        List<TimelineRect> rects = TimelineLayout.layout(
+                List.of(earlyItem, lateItem), WIDTH, HEIGHT);
+
+        TimelineRect earlyRect = rects.stream()
+                .filter(r -> r.id().equals(early)).findFirst().orElseThrow();
+        TimelineRect lateRect = rects.stream()
+                .filter(r -> r.id().equals(late)).findFirst().orElseThrow();
+
+        assertTrue(earlyRect.x() < lateRect.x(),
+                "Earlier date should be left of later date");
+    }
+
+    @Test
+    @DisplayName("item with date range has proportional width")
+    void dateRange_hasWidth() {
+        UUID id = UUID.randomUUID();
+        Instant start = BASE;
+        Instant end = BASE.plus(10, ChronoUnit.DAYS);
+        TimelineItem item = new TimelineItem(id, start, end);
+
+        List<TimelineRect> rects = TimelineLayout.layout(List.of(item),
+                WIDTH, HEIGHT);
+
+        TimelineRect rect = rects.getFirst();
+        assertTrue(rect.width() > 0,
+                "Date range item should have positive width");
+    }
+
+    @Test
+    @DisplayName("overlapping dates get different y positions")
+    void overlappingDates_differentY() {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        TimelineItem item1 = new TimelineItem(id1, BASE, null);
+        TimelineItem item2 = new TimelineItem(id2, BASE, null);
+
+        List<TimelineRect> rects = TimelineLayout.layout(
+                List.of(item1, item2), WIDTH, HEIGHT);
+
+        TimelineRect rect1 = rects.stream()
+                .filter(r -> r.id().equals(id1)).findFirst().orElseThrow();
+        TimelineRect rect2 = rects.stream()
+                .filter(r -> r.id().equals(id2)).findFirst().orElseThrow();
+
+        assertTrue(rect1.y() != rect2.y(),
+                "Overlapping items should have different y positions");
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/TimelineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/TimelineViewModelTest.java
@@ -1,0 +1,98 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TimelineViewModel} — filters notes by date attributes.
+ */
+class TimelineViewModelTest {
+
+    private NoteService noteService;
+
+    @BeforeEach
+    void setUp() {
+        noteService = new NoteServiceImpl(new InMemoryNoteRepository());
+    }
+
+    @Test
+    @DisplayName("notes without date attribute are excluded")
+    void notesWithoutDate_excluded() {
+        noteService.createNote("No Date", "Content");
+
+        List<TimelineItem> items = TimelineViewModel.filterByDate(
+                noteService.getAllNotes(), Attributes.CREATED);
+
+        // The note has $Created set by Note.create, so it should be included
+        assertEquals(1, items.size());
+    }
+
+    @Test
+    @DisplayName("notes with the selected date attribute are included")
+    void notesWithDate_included() {
+        Note note = noteService.createNote("Has Date", "Content");
+        note.setAttribute(Attributes.START_DATE,
+                new AttributeValue.DateValue(Instant.parse("2026-03-15T00:00:00Z")));
+
+        List<TimelineItem> items = TimelineViewModel.filterByDate(
+                noteService.getAllNotes(), Attributes.START_DATE);
+
+        assertEquals(1, items.size());
+        assertEquals(note.getId(), items.getFirst().id());
+    }
+
+    @Test
+    @DisplayName("filtering by $StartDate excludes notes without $StartDate")
+    void filterByStartDate_excludesNonMatching() {
+        Note withDate = noteService.createNote("With", "");
+        withDate.setAttribute(Attributes.START_DATE,
+                new AttributeValue.DateValue(Instant.now()));
+
+        noteService.createNote("Without", "");
+
+        List<TimelineItem> items = TimelineViewModel.filterByDate(
+                noteService.getAllNotes(), Attributes.START_DATE);
+
+        assertEquals(1, items.size());
+        assertEquals(withDate.getId(), items.getFirst().id());
+    }
+
+    @Test
+    @DisplayName("date range items have both start and end")
+    void dateRange_hasBothDates() {
+        Note note = noteService.createNote("Range", "");
+        Instant start = Instant.parse("2026-01-01T00:00:00Z");
+        Instant end = Instant.parse("2026-01-10T00:00:00Z");
+        note.setAttribute(Attributes.START_DATE,
+                new AttributeValue.DateValue(start));
+        note.setAttribute(Attributes.END_DATE,
+                new AttributeValue.DateValue(end));
+
+        List<TimelineItem> items = TimelineViewModel.filterByDate(
+                noteService.getAllNotes(), Attributes.START_DATE);
+
+        assertEquals(1, items.size());
+        assertEquals(start, items.getFirst().start());
+        assertEquals(end, items.getFirst().end());
+    }
+
+    @Test
+    @DisplayName("empty note list returns empty items")
+    void emptyList_returnsEmpty() {
+        assertTrue(TimelineViewModel.filterByDate(
+                List.of(), Attributes.CREATED).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TimelineLayout` — pure algorithm mapping dates to positioned rectangles with overlap stacking
- Adds `TimelineItem` / `TimelineRect` records for layout input/output
- Adds `TimelineViewModel.filterByDate` — filters notes by selected date attribute, supports date ranges
- Notes without the selected date attribute are excluded
- Pure TDD: every feature started with a failing test

## Test plan
- [x] Unit tests for TimelineLayout (empty, single, ordering, date range width, overlap stacking)
- [x] Unit tests for TimelineViewModel filtering (inclusion, exclusion, date ranges, empty list)
- [x] All existing tests still pass

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)