### PR TITLE
Undo/Redo with Memento Pattern (fixes #220)

### DIFF
--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -124,6 +124,30 @@ final class MenuBarFactory {
     }
 
     private static Menu buildEditMenu(WindowContext ctx) {
+        var undoRedo = ctx.sharedServices().undoRedoService();
+        var noteRepo = ctx.sharedServices().noteRepository();
+
+        MenuItem undoItem = new MenuItem("Undo");
+        undoItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.Z,
+                        KeyCombination.SHORTCUT_DOWN));
+        undoItem.setDisable(!undoRedo.canUndo());
+        undoItem.setOnAction(e -> {
+            undoRedo.undo(noteRepo);
+            ctx.refreshAll().run();
+        });
+
+        MenuItem redoItem = new MenuItem("Redo");
+        redoItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.Z,
+                        KeyCombination.SHORTCUT_DOWN,
+                        KeyCombination.SHIFT_DOWN));
+        redoItem.setDisable(!undoRedo.canRedo());
+        redoItem.setOnAction(e -> {
+            undoRedo.redo(noteRepo);
+            ctx.refreshAll().run();
+        });
+
         MenuItem findItem = new MenuItem("Find");
         findItem.setAccelerator(
                 new KeyCodeCombination(KeyCode.F,
@@ -133,8 +157,10 @@ final class MenuBarFactory {
                 ctx.onFind().run();
             }
         });
+
         Menu menu = new Menu("Edit");
-        menu.getItems().add(findItem);
+        menu.getItems().addAll(undoItem, redoItem,
+                new SeparatorMenuItem(), findItem);
         return menu;
     }
 

--- a/src/main/java/com/embervault/SharedServices.java
+++ b/src/main/java/com/embervault/SharedServices.java
@@ -48,7 +48,9 @@ public record SharedServices(
         Project project =
                 new ProjectServiceImpl().createEmptyProject();
         InMemoryNoteRepository noteRepo = new InMemoryNoteRepository();
-        NoteService noteService = new NoteServiceImpl(noteRepo);
+        UndoRedoService undoRedoService = new UndoRedoService();
+        NoteService noteService = new NoteServiceImpl(
+                noteRepo, undoRedoService);
         LinkService linkService =
                 new LinkServiceImpl(new InMemoryLinkRepository());
         StampService stampService = new StampServiceImpl(
@@ -56,7 +58,6 @@ public record SharedServices(
         noteRepo.save(project.getRootNote());
         AttributeSchemaRegistry schemaRegistry =
                 new AttributeSchemaRegistry();
-        UndoRedoService undoRedoService = new UndoRedoService();
         return new SharedServices(project, noteRepo,
                 noteService, linkService,
                 stampService, schemaRegistry,

--- a/src/main/java/com/embervault/SharedServices.java
+++ b/src/main/java/com/embervault/SharedServices.java
@@ -7,6 +7,7 @@ import com.embervault.application.LinkServiceImpl;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.ProjectServiceImpl;
 import com.embervault.application.StampServiceImpl;
+import com.embervault.application.UndoRedoService;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
@@ -25,7 +26,8 @@ import com.embervault.domain.Project;
  * @param noteService     the note service
  * @param linkService     the link service
  * @param stampService    the stamp service
- * @param schemaRegistry  the attribute schema registry
+ * @param schemaRegistry    the attribute schema registry
+ * @param undoRedoService   the undo/redo service
  */
 public record SharedServices(
         Project project,
@@ -33,7 +35,8 @@ public record SharedServices(
         NoteService noteService,
         LinkService linkService,
         StampService stampService,
-        AttributeSchemaRegistry schemaRegistry
+        AttributeSchemaRegistry schemaRegistry,
+        UndoRedoService undoRedoService
 ) {
 
     /**
@@ -53,8 +56,10 @@ public record SharedServices(
         noteRepo.save(project.getRootNote());
         AttributeSchemaRegistry schemaRegistry =
                 new AttributeSchemaRegistry();
+        UndoRedoService undoRedoService = new UndoRedoService();
         return new SharedServices(project, noteRepo,
                 noteService, linkService,
-                stampService, schemaRegistry);
+                stampService, schemaRegistry,
+                undoRedoService);
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/SelectedNoteViewModel.java
@@ -1,12 +1,9 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
-import static com.embervault.domain.Attributes.TEXT;
-
 import java.util.Objects;
 import java.util.UUID;
 
 import com.embervault.application.port.in.NoteService;
-import com.embervault.domain.AttributeValue;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -109,8 +106,11 @@ public final class SelectedNoteViewModel {
             return;
         }
         noteService.getNote(noteId).ifPresent(note -> {
-            note.setAttribute(TEXT,
-                    new AttributeValue.StringValue(newText));
+            String currentTitle = note.getTitle();
+            if (currentTitle == null || currentTitle.isBlank()) {
+                currentTitle = "Untitled";
+            }
+            noteService.updateNote(noteId, currentTitle, newText);
         });
         text.set(newText);
         dataChangeSupport.notifyDataChanged();

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -42,24 +42,36 @@ public final class NoteServiceImpl implements NoteService {
 
     private final NoteRepository repository;
     private final Random random;
+    private final UndoRedoService undoRedoService;
 
-    /**
-     * Constructs a NoteServiceImpl backed by the given repository.
-     */
+    /** Constructs a NoteServiceImpl backed by the given repository. */
     public NoteServiceImpl(NoteRepository repository) {
-        this(repository, new Random());
+        this(repository, new Random(), null);
     }
 
-    /**
-     * Constructs a NoteServiceImpl backed by the given repository and random source.
-     *
-     * @param repository the repository
-     * @param random     the random source for position generation
-     */
+    /** Constructs a NoteServiceImpl with an undo/redo service. */
+    public NoteServiceImpl(NoteRepository repository,
+            UndoRedoService undoRedoService) {
+        this(repository, new Random(), undoRedoService);
+    }
+
+    /** Constructs with repository, random source, and optional undo. */
     public NoteServiceImpl(NoteRepository repository, Random random) {
+        this(repository, random, null);
+    }
+
+    private NoteServiceImpl(NoteRepository repository, Random random,
+            UndoRedoService undoRedoService) {
         this.repository = Objects.requireNonNull(repository,
                 "repository must not be null");
         this.random = Objects.requireNonNull(random, "random must not be null");
+        this.undoRedoService = undoRedoService;
+    }
+
+    private void recordForUndo(Note note) {
+        if (undoRedoService != null) {
+            undoRedoService.recordChange(note);
+        }
     }
 
     @Override
@@ -83,6 +95,7 @@ public final class NoteServiceImpl implements NoteService {
         Note note = repository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + id));
+        recordForUndo(note);
         note.update(title, content);
         return repository.save(note);
     }
@@ -117,6 +130,7 @@ public final class NoteServiceImpl implements NoteService {
         Note note = repository.findById(noteId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
+        recordForUndo(note);
         note.setAttribute(NAME, new AttributeValue.StringValue(newTitle));
         return repository.save(note);
     }
@@ -149,6 +163,7 @@ public final class NoteServiceImpl implements NoteService {
         Note note = repository.findById(noteId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
+        recordForUndo(note);
         repository.findById(newParentId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Parent note not found: " + newParentId));
@@ -168,6 +183,7 @@ public final class NoteServiceImpl implements NoteService {
         Note note = repository.findById(noteId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
+        recordForUndo(note);
         repository.findById(newParentId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Parent not found: " + newParentId));
@@ -254,6 +270,7 @@ public final class NoteServiceImpl implements NoteService {
         Note note = repository.findById(noteId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
+        recordForUndo(note);
 
         String containerId = note.getAttribute(CONTAINER)
                 .filter(v -> v instanceof AttributeValue.StringValue)
@@ -307,6 +324,7 @@ public final class NoteServiceImpl implements NoteService {
         Note note = repository.findById(noteId)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Note not found: " + noteId));
+        recordForUndo(note);
 
         String containerId = note.getAttribute(CONTAINER)
                 .filter(v -> v instanceof AttributeValue.StringValue)

--- a/src/main/java/com/embervault/application/UndoRedoService.java
+++ b/src/main/java/com/embervault/application/UndoRedoService.java
@@ -1,0 +1,79 @@
+package com.embervault.application;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.Note;
+import com.embervault.domain.NoteMemento;
+
+/**
+ * Manages undo/redo stacks using the Memento pattern.
+ *
+ * <p>Before each mutation, callers record the note's current state via
+ * {@link #recordChange(Note)}. Undo restores the most recent memento
+ * and pushes the current state onto the redo stack.</p>
+ */
+public class UndoRedoService {
+
+    private static final int MAX_STACK_SIZE = 50;
+
+    private final Deque<NoteMemento> undoStack = new ArrayDeque<>();
+    private final Deque<NoteMemento> redoStack = new ArrayDeque<>();
+
+    /**
+     * Records the current state of a note before it is mutated.
+     *
+     * @param note the note about to be changed
+     */
+    public void recordChange(Note note) {
+        undoStack.push(NoteMemento.capture(note));
+        redoStack.clear();
+        if (undoStack.size() > MAX_STACK_SIZE) {
+            undoStack.removeLast();
+        }
+    }
+
+    /**
+     * Undoes the most recent change by restoring the note from the
+     * top memento and pushing the current state onto the redo stack.
+     *
+     * @param repository the repository to retrieve and save the note
+     */
+    public void undo(NoteRepository repository) {
+        if (undoStack.isEmpty()) {
+            return;
+        }
+        NoteMemento memento = undoStack.pop();
+        Note note = repository.findById(memento.getNoteId()).orElseThrow();
+        redoStack.push(NoteMemento.capture(note));
+        memento.restore(note);
+        repository.save(note);
+    }
+
+    /**
+     * Redoes the most recently undone change.
+     *
+     * @param repository the repository to retrieve and save the note
+     */
+    public void redo(NoteRepository repository) {
+        if (redoStack.isEmpty()) {
+            return;
+        }
+        NoteMemento memento = redoStack.pop();
+        Note note = repository.findById(memento.getNoteId()).orElseThrow();
+        undoStack.push(NoteMemento.capture(note));
+        memento.restore(note);
+        repository.save(note);
+    }
+
+    /** Returns whether there are changes that can be undone. */
+    public boolean canUndo() {
+        return !undoStack.isEmpty();
+    }
+
+    /** Returns whether there are changes that can be redone. */
+    public boolean canRedo() {
+        return !redoStack.isEmpty();
+    }
+}

--- a/src/main/java/com/embervault/domain/NoteMemento.java
+++ b/src/main/java/com/embervault/domain/NoteMemento.java
@@ -1,0 +1,63 @@
+package com.embervault.domain;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * An immutable snapshot of a note's state at a point in time.
+ *
+ * <p>Captures the note's id, attribute map, and prototype id so the
+ * note can be restored to this exact state later (Memento pattern).</p>
+ */
+public final class NoteMemento {
+
+    private final UUID noteId;
+    private final AttributeMap attributeSnapshot;
+    private final UUID prototypeId;
+
+    private NoteMemento(UUID noteId, AttributeMap attributeSnapshot,
+            UUID prototypeId) {
+        this.noteId = Objects.requireNonNull(noteId);
+        this.attributeSnapshot = Objects.requireNonNull(attributeSnapshot);
+        this.prototypeId = prototypeId;
+    }
+
+    /**
+     * Captures an immutable snapshot of the given note's current state.
+     *
+     * @param note the note to snapshot
+     * @return a memento holding a copy of the note's attributes
+     */
+    public static NoteMemento capture(Note note) {
+        return new NoteMemento(
+                note.getId(),
+                new AttributeMap(note.getAttributes()),
+                note.getPrototypeId().orElse(null));
+    }
+
+    /**
+     * Restores the given note to the state captured in this memento.
+     *
+     * @param note the note to restore (must have the same id)
+     */
+    public void restore(Note note) {
+        if (!note.getId().equals(noteId)) {
+            throw new IllegalArgumentException(
+                    "Cannot restore memento for note " + noteId
+                    + " onto note " + note.getId());
+        }
+        AttributeMap current = note.getAttributes();
+        for (String key : current.localEntries().keySet().toArray(String[]::new)) {
+            current.remove(key);
+        }
+        for (var entry : attributeSnapshot.localEntries().entrySet()) {
+            current.set(entry.getKey(), entry.getValue());
+        }
+        note.setPrototypeId(prototypeId);
+    }
+
+    /** Returns the id of the note this memento was captured from. */
+    public UUID getNoteId() {
+        return noteId;
+    }
+}

--- a/src/test/java/com/embervault/SharedServicesTest.java
+++ b/src/test/java/com/embervault/SharedServicesTest.java
@@ -10,6 +10,7 @@ import com.embervault.application.LinkServiceImpl;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.ProjectServiceImpl;
 import com.embervault.application.StampServiceImpl;
+import com.embervault.application.UndoRedoService;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
@@ -35,9 +36,10 @@ class SharedServicesTest {
         AttributeSchemaRegistry registry = new AttributeSchemaRegistry();
         Project project = new ProjectServiceImpl().createEmptyProject();
 
+        UndoRedoService undoRedoService = new UndoRedoService();
         SharedServices services = new SharedServices(
                 project, noteRepo, noteService, linkService,
-                stampService, registry);
+                stampService, registry, undoRedoService);
 
         assertNotNull(services.project());
         assertSame(noteService, services.noteService());

--- a/src/test/java/com/embervault/application/UndoRedoAutoRecordTest.java
+++ b/src/test/java/com/embervault/application/UndoRedoAutoRecordTest.java
@@ -1,0 +1,64 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that NoteServiceImpl auto-records changes to UndoRedoService.
+ */
+class UndoRedoAutoRecordTest {
+
+    private UndoRedoService undoRedoService;
+    private NoteServiceImpl noteService;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        undoRedoService = new UndoRedoService();
+        noteService = new NoteServiceImpl(repository, undoRedoService);
+    }
+
+    @Test
+    @DisplayName("renameNote auto-records for undo")
+    void renameNote_autoRecords() {
+        Note note = noteService.createNote("Original", "Content");
+
+        noteService.renameNote(note.getId(), "Renamed");
+        assertTrue(undoRedoService.canUndo());
+
+        undoRedoService.undo(repository);
+        assertEquals("Original",
+                repository.findById(note.getId()).orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("updateNote auto-records for undo")
+    void updateNote_autoRecords() {
+        Note note = noteService.createNote("Title", "Original text");
+
+        noteService.updateNote(note.getId(), "Title", "New text");
+        assertTrue(undoRedoService.canUndo());
+
+        undoRedoService.undo(repository);
+        assertEquals("Original text",
+                repository.findById(note.getId()).orElseThrow().getContent());
+    }
+
+    @Test
+    @DisplayName("moveNote auto-records for undo")
+    void moveNote_autoRecords() {
+        Note parent1 = noteService.createNote("Parent1", "");
+        Note parent2 = noteService.createNote("Parent2", "");
+        Note child = noteService.createChildNote(parent1.getId(), "Child");
+
+        noteService.moveNote(child.getId(), parent2.getId());
+        assertTrue(undoRedoService.canUndo());
+    }
+}

--- a/src/test/java/com/embervault/application/UndoRedoServiceIntegrationTest.java
+++ b/src/test/java/com/embervault/application/UndoRedoServiceIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.SharedServices;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test verifying UndoRedoService is wired into SharedServices.
+ */
+class UndoRedoServiceIntegrationTest {
+
+    private SharedServices services;
+
+    @BeforeEach
+    void setUp() {
+        services = SharedServices.create();
+    }
+
+    @Test
+    @DisplayName("SharedServices exposes an UndoRedoService")
+    void sharedServicesHasUndoRedo() {
+        assertNotNull(services.undoRedoService());
+    }
+
+    @Test
+    @DisplayName("undo via SharedServices restores note state")
+    void undoViaSharedServices() {
+        Note note = services.noteService().createNote("Original", "");
+        services.undoRedoService().recordChange(note);
+
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed"));
+        services.noteRepository().save(note);
+
+        assertTrue(services.undoRedoService().canUndo());
+        services.undoRedoService().undo(services.noteRepository());
+
+        assertEquals("Original",
+                services.noteRepository().findById(note.getId())
+                        .orElseThrow().getTitle());
+        assertFalse(services.undoRedoService().canUndo());
+    }
+}

--- a/src/test/java/com/embervault/application/UndoRedoServiceTest.java
+++ b/src/test/java/com/embervault/application/UndoRedoServiceTest.java
@@ -1,0 +1,145 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UndoRedoService}.
+ */
+class UndoRedoServiceTest {
+
+    private UndoRedoService undoRedoService;
+    private NoteService noteService;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        undoRedoService = new UndoRedoService();
+    }
+
+    @Test
+    @DisplayName("initially canUndo and canRedo are false")
+    void initialState() {
+        assertFalse(undoRedoService.canUndo());
+        assertFalse(undoRedoService.canRedo());
+    }
+
+    @Test
+    @DisplayName("after recording a change, canUndo is true")
+    void recordChange_enablesUndo() {
+        Note note = noteService.createNote("Title", "Content");
+        undoRedoService.recordChange(note);
+
+        assertTrue(undoRedoService.canUndo());
+        assertFalse(undoRedoService.canRedo());
+    }
+
+    @Test
+    @DisplayName("undo restores note to previous state")
+    void undo_restoresPreviousState() {
+        Note note = noteService.createNote("Original", "Content");
+        undoRedoService.recordChange(note);
+
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed"));
+        repository.save(note);
+
+        undoRedoService.undo(repository);
+
+        Note restored = repository.findById(note.getId()).orElseThrow();
+        assertEquals("Original", restored.getTitle());
+    }
+
+    @Test
+    @DisplayName("redo re-applies an undone change")
+    void redo_reappliesChange() {
+        Note note = noteService.createNote("Original", "Content");
+        undoRedoService.recordChange(note);
+
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed"));
+        repository.save(note);
+
+        undoRedoService.undo(repository);
+        assertTrue(undoRedoService.canRedo());
+
+        undoRedoService.redo(repository);
+
+        Note result = repository.findById(note.getId()).orElseThrow();
+        assertEquals("Changed", result.getTitle());
+    }
+
+    @Test
+    @DisplayName("new change after undo clears redo stack")
+    void newChange_clearsRedoStack() {
+        Note note = noteService.createNote("Original", "Content");
+        undoRedoService.recordChange(note);
+
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed"));
+        repository.save(note);
+
+        undoRedoService.undo(repository);
+        assertTrue(undoRedoService.canRedo());
+
+        undoRedoService.recordChange(note);
+        assertFalse(undoRedoService.canRedo());
+    }
+
+    @Test
+    @DisplayName("multiple undos work in reverse order")
+    void multipleUndos_reverseOrder() {
+        Note note = noteService.createNote("First", "Content");
+
+        undoRedoService.recordChange(note);
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Second"));
+        repository.save(note);
+
+        undoRedoService.recordChange(note);
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Third"));
+        repository.save(note);
+
+        undoRedoService.undo(repository);
+        assertEquals("Second",
+                repository.findById(note.getId()).orElseThrow().getTitle());
+
+        undoRedoService.undo(repository);
+        assertEquals("First",
+                repository.findById(note.getId()).orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("undo stack respects max size limit")
+    void undoStack_respectsMaxSize() {
+        Note note = noteService.createNote("Start", "Content");
+
+        for (int i = 0; i < 60; i++) {
+            undoRedoService.recordChange(note);
+            note.setAttribute(Attributes.NAME,
+                    new AttributeValue.StringValue("Change " + i));
+            repository.save(note);
+        }
+
+        int undoCount = 0;
+        while (undoRedoService.canUndo()) {
+            undoRedoService.undo(repository);
+            undoCount++;
+        }
+
+        assertTrue(undoCount <= 50);
+    }
+}

--- a/src/test/java/com/embervault/domain/NoteMementoTest.java
+++ b/src/test/java/com/embervault/domain/NoteMementoTest.java
@@ -1,0 +1,65 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link NoteMemento} — immutable snapshots of note state.
+ */
+class NoteMementoTest {
+
+    @Test
+    @DisplayName("memento captures note attributes and can restore them")
+    void captureAndRestore() {
+        Note note = Note.create("Original Title", "Original content");
+
+        NoteMemento memento = NoteMemento.capture(note);
+
+        note.setAttribute(Attributes.NAME,
+                new AttributeValue.StringValue("Changed Title"));
+        note.setAttribute(Attributes.TEXT,
+                new AttributeValue.StringValue("Changed content"));
+        assertEquals("Changed Title", note.getTitle());
+
+        memento.restore(note);
+
+        assertEquals("Original Title", note.getTitle());
+        assertEquals("Original content", note.getContent());
+    }
+
+    @Test
+    @DisplayName("memento holds an independent copy of attributes")
+    void mementoIsIndependentCopy() {
+        Note note = Note.create("Title", "Content");
+
+        NoteMemento memento = NoteMemento.capture(note);
+
+        note.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+
+        memento.restore(note);
+
+        assertEquals(Optional.empty(), note.getAttribute(Attributes.COLOR));
+    }
+
+    @Test
+    @DisplayName("memento captures and restores prototype id")
+    void capturesPrototypeId() {
+        Note note = Note.create("Title", "Content");
+        java.util.UUID protoId = java.util.UUID.randomUUID();
+        note.setPrototypeId(protoId);
+
+        NoteMemento memento = NoteMemento.capture(note);
+
+        note.setPrototypeId(null);
+        assertEquals(Optional.empty(), note.getPrototypeId());
+
+        memento.restore(note);
+
+        assertEquals(Optional.of(protoId), note.getPrototypeId());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `NoteMemento` domain class — immutable snapshot of note state (attributes + prototype id)
- Adds `UndoRedoService` in application layer — manages undo/redo stacks with Memento pattern
- Wires `UndoRedoService` into `SharedServices` so all windows share undo state
- Adds **Undo** (Cmd+Z) and **Redo** (Cmd+Shift+Z) to the Edit menu with separator before Find
- Undo restores previous state, redo re-applies, new actions clear redo stack
- Stack capped at 50 entries to bound memory usage
- Pure TDD: every feature started with a failing test

## Test plan
- [x] Unit tests for NoteMemento capture/restore/independence/prototype
- [x] Unit tests for UndoRedoService (initial state, undo, redo, ordering, redo-clear, stack limit)
- [x] Integration test for SharedServices wiring and undo flow
- [x] All existing tests still pass

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)