### PR TITLE
Rich Text Editor: Markdown highlighting and formatting (fixes #221)

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/MarkdownFormatter.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MarkdownFormatter.java
@@ -1,0 +1,71 @@
+package com.embervault.adapter.in.ui.view;
+
+/**
+ * Pure text manipulation for Markdown formatting shortcuts.
+ *
+ * <p>Each toggle method wraps/unwraps the selected text region with
+ * the appropriate Markdown delimiter (**, *, `). Returns a
+ * {@link FormatResult} with the new text and adjusted selection bounds.</p>
+ */
+public final class MarkdownFormatter {
+
+    private MarkdownFormatter() {
+    }
+
+    /**
+     * Result of a formatting operation.
+     *
+     * @param text           the full text after formatting
+     * @param selectionStart the new selection start
+     * @param selectionEnd   the new selection end
+     */
+    public record FormatResult(String text, int selectionStart,
+            int selectionEnd) {
+    }
+
+    /** Toggles bold (**) around the selection. */
+    public static FormatResult toggleBold(String text,
+            int selStart, int selEnd) {
+        return toggle(text, selStart, selEnd, "**");
+    }
+
+    /** Toggles italic (*) around the selection. */
+    public static FormatResult toggleItalic(String text,
+            int selStart, int selEnd) {
+        return toggle(text, selStart, selEnd, "*");
+    }
+
+    /** Toggles inline code (`) around the selection. */
+    public static FormatResult toggleCode(String text,
+            int selStart, int selEnd) {
+        return toggle(text, selStart, selEnd, "`");
+    }
+
+    private static FormatResult toggle(String text,
+            int selStart, int selEnd, String delimiter) {
+        int delimLen = delimiter.length();
+
+        // Check if already wrapped
+        int beforeStart = selStart - delimLen;
+        int afterEnd = selEnd + delimLen;
+        if (beforeStart >= 0 && afterEnd <= text.length()
+                && text.substring(beforeStart, selStart).equals(delimiter)
+                && text.substring(selEnd, afterEnd).equals(delimiter)) {
+            // Remove delimiters
+            String newText = text.substring(0, beforeStart)
+                    + text.substring(selStart, selEnd)
+                    + text.substring(afterEnd);
+            return new FormatResult(newText, beforeStart,
+                    beforeStart + (selEnd - selStart));
+        }
+
+        // Add delimiters
+        String newText = text.substring(0, selStart)
+                + delimiter
+                + text.substring(selStart, selEnd)
+                + delimiter
+                + text.substring(selEnd);
+        return new FormatResult(newText, selStart + delimLen,
+                selEnd + delimLen);
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighter.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighter.java
@@ -1,0 +1,67 @@
+package com.embervault.adapter.in.ui.view;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Computes syntax highlighting style spans for Markdown text.
+ *
+ * <p>Returns a list of {@link StyleSpan} records indicating which ranges
+ * of the text should receive which CSS style class. This is a pure
+ * function with no UI dependencies.</p>
+ */
+public final class MarkdownSyntaxHighlighter {
+
+    private static final Pattern HEADER = Pattern.compile("^#{1,6}\\s+.+$",
+            Pattern.MULTILINE);
+    private static final Pattern BOLD = Pattern.compile("\\*\\*.+?\\*\\*");
+    private static final Pattern ITALIC = Pattern.compile(
+            "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)");
+    private static final Pattern CODE = Pattern.compile("`[^`]+`");
+    private static final Pattern LINK = Pattern.compile("\\[.+?]\\(.+?\\)");
+    private static final Pattern WIKI_LINK = Pattern.compile("\\[\\[.+?]]");
+
+    private MarkdownSyntaxHighlighter() {
+    }
+
+    /**
+     * A range of text with an associated style class.
+     *
+     * @param styleClass the CSS style class name
+     * @param start      the start index (inclusive)
+     * @param end        the end index (exclusive)
+     */
+    public record StyleSpan(String styleClass, int start, int end) {
+    }
+
+    /**
+     * Computes style spans for the given Markdown text.
+     *
+     * @param text the Markdown text
+     * @return an unmodifiable list of style spans
+     */
+    public static List<StyleSpan> computeSpans(String text) {
+        if (text == null || text.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<StyleSpan> spans = new ArrayList<>();
+        addSpans(spans, HEADER, text, "header");
+        addSpans(spans, BOLD, text, "bold");
+        addSpans(spans, ITALIC, text, "italic");
+        addSpans(spans, CODE, text, "code");
+        addSpans(spans, LINK, text, "link");
+        addSpans(spans, WIKI_LINK, text, "link");
+        return Collections.unmodifiableList(spans);
+    }
+
+    private static void addSpans(List<StyleSpan> spans, Pattern pattern,
+            String text, String styleClass) {
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            spans.add(new StyleSpan(styleClass, matcher.start(), matcher.end()));
+        }
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/MarkdownFormatterTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MarkdownFormatterTest.java
@@ -1,0 +1,72 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MarkdownFormatter} — text manipulation for formatting shortcuts.
+ */
+class MarkdownFormatterTest {
+
+    @Test
+    @DisplayName("toggleBold wraps selected text in **")
+    void toggleBold_wrapsInStars() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleBold("hello world", 6, 11);
+        assertEquals("hello **world**", result.text());
+        assertEquals(8, result.selectionStart());
+        assertEquals(13, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleBold removes ** from already bold text")
+    void toggleBold_removesStars() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleBold("hello **world**", 8, 13);
+        assertEquals("hello world", result.text());
+        assertEquals(6, result.selectionStart());
+        assertEquals(11, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleItalic wraps selected text in *")
+    void toggleItalic_wrapsInStar() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleItalic("hello world", 6, 11);
+        assertEquals("hello *world*", result.text());
+        assertEquals(7, result.selectionStart());
+        assertEquals(12, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleItalic removes * from already italic text")
+    void toggleItalic_removesStar() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleItalic("hello *world*", 7, 12);
+        assertEquals("hello world", result.text());
+        assertEquals(6, result.selectionStart());
+        assertEquals(11, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleCode wraps selected text in backticks")
+    void toggleCode_wrapsInBackticks() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleCode("hello world", 6, 11);
+        assertEquals("hello `world`", result.text());
+        assertEquals(7, result.selectionStart());
+        assertEquals(12, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleCode removes backticks from already code text")
+    void toggleCode_removesBackticks() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleCode("hello `world`", 7, 12);
+        assertEquals("hello world", result.text());
+        assertEquals(6, result.selectionStart());
+        assertEquals(11, result.selectionEnd());
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighterTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighterTest.java
@@ -1,0 +1,84 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MarkdownSyntaxHighlighter} — computes style spans for Markdown text.
+ */
+class MarkdownSyntaxHighlighterTest {
+
+    @Test
+    @DisplayName("empty text returns no spans")
+    void emptyText_noSpans() {
+        assertTrue(MarkdownSyntaxHighlighter.computeSpans("").isEmpty());
+    }
+
+    @Test
+    @DisplayName("header line gets header style")
+    void headerLine_getsHeaderStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("# Header");
+        assertEquals(1, spans.size());
+        assertEquals("header", spans.getFirst().styleClass());
+        assertEquals(0, spans.getFirst().start());
+        assertEquals(8, spans.getFirst().end());
+    }
+
+    @Test
+    @DisplayName("bold text gets bold style")
+    void boldText_getBoldStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("some **bold** text");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("bold") && s.start() == 5 && s.end() == 13));
+    }
+
+    @Test
+    @DisplayName("italic text gets italic style")
+    void italicText_getsItalicStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("some *italic* text");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("italic") && s.start() == 5 && s.end() == 13));
+    }
+
+    @Test
+    @DisplayName("inline code gets code style")
+    void inlineCode_getsCodeStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("use `code` here");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("code") && s.start() == 4 && s.end() == 10));
+    }
+
+    @Test
+    @DisplayName("link gets link style")
+    void link_getsLinkStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("[text](url)");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("link")));
+    }
+
+    @Test
+    @DisplayName("wiki-link gets link style")
+    void wikiLink_getsLinkStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("see [[My Note]]");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("link")));
+    }
+
+    @Test
+    @DisplayName("plain text returns no spans")
+    void plainText_noSpans() {
+        assertTrue(MarkdownSyntaxHighlighter.computeSpans(
+                "just plain text").isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MarkdownSyntaxHighlighter` — pure function computing style spans for Markdown elements (headers, bold, italic, code, links, wiki-links)
- Adds `MarkdownFormatter` — text manipulation for keyboard shortcuts (Cmd+B/I toggle bold/italic/code with wrap/unwrap)
- Both classes are pure logic with no UI dependencies, fully testable
- $Text storage remains raw Markdown — no format conversion
- Pure TDD: every feature started with a failing test

## Test plan
- [x] Unit tests for MarkdownSyntaxHighlighter (8 cases: each element type + edge cases)
- [x] Unit tests for MarkdownFormatter (6 cases: wrap and unwrap for bold, italic, code)
- [x] All existing tests still pass

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)