### PR TITLE
Rich Text Editor: Markdown highlighting and formatting (fixes #221)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.fxmisc.richtext</groupId>
+            <artifactId>richtextfx</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
             <version>${archunit-junit5.version}</version>

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -133,8 +133,33 @@ final class MenuBarFactory {
                 ctx.onFind().run();
             }
         });
+
+        Menu formatMenu = buildFormatMenu();
+
         Menu menu = new Menu("Edit");
-        menu.getItems().add(findItem);
+        menu.getItems().addAll(findItem,
+                new SeparatorMenuItem(), formatMenu);
+        return menu;
+    }
+
+    private static Menu buildFormatMenu() {
+        MenuItem boldItem = new MenuItem("Bold");
+        boldItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.B,
+                        KeyCombination.SHORTCUT_DOWN));
+
+        MenuItem italicItem = new MenuItem("Italic");
+        italicItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.I,
+                        KeyCombination.SHORTCUT_DOWN));
+
+        MenuItem codeItem = new MenuItem("Code");
+        codeItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.K,
+                        KeyCombination.SHORTCUT_DOWN));
+
+        Menu menu = new Menu("Format");
+        menu.getItems().addAll(boldItem, italicItem, codeItem);
         return menu;
     }
 

--- a/src/main/java/com/embervault/adapter/in/ui/view/MarkdownEditorHelper.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MarkdownEditorHelper.java
@@ -1,0 +1,46 @@
+package com.embervault.adapter.in.ui.view;
+
+import java.util.List;
+
+/**
+ * Bridges {@link MarkdownSyntaxHighlighter} and {@link MarkdownFormatter}
+ * for use by the text pane editor.
+ *
+ * <p>Provides a single entry point for computing highlights and
+ * applying formatting operations. The controller delegates to this
+ * helper so the logic remains testable without JavaFX.</p>
+ */
+public final class MarkdownEditorHelper {
+
+    private MarkdownEditorHelper() {
+    }
+
+    /**
+     * Computes syntax highlighting spans for the given text.
+     *
+     * @param text the Markdown text
+     * @return style spans for highlighting
+     */
+    public static List<MarkdownSyntaxHighlighter.StyleSpan> computeHighlighting(
+            String text) {
+        return MarkdownSyntaxHighlighter.computeSpans(text);
+    }
+
+    /** Toggles bold around the selection. */
+    public static MarkdownFormatter.FormatResult applyBold(
+            String text, int selStart, int selEnd) {
+        return MarkdownFormatter.toggleBold(text, selStart, selEnd);
+    }
+
+    /** Toggles italic around the selection. */
+    public static MarkdownFormatter.FormatResult applyItalic(
+            String text, int selStart, int selEnd) {
+        return MarkdownFormatter.toggleItalic(text, selStart, selEnd);
+    }
+
+    /** Toggles code around the selection. */
+    public static MarkdownFormatter.FormatResult applyCode(
+            String text, int selStart, int selEnd) {
+        return MarkdownFormatter.toggleCode(text, selStart, selEnd);
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/MarkdownFormatter.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MarkdownFormatter.java
@@ -1,0 +1,68 @@
+package com.embervault.adapter.in.ui.view;
+
+/**
+ * Pure text manipulation for Markdown formatting shortcuts.
+ *
+ * <p>Each toggle method wraps/unwraps the selected text region with
+ * the appropriate Markdown delimiter. Returns a {@link FormatResult}
+ * with the new text and adjusted selection bounds.</p>
+ */
+public final class MarkdownFormatter {
+
+    private MarkdownFormatter() {
+    }
+
+    /**
+     * Result of a formatting operation.
+     *
+     * @param text           the full text after formatting
+     * @param selectionStart the new selection start
+     * @param selectionEnd   the new selection end
+     */
+    public record FormatResult(String text, int selectionStart,
+            int selectionEnd) {
+    }
+
+    /** Toggles bold (**) around the selection. */
+    public static FormatResult toggleBold(String text,
+            int selStart, int selEnd) {
+        return toggle(text, selStart, selEnd, "**");
+    }
+
+    /** Toggles italic (*) around the selection. */
+    public static FormatResult toggleItalic(String text,
+            int selStart, int selEnd) {
+        return toggle(text, selStart, selEnd, "*");
+    }
+
+    /** Toggles inline code (`) around the selection. */
+    public static FormatResult toggleCode(String text,
+            int selStart, int selEnd) {
+        return toggle(text, selStart, selEnd, "`");
+    }
+
+    private static FormatResult toggle(String text,
+            int selStart, int selEnd, String delimiter) {
+        int delimLen = delimiter.length();
+        int beforeStart = selStart - delimLen;
+        int afterEnd = selEnd + delimLen;
+
+        if (beforeStart >= 0 && afterEnd <= text.length()
+                && text.substring(beforeStart, selStart).equals(delimiter)
+                && text.substring(selEnd, afterEnd).equals(delimiter)) {
+            String newText = text.substring(0, beforeStart)
+                    + text.substring(selStart, selEnd)
+                    + text.substring(afterEnd);
+            return new FormatResult(newText, beforeStart,
+                    beforeStart + (selEnd - selStart));
+        }
+
+        String newText = text.substring(0, selStart)
+                + delimiter
+                + text.substring(selStart, selEnd)
+                + delimiter
+                + text.substring(selEnd);
+        return new FormatResult(newText, selStart + delimLen,
+                selEnd + delimLen);
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighter.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighter.java
@@ -1,0 +1,67 @@
+package com.embervault.adapter.in.ui.view;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Computes syntax highlighting style spans for Markdown text.
+ *
+ * <p>Pure function with no UI dependencies — returns {@link StyleSpan}
+ * records indicating which text ranges get which CSS style class.</p>
+ */
+public final class MarkdownSyntaxHighlighter {
+
+    private static final Pattern HEADER = Pattern.compile(
+            "^#{1,6}\\s+.+$", Pattern.MULTILINE);
+    private static final Pattern BOLD = Pattern.compile("\\*\\*.+?\\*\\*");
+    private static final Pattern ITALIC = Pattern.compile(
+            "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)");
+    private static final Pattern CODE = Pattern.compile("`[^`]+`");
+    private static final Pattern LINK = Pattern.compile("\\[.+?]\\(.+?\\)");
+    private static final Pattern WIKI_LINK = Pattern.compile("\\[\\[.+?]]");
+
+    private MarkdownSyntaxHighlighter() {
+    }
+
+    /**
+     * A text range with an associated style class.
+     *
+     * @param styleClass the CSS style class name
+     * @param start      the start index (inclusive)
+     * @param end        the end index (exclusive)
+     */
+    public record StyleSpan(String styleClass, int start, int end) {
+    }
+
+    /**
+     * Computes style spans for the given Markdown text.
+     *
+     * @param text the Markdown text
+     * @return an unmodifiable list of style spans
+     */
+    public static List<StyleSpan> computeSpans(String text) {
+        if (text == null || text.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<StyleSpan> spans = new ArrayList<>();
+        addSpans(spans, HEADER, text, "header");
+        addSpans(spans, BOLD, text, "bold");
+        addSpans(spans, ITALIC, text, "italic");
+        addSpans(spans, CODE, text, "code");
+        addSpans(spans, LINK, text, "link");
+        addSpans(spans, WIKI_LINK, text, "link");
+        return Collections.unmodifiableList(spans);
+    }
+
+    private static void addSpans(List<StyleSpan> spans,
+            Pattern pattern, String text, String styleClass) {
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            spans.add(new StyleSpan(styleClass,
+                    matcher.start(), matcher.end()));
+        }
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/TextPaneViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TextPaneViewController.java
@@ -1,42 +1,74 @@
 package com.embervault.adapter.in.ui.view;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.VBox;
+import org.fxmisc.richtext.StyleClassedTextArea;
+import org.fxmisc.richtext.model.StyleSpans;
+import org.fxmisc.richtext.model.StyleSpansBuilder;
 
 /**
  * FXML controller for the Text Pane view.
  *
- * <p>Binds the title and text fields to the SelectedNoteViewModel.
- * Shows a placeholder when no note is selected, and saves changes
- * on focus-lost or Enter key press.</p>
+ * <p>Uses a RichTextFX {@link StyleClassedTextArea} for Markdown syntax
+ * highlighting. Binds to {@link SelectedNoteViewModel} for note
+ * selection and persistence.</p>
  */
 public class TextPaneViewController {
 
     @FXML private VBox textPaneRoot;
     @FXML private Label placeholderLabel;
     @FXML private TextField titleField;
-    @FXML private TextArea textArea;
 
+    private StyleClassedTextArea editor;
     private SelectedNoteViewModel viewModel;
+    private boolean suppressTextSync;
 
     /**
-     * Injects the ViewModel and binds UI controls to its properties.
+     * Called by FXML after loading. Creates the rich text editor
+     * programmatically (RichTextFX controls aren't FXML-native).
+     */
+    @FXML
+    void initialize() {
+        editor = new StyleClassedTextArea();
+        editor.setWrapText(true);
+        editor.getStyleClass().add("markdown-editor");
+        editor.getStylesheets().add(getClass().getResource(
+                "markdown-editor.css").toExternalForm());
+        editor.setVisible(false);
+        editor.setManaged(false);
+        VBox.setVgrow(editor, javafx.scene.layout.Priority.ALWAYS);
+        textPaneRoot.getChildren().add(editor);
+
+        editor.textProperty().addListener(
+                (obs, oldVal, newVal) -> applyHighlighting());
+
+        wireFormatShortcuts();
+    }
+
+    /**
+     * Injects the ViewModel and binds UI controls.
      *
      * @param viewModel the selected note view model
      */
     public void initViewModel(SelectedNoteViewModel viewModel) {
         this.viewModel = viewModel;
 
-        // Show/hide placeholder vs editor based on selection
         viewModel.selectedNoteIdProperty().addListener(
-                (obs, oldVal, newVal) -> updateVisibility(newVal != null));
-        updateVisibility(viewModel.selectedNoteIdProperty().get() != null);
+                (obs, oldVal, newVal) ->
+                        updateVisibility(newVal != null));
+        updateVisibility(
+                viewModel.selectedNoteIdProperty().get() != null);
 
-        // Bind title field
         titleField.setText(viewModel.titleProperty().get());
         viewModel.titleProperty().addListener(
                 (obs, oldVal, newVal) -> {
@@ -45,7 +77,6 @@ public class TextPaneViewController {
                     }
                 });
 
-        // Save title on focus lost
         titleField.focusedProperty().addListener(
                 (obs, wasFocused, isFocused) -> {
                     if (!isFocused) {
@@ -53,24 +84,24 @@ public class TextPaneViewController {
                     }
                 });
 
-        // Save title on Enter
         titleField.setOnAction(
                 e -> viewModel.saveTitle(titleField.getText()));
 
-        // Bind text area
-        textArea.setText(viewModel.textProperty().get());
+        setEditorText(viewModel.textProperty().get());
         viewModel.textProperty().addListener(
                 (obs, oldVal, newVal) -> {
-                    if (!textArea.getText().equals(newVal)) {
-                        textArea.setText(newVal);
+                    if (!suppressTextSync
+                            && !editor.getText().equals(newVal)) {
+                        setEditorText(newVal);
                     }
                 });
 
-        // Save text on focus lost
-        textArea.focusedProperty().addListener(
+        editor.focusedProperty().addListener(
                 (obs, wasFocused, isFocused) -> {
                     if (!isFocused) {
-                        viewModel.saveText(textArea.getText());
+                        suppressTextSync = true;
+                        viewModel.saveText(editor.getText());
+                        suppressTextSync = false;
                     }
                 });
     }
@@ -80,12 +111,100 @@ public class TextPaneViewController {
         return viewModel;
     }
 
+    private void setEditorText(String text) {
+        editor.replaceText(text != null ? text : "");
+        applyHighlighting();
+    }
+
+    private void applyHighlighting() {
+        String text = editor.getText();
+        if (text.isEmpty()) {
+            return;
+        }
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownEditorHelper.computeHighlighting(text);
+        editor.setStyleSpans(0, buildStyleSpans(text, spans));
+    }
+
+    private StyleSpans<Collection<String>> buildStyleSpans(
+            String text,
+            List<MarkdownSyntaxHighlighter.StyleSpan> spans) {
+        StyleSpansBuilder<Collection<String>> builder =
+                new StyleSpansBuilder<>();
+        int lastEnd = 0;
+        // Sort by start position
+        List<MarkdownSyntaxHighlighter.StyleSpan> sorted =
+                spans.stream()
+                        .sorted((a, b) -> Integer.compare(
+                                a.start(), b.start()))
+                        .toList();
+        for (MarkdownSyntaxHighlighter.StyleSpan span : sorted) {
+            if (span.start() < lastEnd) {
+                continue; // skip overlapping spans
+            }
+            if (span.start() > lastEnd) {
+                builder.add(Collections.emptyList(),
+                        span.start() - lastEnd);
+            }
+            builder.add(List.of(span.styleClass()),
+                    span.end() - span.start());
+            lastEnd = span.end();
+        }
+        if (lastEnd < text.length()) {
+            builder.add(Collections.emptyList(),
+                    text.length() - lastEnd);
+        }
+        return builder.create();
+    }
+
+    private void wireFormatShortcuts() {
+        KeyCodeCombination boldCombo = new KeyCodeCombination(
+                KeyCode.B, KeyCombination.SHORTCUT_DOWN);
+        KeyCodeCombination italicCombo = new KeyCodeCombination(
+                KeyCode.I, KeyCombination.SHORTCUT_DOWN);
+        KeyCodeCombination codeCombo = new KeyCodeCombination(
+                KeyCode.K, KeyCombination.SHORTCUT_DOWN);
+
+        editor.setOnKeyPressed(event -> {
+            if (boldCombo.match(event)) {
+                applyFormat(MarkdownEditorHelper::applyBold);
+                event.consume();
+            } else if (italicCombo.match(event)) {
+                applyFormat(MarkdownEditorHelper::applyItalic);
+                event.consume();
+            } else if (codeCombo.match(event)) {
+                applyFormat(MarkdownEditorHelper::applyCode);
+                event.consume();
+            }
+        });
+    }
+
+    private void applyFormat(FormatFunction fn) {
+        String text = editor.getText();
+        int selStart = editor.getSelection().getStart();
+        int selEnd = editor.getSelection().getEnd();
+        if (selStart == selEnd) {
+            return;
+        }
+        MarkdownFormatter.FormatResult result =
+                fn.apply(text, selStart, selEnd);
+        editor.replaceText(result.text());
+        editor.selectRange(result.selectionStart(),
+                result.selectionEnd());
+    }
+
+    @FunctionalInterface
+    private interface FormatFunction {
+        MarkdownFormatter.FormatResult apply(
+                String text, int selStart, int selEnd);
+    }
+
     private void updateVisibility(boolean noteSelected) {
         placeholderLabel.setVisible(!noteSelected);
         placeholderLabel.setManaged(!noteSelected);
         titleField.setVisible(noteSelected);
         titleField.setManaged(noteSelected);
-        textArea.setVisible(noteSelected);
-        textArea.setManaged(noteSelected);
+        editor.setVisible(noteSelected);
+        editor.setManaged(noteSelected);
     }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module com.embervault {
     requires javafx.controls;
     requires javafx.fxml;
+    requires org.fxmisc.richtext;
     requires org.slf4j;
     requires org.snakeyaml.engine.v2;
 

--- a/src/main/resources/com/embervault/adapter/in/ui/view/TextPaneView.fxml
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/TextPaneView.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.VBox?>
 
@@ -19,6 +18,5 @@
     <TextField fx:id="titleField" promptText="Note title"
                style="-fx-font-weight: bold; -fx-font-size: 16px;"
                visible="false" managed="false"/>
-    <TextArea fx:id="textArea" promptText="Note content" wrapText="true"
-              VBox.vgrow="ALWAYS" visible="false" managed="false"/>
+    <!-- StyleClassedTextArea added programmatically in initialize() -->
 </VBox>

--- a/src/main/resources/com/embervault/adapter/in/ui/view/markdown-editor.css
+++ b/src/main/resources/com/embervault/adapter/in/ui/view/markdown-editor.css
@@ -1,0 +1,29 @@
+.markdown-editor {
+    -fx-font-family: "System";
+    -fx-font-size: 14px;
+}
+
+.markdown-editor .header {
+    -fx-font-weight: bold;
+    -fx-font-size: 18px;
+    -fx-fill: #2c3e50;
+}
+
+.markdown-editor .bold {
+    -fx-font-weight: bold;
+}
+
+.markdown-editor .italic {
+    -fx-font-style: italic;
+}
+
+.markdown-editor .code {
+    -fx-font-family: "Menlo", "Consolas", monospace;
+    -fx-fill: #c0392b;
+    -fx-background-color: #f0f0f0;
+}
+
+.markdown-editor .link {
+    -fx-fill: #2980b9;
+    -fx-underline: true;
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/MarkdownEditorHelperTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MarkdownEditorHelperTest.java
@@ -1,0 +1,56 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MarkdownEditorHelper} — bridges highlighter/formatter
+ * with editor text operations.
+ */
+class MarkdownEditorHelperTest {
+
+    @Test
+    @DisplayName("computeHighlighting returns spans for markdown text")
+    void computeHighlighting_returnsSpans() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownEditorHelper.computeHighlighting("# Hello");
+        assertFalse(spans.isEmpty());
+        assertEquals("header", spans.getFirst().styleClass());
+    }
+
+    @Test
+    @DisplayName("applyBold wraps selection and returns result")
+    void applyBold_wrapsSelection() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownEditorHelper.applyBold("hello world", 6, 11);
+        assertEquals("hello **world**", result.text());
+    }
+
+    @Test
+    @DisplayName("applyItalic wraps selection and returns result")
+    void applyItalic_wrapsSelection() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownEditorHelper.applyItalic("hello world", 6, 11);
+        assertEquals("hello *world*", result.text());
+    }
+
+    @Test
+    @DisplayName("applyCode wraps selection and returns result")
+    void applyCode_wrapsSelection() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownEditorHelper.applyCode("hello world", 6, 11);
+        assertEquals("hello `world`", result.text());
+    }
+
+    @Test
+    @DisplayName("empty text returns no highlights")
+    void emptyText_noHighlights() {
+        assertTrue(MarkdownEditorHelper.computeHighlighting("").isEmpty());
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/MarkdownFormatterTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MarkdownFormatterTest.java
@@ -1,0 +1,72 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MarkdownFormatter}.
+ */
+class MarkdownFormatterTest {
+
+    @Test
+    @DisplayName("toggleBold wraps selected text in **")
+    void toggleBold_wraps() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleBold("hello world", 6, 11);
+        assertEquals("hello **world**", result.text());
+        assertEquals(8, result.selectionStart());
+        assertEquals(13, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleBold removes ** from already bold text")
+    void toggleBold_unwraps() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleBold("hello **world**", 8, 13);
+        assertEquals("hello world", result.text());
+        assertEquals(6, result.selectionStart());
+        assertEquals(11, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleItalic wraps selected text in *")
+    void toggleItalic_wraps() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleItalic("hello world", 6, 11);
+        assertEquals("hello *world*", result.text());
+        assertEquals(7, result.selectionStart());
+        assertEquals(12, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleItalic removes * from already italic text")
+    void toggleItalic_unwraps() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleItalic("hello *world*", 7, 12);
+        assertEquals("hello world", result.text());
+        assertEquals(6, result.selectionStart());
+        assertEquals(11, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleCode wraps selected text in backticks")
+    void toggleCode_wraps() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleCode("hello world", 6, 11);
+        assertEquals("hello `world`", result.text());
+        assertEquals(7, result.selectionStart());
+        assertEquals(12, result.selectionEnd());
+    }
+
+    @Test
+    @DisplayName("toggleCode removes backticks from already code text")
+    void toggleCode_unwraps() {
+        MarkdownFormatter.FormatResult result =
+                MarkdownFormatter.toggleCode("hello `world`", 7, 12);
+        assertEquals("hello world", result.text());
+        assertEquals(6, result.selectionStart());
+        assertEquals(11, result.selectionEnd());
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighterTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/MarkdownSyntaxHighlighterTest.java
@@ -1,0 +1,80 @@
+package com.embervault.adapter.in.ui.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MarkdownSyntaxHighlighter}.
+ */
+class MarkdownSyntaxHighlighterTest {
+
+    @Test
+    @DisplayName("empty text returns no spans")
+    void emptyText_noSpans() {
+        assertTrue(MarkdownSyntaxHighlighter.computeSpans("").isEmpty());
+    }
+
+    @Test
+    @DisplayName("header line gets header style")
+    void headerLine_getsHeaderStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("# Header");
+        assertEquals(1, spans.size());
+        assertEquals("header", spans.getFirst().styleClass());
+        assertEquals(0, spans.getFirst().start());
+        assertEquals(8, spans.getFirst().end());
+    }
+
+    @Test
+    @DisplayName("bold text gets bold style")
+    void boldText_getBoldStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("some **bold** text");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("bold") && s.start() == 5 && s.end() == 13));
+    }
+
+    @Test
+    @DisplayName("italic text gets italic style")
+    void italicText_getsItalicStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("some *italic* text");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("italic") && s.start() == 5 && s.end() == 13));
+    }
+
+    @Test
+    @DisplayName("inline code gets code style")
+    void inlineCode_getsCodeStyle() {
+        List<MarkdownSyntaxHighlighter.StyleSpan> spans =
+                MarkdownSyntaxHighlighter.computeSpans("use `code` here");
+        assertTrue(spans.stream().anyMatch(s ->
+                s.styleClass().equals("code") && s.start() == 4 && s.end() == 10));
+    }
+
+    @Test
+    @DisplayName("link gets link style")
+    void link_getsLinkStyle() {
+        assertTrue(MarkdownSyntaxHighlighter.computeSpans("[text](url)")
+                .stream().anyMatch(s -> s.styleClass().equals("link")));
+    }
+
+    @Test
+    @DisplayName("wiki-link gets link style")
+    void wikiLink_getsLinkStyle() {
+        assertTrue(MarkdownSyntaxHighlighter.computeSpans("see [[My Note]]")
+                .stream().anyMatch(s -> s.styleClass().equals("link")));
+    }
+
+    @Test
+    @DisplayName("plain text returns no spans")
+    void plainText_noSpans() {
+        assertTrue(MarkdownSyntaxHighlighter.computeSpans(
+                "just plain text").isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MarkdownSyntaxHighlighter` — pure function computing style spans for headers, bold, italic, code, links, wiki-links
- Adds `MarkdownFormatter` — toggle bold/italic/code delimiters around text selection with adjusted cursor positions
- Adds RichTextFX dependency (`org.fxmisc.richtext:richtextfx:0.11.5`) and module requirement
- Adds Edit > Format submenu with Bold (Cmd+B), Italic (Cmd+I), Code (Cmd+K) menu items
- `$Text` storage remains raw Markdown — no format conversion
- Pure TDD: every feature started with a failing test

## Test plan
- [x] Unit tests for MarkdownSyntaxHighlighter (8 cases: each element type + edge cases)
- [x] Unit tests for MarkdownFormatter (6 cases: wrap and unwrap for bold, italic, code)
- [x] All existing tests still pass

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)