### PR TITLE
Replace view-switching switch with View Registry pattern (#235)

### DIFF
--- a/src/main/java/com/embervault/AttributeBrowserViewFactory.java
+++ b/src/main/java/com/embervault/AttributeBrowserViewFactory.java
@@ -11,25 +11,26 @@ import com.embervault.adapter.in.ui.viewmodel.AttributeBrowserViewModel;
  */
 final class AttributeBrowserViewFactory implements ViewFactory {
 
-  @Override
-  public ViewCreationResult create(
-      ViewPaneDeps deps,
-      UUID baseNoteId,
-      Consumer<String> onViewSwitch) {
-    AttributeBrowserViewModel vm =
-        new AttributeBrowserViewModel(
-            deps.noteService(), deps.schemaRegistry());
-    vm.setOnDataChanged(deps.refreshAll());
-    return new ViewCreationResult(
-        vm.tabTitleProperty(),
-        vm::groupNotes,
-        vm::groupNotes,
-        c -> {
-          AttributeBrowserViewController ctrl =
-              (AttributeBrowserViewController) c;
-          ctrl.setOnViewSwitch(onViewSwitch);
-          ctrl.initViewModel(vm);
-        },
-        null);
-  }
+    @Override
+    public ViewCreationResult create(
+            ViewPaneDeps deps,
+            UUID baseNoteId,
+            Consumer<String> onViewSwitch) {
+        AttributeBrowserViewModel vm =
+                new AttributeBrowserViewModel(
+                        deps.noteService(),
+                        deps.schemaRegistry());
+        vm.setOnDataChanged(deps.refreshAll());
+        return new ViewCreationResult(
+                vm.tabTitleProperty(),
+                vm::groupNotes,
+                vm::groupNotes,
+                c -> {
+                    AttributeBrowserViewController ctrl =
+                            (AttributeBrowserViewController) c;
+                    ctrl.setOnViewSwitch(onViewSwitch);
+                    ctrl.initViewModel(vm);
+                },
+                null);
+    }
 }

--- a/src/main/java/com/embervault/AttributeBrowserViewFactory.java
+++ b/src/main/java/com/embervault/AttributeBrowserViewFactory.java
@@ -1,0 +1,35 @@
+package com.embervault;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import com.embervault.adapter.in.ui.view.AttributeBrowserViewController;
+import com.embervault.adapter.in.ui.viewmodel.AttributeBrowserViewModel;
+
+/**
+ * Factory that creates the Attribute Browser view and its ViewModel.
+ */
+final class AttributeBrowserViewFactory implements ViewFactory {
+
+  @Override
+  public ViewCreationResult create(
+      ViewPaneDeps deps,
+      UUID baseNoteId,
+      Consumer<String> onViewSwitch) {
+    AttributeBrowserViewModel vm =
+        new AttributeBrowserViewModel(
+            deps.noteService(), deps.schemaRegistry());
+    vm.setOnDataChanged(deps.refreshAll());
+    return new ViewCreationResult(
+        vm.tabTitleProperty(),
+        vm::groupNotes,
+        vm::groupNotes,
+        c -> {
+          AttributeBrowserViewController ctrl =
+              (AttributeBrowserViewController) c;
+          ctrl.setOnViewSwitch(onViewSwitch);
+          ctrl.initViewModel(vm);
+        },
+        null);
+  }
+}

--- a/src/main/java/com/embervault/HyperbolicViewFactory.java
+++ b/src/main/java/com/embervault/HyperbolicViewFactory.java
@@ -11,31 +11,32 @@ import com.embervault.adapter.in.ui.viewmodel.HyperbolicViewModel;
  */
 final class HyperbolicViewFactory implements ViewFactory {
 
-  @Override
-  public ViewCreationResult create(
-      ViewPaneDeps deps,
-      UUID baseNoteId,
-      Consumer<String> onViewSwitch) {
-    HyperbolicViewModel vm = new HyperbolicViewModel(
-        deps.noteService(), deps.linkService());
-    vm.setOnDataChanged(deps.refreshAll());
-    if (baseNoteId != null) {
-      vm.setFocusNote(baseNoteId);
+    @Override
+    public ViewCreationResult create(
+            ViewPaneDeps deps,
+            UUID baseNoteId,
+            Consumer<String> onViewSwitch) {
+        HyperbolicViewModel vm = new HyperbolicViewModel(
+                deps.noteService(), deps.linkService());
+        vm.setOnDataChanged(deps.refreshAll());
+        if (baseNoteId != null) {
+            vm.setFocusNote(baseNoteId);
+        }
+        return new ViewCreationResult(
+                vm.tabTitleProperty(),
+                () -> {
+                    if (vm.getFocusNoteId() != null) {
+                        vm.setFocusNote(
+                                vm.getFocusNoteId());
+                    }
+                },
+                () -> { },
+                c -> {
+                    HyperbolicViewController ctrl =
+                            (HyperbolicViewController) c;
+                    ctrl.setOnViewSwitch(onViewSwitch);
+                    ctrl.initViewModel(vm);
+                },
+                vm.selectedNoteIdProperty());
     }
-    return new ViewCreationResult(
-        vm.tabTitleProperty(),
-        () -> {
-          if (vm.getFocusNoteId() != null) {
-            vm.setFocusNote(vm.getFocusNoteId());
-          }
-        },
-        () -> { },
-        c -> {
-          HyperbolicViewController ctrl =
-              (HyperbolicViewController) c;
-          ctrl.setOnViewSwitch(onViewSwitch);
-          ctrl.initViewModel(vm);
-        },
-        vm.selectedNoteIdProperty());
-  }
 }

--- a/src/main/java/com/embervault/HyperbolicViewFactory.java
+++ b/src/main/java/com/embervault/HyperbolicViewFactory.java
@@ -1,0 +1,41 @@
+package com.embervault;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import com.embervault.adapter.in.ui.view.HyperbolicViewController;
+import com.embervault.adapter.in.ui.viewmodel.HyperbolicViewModel;
+
+/**
+ * Factory that creates the Hyperbolic view and its ViewModel.
+ */
+final class HyperbolicViewFactory implements ViewFactory {
+
+  @Override
+  public ViewCreationResult create(
+      ViewPaneDeps deps,
+      UUID baseNoteId,
+      Consumer<String> onViewSwitch) {
+    HyperbolicViewModel vm = new HyperbolicViewModel(
+        deps.noteService(), deps.linkService());
+    vm.setOnDataChanged(deps.refreshAll());
+    if (baseNoteId != null) {
+      vm.setFocusNote(baseNoteId);
+    }
+    return new ViewCreationResult(
+        vm.tabTitleProperty(),
+        () -> {
+          if (vm.getFocusNoteId() != null) {
+            vm.setFocusNote(vm.getFocusNoteId());
+          }
+        },
+        () -> { },
+        c -> {
+          HyperbolicViewController ctrl =
+              (HyperbolicViewController) c;
+          ctrl.setOnViewSwitch(onViewSwitch);
+          ctrl.initViewModel(vm);
+        },
+        vm.selectedNoteIdProperty());
+  }
+}

--- a/src/main/java/com/embervault/MapViewFactory.java
+++ b/src/main/java/com/embervault/MapViewFactory.java
@@ -1,0 +1,34 @@
+package com.embervault;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import com.embervault.adapter.in.ui.view.MapViewController;
+import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
+
+/**
+ * Factory that creates the Map view and its ViewModel.
+ */
+final class MapViewFactory implements ViewFactory {
+
+  @Override
+  public ViewCreationResult create(
+      ViewPaneDeps deps,
+      UUID baseNoteId,
+      Consumer<String> onViewSwitch) {
+    MapViewModel vm = new MapViewModel(
+        deps.rootNoteTitle(), deps.noteService());
+    vm.setBaseNoteId(baseNoteId);
+    vm.setOnDataChanged(deps.refreshAll());
+    return new ViewCreationResult(
+        vm.tabTitleProperty(),
+        vm::loadNotes,
+        vm::loadNotes,
+        c -> {
+          MapViewController ctrl = (MapViewController) c;
+          ctrl.setOnViewSwitch(onViewSwitch);
+          ctrl.initViewModel(vm);
+        },
+        vm.selectedNoteIdProperty());
+  }
+}

--- a/src/main/java/com/embervault/MapViewFactory.java
+++ b/src/main/java/com/embervault/MapViewFactory.java
@@ -11,24 +11,25 @@ import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
  */
 final class MapViewFactory implements ViewFactory {
 
-  @Override
-  public ViewCreationResult create(
-      ViewPaneDeps deps,
-      UUID baseNoteId,
-      Consumer<String> onViewSwitch) {
-    MapViewModel vm = new MapViewModel(
-        deps.rootNoteTitle(), deps.noteService());
-    vm.setBaseNoteId(baseNoteId);
-    vm.setOnDataChanged(deps.refreshAll());
-    return new ViewCreationResult(
-        vm.tabTitleProperty(),
-        vm::loadNotes,
-        vm::loadNotes,
-        c -> {
-          MapViewController ctrl = (MapViewController) c;
-          ctrl.setOnViewSwitch(onViewSwitch);
-          ctrl.initViewModel(vm);
-        },
-        vm.selectedNoteIdProperty());
-  }
+    @Override
+    public ViewCreationResult create(
+            ViewPaneDeps deps,
+            UUID baseNoteId,
+            Consumer<String> onViewSwitch) {
+        MapViewModel vm = new MapViewModel(
+                deps.rootNoteTitle(), deps.noteService());
+        vm.setBaseNoteId(baseNoteId);
+        vm.setOnDataChanged(deps.refreshAll());
+        return new ViewCreationResult(
+                vm.tabTitleProperty(),
+                vm::loadNotes,
+                vm::loadNotes,
+                c -> {
+                    MapViewController ctrl =
+                            (MapViewController) c;
+                    ctrl.setOnViewSwitch(onViewSwitch);
+                    ctrl.initViewModel(vm);
+                },
+                vm.selectedNoteIdProperty());
+    }
 }

--- a/src/main/java/com/embervault/OutlineViewFactory.java
+++ b/src/main/java/com/embervault/OutlineViewFactory.java
@@ -1,0 +1,35 @@
+package com.embervault;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import com.embervault.adapter.in.ui.view.OutlineViewController;
+import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
+
+/**
+ * Factory that creates the Outline view and its ViewModel.
+ */
+final class OutlineViewFactory implements ViewFactory {
+
+  @Override
+  public ViewCreationResult create(
+      ViewPaneDeps deps,
+      UUID baseNoteId,
+      Consumer<String> onViewSwitch) {
+    OutlineViewModel vm = new OutlineViewModel(
+        deps.rootNoteTitle(), deps.noteService());
+    vm.setBaseNoteId(baseNoteId);
+    vm.setOnDataChanged(deps.refreshAll());
+    return new ViewCreationResult(
+        vm.tabTitleProperty(),
+        vm::loadNotes,
+        vm::loadNotes,
+        c -> {
+          OutlineViewController ctrl =
+              (OutlineViewController) c;
+          ctrl.setOnViewSwitch(onViewSwitch);
+          ctrl.initViewModel(vm);
+        },
+        vm.selectedNoteIdProperty());
+  }
+}

--- a/src/main/java/com/embervault/OutlineViewFactory.java
+++ b/src/main/java/com/embervault/OutlineViewFactory.java
@@ -11,25 +11,25 @@ import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
  */
 final class OutlineViewFactory implements ViewFactory {
 
-  @Override
-  public ViewCreationResult create(
-      ViewPaneDeps deps,
-      UUID baseNoteId,
-      Consumer<String> onViewSwitch) {
-    OutlineViewModel vm = new OutlineViewModel(
-        deps.rootNoteTitle(), deps.noteService());
-    vm.setBaseNoteId(baseNoteId);
-    vm.setOnDataChanged(deps.refreshAll());
-    return new ViewCreationResult(
-        vm.tabTitleProperty(),
-        vm::loadNotes,
-        vm::loadNotes,
-        c -> {
-          OutlineViewController ctrl =
-              (OutlineViewController) c;
-          ctrl.setOnViewSwitch(onViewSwitch);
-          ctrl.initViewModel(vm);
-        },
-        vm.selectedNoteIdProperty());
-  }
+    @Override
+    public ViewCreationResult create(
+            ViewPaneDeps deps,
+            UUID baseNoteId,
+            Consumer<String> onViewSwitch) {
+        OutlineViewModel vm = new OutlineViewModel(
+                deps.rootNoteTitle(), deps.noteService());
+        vm.setBaseNoteId(baseNoteId);
+        vm.setOnDataChanged(deps.refreshAll());
+        return new ViewCreationResult(
+                vm.tabTitleProperty(),
+                vm::loadNotes,
+                vm::loadNotes,
+                c -> {
+                    OutlineViewController ctrl =
+                            (OutlineViewController) c;
+                    ctrl.setOnViewSwitch(onViewSwitch);
+                    ctrl.initViewModel(vm);
+                },
+                vm.selectedNoteIdProperty());
+    }
 }

--- a/src/main/java/com/embervault/TreemapViewFactory.java
+++ b/src/main/java/com/embervault/TreemapViewFactory.java
@@ -11,25 +11,25 @@ import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
  */
 final class TreemapViewFactory implements ViewFactory {
 
-  @Override
-  public ViewCreationResult create(
-      ViewPaneDeps deps,
-      UUID baseNoteId,
-      Consumer<String> onViewSwitch) {
-    TreemapViewModel vm = new TreemapViewModel(
-        deps.rootNoteTitle(), deps.noteService());
-    vm.setBaseNoteId(baseNoteId);
-    vm.setOnDataChanged(deps.refreshAll());
-    return new ViewCreationResult(
-        vm.tabTitleProperty(),
-        vm::loadNotes,
-        vm::loadNotes,
-        c -> {
-          TreemapViewController ctrl =
-              (TreemapViewController) c;
-          ctrl.setOnViewSwitch(onViewSwitch);
-          ctrl.initViewModel(vm);
-        },
-        vm.selectedNoteIdProperty());
-  }
+    @Override
+    public ViewCreationResult create(
+            ViewPaneDeps deps,
+            UUID baseNoteId,
+            Consumer<String> onViewSwitch) {
+        TreemapViewModel vm = new TreemapViewModel(
+                deps.rootNoteTitle(), deps.noteService());
+        vm.setBaseNoteId(baseNoteId);
+        vm.setOnDataChanged(deps.refreshAll());
+        return new ViewCreationResult(
+                vm.tabTitleProperty(),
+                vm::loadNotes,
+                vm::loadNotes,
+                c -> {
+                    TreemapViewController ctrl =
+                            (TreemapViewController) c;
+                    ctrl.setOnViewSwitch(onViewSwitch);
+                    ctrl.initViewModel(vm);
+                },
+                vm.selectedNoteIdProperty());
+    }
 }

--- a/src/main/java/com/embervault/TreemapViewFactory.java
+++ b/src/main/java/com/embervault/TreemapViewFactory.java
@@ -1,0 +1,35 @@
+package com.embervault;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import com.embervault.adapter.in.ui.view.TreemapViewController;
+import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
+
+/**
+ * Factory that creates the Treemap view and its ViewModel.
+ */
+final class TreemapViewFactory implements ViewFactory {
+
+  @Override
+  public ViewCreationResult create(
+      ViewPaneDeps deps,
+      UUID baseNoteId,
+      Consumer<String> onViewSwitch) {
+    TreemapViewModel vm = new TreemapViewModel(
+        deps.rootNoteTitle(), deps.noteService());
+    vm.setBaseNoteId(baseNoteId);
+    vm.setOnDataChanged(deps.refreshAll());
+    return new ViewCreationResult(
+        vm.tabTitleProperty(),
+        vm::loadNotes,
+        vm::loadNotes,
+        c -> {
+          TreemapViewController ctrl =
+              (TreemapViewController) c;
+          ctrl.setOnViewSwitch(onViewSwitch);
+          ctrl.initViewModel(vm);
+        },
+        vm.selectedNoteIdProperty());
+  }
+}

--- a/src/main/java/com/embervault/ViewCreationResult.java
+++ b/src/main/java/com/embervault/ViewCreationResult.java
@@ -1,0 +1,30 @@
+package com.embervault;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyStringProperty;
+
+/**
+ * Result of creating a view via a {@link ViewFactory}.
+ *
+ * <p>Encapsulates all the pieces that {@link ViewPaneContext} needs
+ * to wire up after a view switch: the tab title binding, the refresh
+ * and initial-load runnables, the controller initializer, and an
+ * optional selected-note property for selection wiring.</p>
+ *
+ * @param tabTitle              the tab title property to bind
+ * @param viewRefresh           the runnable to refresh the view
+ * @param initialLoad           the runnable to perform initial data load
+ * @param controllerInitializer the consumer to initialize the FXML controller
+ * @param selectedNoteIdProperty the selected note property, or null if
+ *                               the view does not support selection
+ */
+public record ViewCreationResult(
+    ReadOnlyStringProperty tabTitle,
+    Runnable viewRefresh,
+    Runnable initialLoad,
+    Consumer<Object> controllerInitializer,
+    ObjectProperty<UUID> selectedNoteIdProperty) {
+}

--- a/src/main/java/com/embervault/ViewCreationResult.java
+++ b/src/main/java/com/embervault/ViewCreationResult.java
@@ -17,14 +17,15 @@ import javafx.beans.property.ReadOnlyStringProperty;
  * @param tabTitle              the tab title property to bind
  * @param viewRefresh           the runnable to refresh the view
  * @param initialLoad           the runnable to perform initial data load
- * @param controllerInitializer the consumer to initialize the FXML controller
- * @param selectedNoteIdProperty the selected note property, or null if
- *                               the view does not support selection
+ * @param controllerInitializer the consumer to initialize the FXML
+ *                              controller
+ * @param selectedNoteIdProperty the selected note property, or null
+ *                               if the view does not support selection
  */
 public record ViewCreationResult(
-    ReadOnlyStringProperty tabTitle,
-    Runnable viewRefresh,
-    Runnable initialLoad,
-    Consumer<Object> controllerInitializer,
-    ObjectProperty<UUID> selectedNoteIdProperty) {
+        ReadOnlyStringProperty tabTitle,
+        Runnable viewRefresh,
+        Runnable initialLoad,
+        Consumer<Object> controllerInitializer,
+        ObjectProperty<UUID> selectedNoteIdProperty) {
 }

--- a/src/main/java/com/embervault/ViewFactory.java
+++ b/src/main/java/com/embervault/ViewFactory.java
@@ -1,0 +1,27 @@
+package com.embervault;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Factory for creating views within a {@link ViewPaneContext}.
+ *
+ * <p>Each implementation knows how to create the ViewModel, configure
+ * it, and produce a {@link ViewCreationResult} containing the pieces
+ * that the pane context needs for wiring.</p>
+ */
+public interface ViewFactory {
+
+  /**
+   * Creates a view with its ViewModel and wiring callbacks.
+   *
+   * @param deps          the shared dependencies
+   * @param baseNoteId    the base note id for the pane
+   * @param onViewSwitch  callback to trigger a view switch
+   * @return the creation result
+   */
+  ViewCreationResult create(
+      ViewPaneDeps deps,
+      UUID baseNoteId,
+      Consumer<String> onViewSwitch);
+}

--- a/src/main/java/com/embervault/ViewFactory.java
+++ b/src/main/java/com/embervault/ViewFactory.java
@@ -12,16 +12,16 @@ import java.util.function.Consumer;
  */
 public interface ViewFactory {
 
-  /**
-   * Creates a view with its ViewModel and wiring callbacks.
-   *
-   * @param deps          the shared dependencies
-   * @param baseNoteId    the base note id for the pane
-   * @param onViewSwitch  callback to trigger a view switch
-   * @return the creation result
-   */
-  ViewCreationResult create(
-      ViewPaneDeps deps,
-      UUID baseNoteId,
-      Consumer<String> onViewSwitch);
+    /**
+     * Creates a view with its ViewModel and wiring callbacks.
+     *
+     * @param deps          the shared dependencies
+     * @param baseNoteId    the base note id for the pane
+     * @param onViewSwitch  callback to trigger a view switch
+     * @return the creation result
+     */
+    ViewCreationResult create(
+            ViewPaneDeps deps,
+            UUID baseNoteId,
+            Consumer<String> onViewSwitch);
 }

--- a/src/main/java/com/embervault/ViewFactoryRegistry.java
+++ b/src/main/java/com/embervault/ViewFactoryRegistry.java
@@ -1,0 +1,41 @@
+package com.embervault;
+
+import java.util.Map;
+
+/**
+ * Registry that maps each {@link ViewType} to its {@link ViewFactory}.
+ *
+ * <p>Replaces the switch statement in {@link ViewPaneContext} with a
+ * lookup-based dispatch, making it easy to add new view types without
+ * modifying the switching logic.</p>
+ */
+public final class ViewFactoryRegistry {
+
+  private final Map<ViewType, ViewFactory> factories;
+
+  /** Creates a registry pre-populated with all known view factories. */
+  public ViewFactoryRegistry() {
+    factories = Map.of(
+        ViewType.MAP, new MapViewFactory(),
+        ViewType.OUTLINE, new OutlineViewFactory(),
+        ViewType.TREEMAP, new TreemapViewFactory(),
+        ViewType.HYPERBOLIC, new HyperbolicViewFactory(),
+        ViewType.BROWSER, new AttributeBrowserViewFactory());
+  }
+
+  /**
+   * Returns the factory for the given view type.
+   *
+   * @param type the view type
+   * @return the corresponding factory
+   * @throws IllegalArgumentException if no factory is registered
+   */
+  public ViewFactory getFactory(ViewType type) {
+    ViewFactory factory = factories.get(type);
+    if (factory == null) {
+      throw new IllegalArgumentException(
+          "No factory registered for " + type);
+    }
+    return factory;
+  }
+}

--- a/src/main/java/com/embervault/ViewFactoryRegistry.java
+++ b/src/main/java/com/embervault/ViewFactoryRegistry.java
@@ -11,31 +11,34 @@ import java.util.Map;
  */
 public final class ViewFactoryRegistry {
 
-  private final Map<ViewType, ViewFactory> factories;
+    private final Map<ViewType, ViewFactory> factories;
 
-  /** Creates a registry pre-populated with all known view factories. */
-  public ViewFactoryRegistry() {
-    factories = Map.of(
-        ViewType.MAP, new MapViewFactory(),
-        ViewType.OUTLINE, new OutlineViewFactory(),
-        ViewType.TREEMAP, new TreemapViewFactory(),
-        ViewType.HYPERBOLIC, new HyperbolicViewFactory(),
-        ViewType.BROWSER, new AttributeBrowserViewFactory());
-  }
-
-  /**
-   * Returns the factory for the given view type.
-   *
-   * @param type the view type
-   * @return the corresponding factory
-   * @throws IllegalArgumentException if no factory is registered
-   */
-  public ViewFactory getFactory(ViewType type) {
-    ViewFactory factory = factories.get(type);
-    if (factory == null) {
-      throw new IllegalArgumentException(
-          "No factory registered for " + type);
+    /**
+     * Creates a registry pre-populated with all known view factories.
+     */
+    public ViewFactoryRegistry() {
+        factories = Map.of(
+                ViewType.MAP, new MapViewFactory(),
+                ViewType.OUTLINE, new OutlineViewFactory(),
+                ViewType.TREEMAP, new TreemapViewFactory(),
+                ViewType.HYPERBOLIC, new HyperbolicViewFactory(),
+                ViewType.BROWSER,
+                new AttributeBrowserViewFactory());
     }
-    return factory;
-  }
+
+    /**
+     * Returns the factory for the given view type.
+     *
+     * @param type the view type
+     * @return the corresponding factory
+     * @throws IllegalArgumentException if no factory is registered
+     */
+    public ViewFactory getFactory(ViewType type) {
+        ViewFactory factory = factories.get(type);
+        if (factory == null) {
+            throw new IllegalArgumentException(
+                    "No factory registered for " + type);
+        }
+        return factory;
+    }
 }

--- a/src/main/java/com/embervault/ViewPaneContext.java
+++ b/src/main/java/com/embervault/ViewPaneContext.java
@@ -4,17 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.UUID;
 
-import com.embervault.adapter.in.ui.view.AttributeBrowserViewController;
-import com.embervault.adapter.in.ui.view.HyperbolicViewController;
-import com.embervault.adapter.in.ui.view.MapViewController;
-import com.embervault.adapter.in.ui.view.OutlineViewController;
-import com.embervault.adapter.in.ui.view.TreemapViewController;
-import com.embervault.adapter.in.ui.viewmodel.AttributeBrowserViewModel;
-import com.embervault.adapter.in.ui.viewmodel.HyperbolicViewModel;
-import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
-import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
-import com.embervault.adapter.in.ui.viewmodel.TreemapViewModel;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeSchemaRegistry;
@@ -52,6 +42,9 @@ public final class ViewPaneContext {
     private Runnable refreshAll;
     private SelectedNoteViewModel selectedNoteVm;
     private StringProperty rootNoteTitle;
+
+    private final ViewFactoryRegistry registry =
+            new ViewFactoryRegistry();
 
     private ViewType currentViewType;
     private UUID baseNoteId;
@@ -158,115 +151,30 @@ public final class ViewPaneContext {
         }
     }
 
-    @SuppressWarnings("CyclomaticComplexity")
     private void doSwitchView(ViewType newType)
             throws IOException {
         label.textProperty().unbind();
 
-        ReadOnlyStringProperty newTitleProp;
+        ViewPaneDeps deps = new ViewPaneDeps(
+                noteService, linkService, schemaRegistry,
+                refreshAll, selectedNoteVm, rootNoteTitle);
+        ViewFactory factory = registry.getFactory(newType);
+        ViewCreationResult result = factory.create(
+                deps, baseNoteId,
+                name -> switchView(ViewType.valueOf(name)));
 
-        switch (newType) {
-            case MAP -> {
-                MapViewModel vm = new MapViewModel(
-                        rootNoteTitle, noteService);
-                vm.setBaseNoteId(baseNoteId);
-                vm.setOnDataChanged(refreshAll);
-                wireSelection(vm.selectedNoteIdProperty());
-                Parent view = loadFxml(newType, c -> {
-                    MapViewController ctrl =
-                            (MapViewController) c;
-                    ctrl.setOnViewSwitch(name ->
-                            switchView(ViewType.valueOf(name)));
-                    ctrl.initViewModel(vm);
-                });
-                replaceView(view);
-                newTitleProp = vm.tabTitleProperty();
-                currentViewRefresh = vm::loadNotes;
-                vm.loadNotes();
-            }
-            case OUTLINE -> {
-                OutlineViewModel vm = new OutlineViewModel(
-                        rootNoteTitle, noteService);
-                vm.setBaseNoteId(baseNoteId);
-                vm.setOnDataChanged(refreshAll);
-                wireSelection(vm.selectedNoteIdProperty());
-                Parent view = loadFxml(newType, c -> {
-                    OutlineViewController ctrl =
-                            (OutlineViewController) c;
-                    ctrl.setOnViewSwitch(name ->
-                            switchView(ViewType.valueOf(name)));
-                    ctrl.initViewModel(vm);
-                });
-                replaceView(view);
-                newTitleProp = vm.tabTitleProperty();
-                currentViewRefresh = vm::loadNotes;
-                vm.loadNotes();
-            }
-            case TREEMAP -> {
-                TreemapViewModel vm = new TreemapViewModel(
-                        rootNoteTitle, noteService);
-                vm.setBaseNoteId(baseNoteId);
-                vm.setOnDataChanged(refreshAll);
-                wireSelection(vm.selectedNoteIdProperty());
-                Parent view = loadFxml(newType, c -> {
-                    TreemapViewController ctrl =
-                            (TreemapViewController) c;
-                    ctrl.setOnViewSwitch(name ->
-                            switchView(ViewType.valueOf(name)));
-                    ctrl.initViewModel(vm);
-                });
-                replaceView(view);
-                newTitleProp = vm.tabTitleProperty();
-                currentViewRefresh = vm::loadNotes;
-                vm.loadNotes();
-            }
-            case HYPERBOLIC -> {
-                HyperbolicViewModel vm =
-                        new HyperbolicViewModel(
-                                noteService, linkService);
-                vm.setOnDataChanged(refreshAll);
-                wireSelection(vm.selectedNoteIdProperty());
-                if (baseNoteId != null) {
-                    vm.setFocusNote(baseNoteId);
-                }
-                Parent view = loadFxml(newType, c -> {
-                    HyperbolicViewController ctrl =
-                            (HyperbolicViewController) c;
-                    ctrl.setOnViewSwitch(name ->
-                            switchView(ViewType.valueOf(name)));
-                    ctrl.initViewModel(vm);
-                });
-                replaceView(view);
-                newTitleProp = vm.tabTitleProperty();
-                currentViewRefresh = () -> {
-                    if (vm.getFocusNoteId() != null) {
-                        vm.setFocusNote(
-                                vm.getFocusNoteId());
-                    }
-                };
-            }
-            case BROWSER -> {
-                AttributeBrowserViewModel vm =
-                        new AttributeBrowserViewModel(
-                                noteService, schemaRegistry);
-                vm.setOnDataChanged(refreshAll);
-                Parent view = loadFxml(newType, c -> {
-                    AttributeBrowserViewController ctrl =
-                            (AttributeBrowserViewController) c;
-                    ctrl.setOnViewSwitch(name ->
-                            switchView(ViewType.valueOf(name)));
-                    ctrl.initViewModel(vm);
-                });
-                replaceView(view);
-                newTitleProp = vm.tabTitleProperty();
-                currentViewRefresh = vm::groupNotes;
-                vm.groupNotes();
-            }
-            default -> throw new IllegalArgumentException(
-                    "Unknown view type: " + newType);
+        Parent view = loadFxml(newType,
+                result.controllerInitializer());
+        replaceView(view);
+
+        if (result.selectedNoteIdProperty() != null) {
+            wireSelection(result.selectedNoteIdProperty());
         }
 
-        label.textProperty().bind(newTitleProp);
+        currentViewRefresh = result.viewRefresh();
+        result.initialLoad().run();
+
+        label.textProperty().bind(result.tabTitle());
         currentViewType = newType;
         labelContextMenu = buildContextMenu();
         label.setContextMenu(labelContextMenu);

--- a/src/test/java/com/embervault/ViewFactoryCreateTest.java
+++ b/src/test/java/com/embervault/ViewFactoryCreateTest.java
@@ -1,0 +1,124 @@
+package com.embervault;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.UUID;
+
+import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
+import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.LinkServiceImpl;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.LinkService;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeSchemaRegistry;
+import com.embervault.domain.Note;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that each {@link ViewFactory} produces a valid
+ * {@link ViewCreationResult}.
+ */
+class ViewFactoryCreateTest {
+
+  private ViewPaneDeps deps;
+  private UUID baseNoteId;
+  private ViewFactoryRegistry registry;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryNoteRepository noteRepo =
+        new InMemoryNoteRepository();
+    NoteService noteService = new NoteServiceImpl(noteRepo);
+    LinkService linkService = new LinkServiceImpl(
+        new InMemoryLinkRepository());
+    AttributeSchemaRegistry schemaRegistry =
+        new AttributeSchemaRegistry();
+    SelectedNoteViewModel selectedNoteVm =
+        new SelectedNoteViewModel(noteService);
+    StringProperty rootNoteTitle =
+        new SimpleStringProperty("Root");
+
+    Note root = noteService.createNote("Root", "");
+    baseNoteId = root.getId();
+
+    deps = new ViewPaneDeps(
+        noteService, linkService, schemaRegistry,
+        () -> { }, selectedNoteVm, rootNoteTitle);
+    registry = new ViewFactoryRegistry();
+  }
+
+  @Test
+  @DisplayName("MapViewFactory returns result with all fields non-null")
+  void mapFactory_shouldReturnCompleteResult() {
+    ViewCreationResult result = registry.getFactory(ViewType.MAP)
+        .create(deps, baseNoteId, name -> { });
+    assertNotNull(result.tabTitle());
+    assertNotNull(result.viewRefresh());
+    assertNotNull(result.initialLoad());
+    assertNotNull(result.controllerInitializer());
+    assertNotNull(result.selectedNoteIdProperty(),
+        "Map supports selection");
+  }
+
+  @Test
+  @DisplayName("OutlineViewFactory returns result with all fields non-null")
+  void outlineFactory_shouldReturnCompleteResult() {
+    ViewCreationResult result =
+        registry.getFactory(ViewType.OUTLINE)
+            .create(deps, baseNoteId, name -> { });
+    assertNotNull(result.tabTitle());
+    assertNotNull(result.viewRefresh());
+    assertNotNull(result.initialLoad());
+    assertNotNull(result.controllerInitializer());
+    assertNotNull(result.selectedNoteIdProperty(),
+        "Outline supports selection");
+  }
+
+  @Test
+  @DisplayName("TreemapViewFactory returns result with all fields non-null")
+  void treemapFactory_shouldReturnCompleteResult() {
+    ViewCreationResult result =
+        registry.getFactory(ViewType.TREEMAP)
+            .create(deps, baseNoteId, name -> { });
+    assertNotNull(result.tabTitle());
+    assertNotNull(result.viewRefresh());
+    assertNotNull(result.initialLoad());
+    assertNotNull(result.controllerInitializer());
+    assertNotNull(result.selectedNoteIdProperty(),
+        "Treemap supports selection");
+  }
+
+  @Test
+  @DisplayName("HyperbolicViewFactory returns result with all fields non-null")
+  void hyperbolicFactory_shouldReturnCompleteResult() {
+    ViewCreationResult result =
+        registry.getFactory(ViewType.HYPERBOLIC)
+            .create(deps, baseNoteId, name -> { });
+    assertNotNull(result.tabTitle());
+    assertNotNull(result.viewRefresh());
+    assertNotNull(result.initialLoad());
+    assertNotNull(result.controllerInitializer());
+    assertNotNull(result.selectedNoteIdProperty(),
+        "Hyperbolic supports selection");
+  }
+
+  @Test
+  @DisplayName("AttributeBrowserViewFactory returns null selectedNoteIdProperty")
+  void browserFactory_shouldReturnNullSelectedNoteIdProperty() {
+    ViewCreationResult result =
+        registry.getFactory(ViewType.BROWSER)
+            .create(deps, baseNoteId, name -> { });
+    assertNotNull(result.tabTitle());
+    assertNotNull(result.viewRefresh());
+    assertNotNull(result.initialLoad());
+    assertNotNull(result.controllerInitializer());
+    assertNull(result.selectedNoteIdProperty(),
+        "Browser does not support selection");
+  }
+}

--- a/src/test/java/com/embervault/ViewFactoryCreateTest.java
+++ b/src/test/java/com/embervault/ViewFactoryCreateTest.java
@@ -26,99 +26,100 @@ import org.junit.jupiter.api.Test;
  */
 class ViewFactoryCreateTest {
 
-  private ViewPaneDeps deps;
-  private UUID baseNoteId;
-  private ViewFactoryRegistry registry;
+    private ViewPaneDeps deps;
+    private UUID baseNoteId;
+    private ViewFactoryRegistry registry;
 
-  @BeforeEach
-  void setUp() {
-    InMemoryNoteRepository noteRepo =
-        new InMemoryNoteRepository();
-    NoteService noteService = new NoteServiceImpl(noteRepo);
-    LinkService linkService = new LinkServiceImpl(
-        new InMemoryLinkRepository());
-    AttributeSchemaRegistry schemaRegistry =
-        new AttributeSchemaRegistry();
-    SelectedNoteViewModel selectedNoteVm =
-        new SelectedNoteViewModel(noteService);
-    StringProperty rootNoteTitle =
-        new SimpleStringProperty("Root");
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository noteRepo =
+                new InMemoryNoteRepository();
+        NoteService noteService = new NoteServiceImpl(noteRepo);
+        LinkService linkService = new LinkServiceImpl(
+                new InMemoryLinkRepository());
+        AttributeSchemaRegistry schemaRegistry =
+                new AttributeSchemaRegistry();
+        SelectedNoteViewModel selectedNoteVm =
+                new SelectedNoteViewModel(noteService);
+        StringProperty rootNoteTitle =
+                new SimpleStringProperty("Root");
 
-    Note root = noteService.createNote("Root", "");
-    baseNoteId = root.getId();
+        Note root = noteService.createNote("Root", "");
+        baseNoteId = root.getId();
 
-    deps = new ViewPaneDeps(
-        noteService, linkService, schemaRegistry,
-        () -> { }, selectedNoteVm, rootNoteTitle);
-    registry = new ViewFactoryRegistry();
-  }
+        deps = new ViewPaneDeps(
+                noteService, linkService, schemaRegistry,
+                () -> { }, selectedNoteVm, rootNoteTitle);
+        registry = new ViewFactoryRegistry();
+    }
 
-  @Test
-  @DisplayName("MapViewFactory returns result with all fields non-null")
-  void mapFactory_shouldReturnCompleteResult() {
-    ViewCreationResult result = registry.getFactory(ViewType.MAP)
-        .create(deps, baseNoteId, name -> { });
-    assertNotNull(result.tabTitle());
-    assertNotNull(result.viewRefresh());
-    assertNotNull(result.initialLoad());
-    assertNotNull(result.controllerInitializer());
-    assertNotNull(result.selectedNoteIdProperty(),
-        "Map supports selection");
-  }
+    @Test
+    @DisplayName("MapViewFactory returns result with all fields non-null")
+    void mapFactory_shouldReturnCompleteResult() {
+        ViewCreationResult result =
+                registry.getFactory(ViewType.MAP)
+                        .create(deps, baseNoteId, name -> { });
+        assertNotNull(result.tabTitle());
+        assertNotNull(result.viewRefresh());
+        assertNotNull(result.initialLoad());
+        assertNotNull(result.controllerInitializer());
+        assertNotNull(result.selectedNoteIdProperty(),
+                "Map supports selection");
+    }
 
-  @Test
-  @DisplayName("OutlineViewFactory returns result with all fields non-null")
-  void outlineFactory_shouldReturnCompleteResult() {
-    ViewCreationResult result =
-        registry.getFactory(ViewType.OUTLINE)
-            .create(deps, baseNoteId, name -> { });
-    assertNotNull(result.tabTitle());
-    assertNotNull(result.viewRefresh());
-    assertNotNull(result.initialLoad());
-    assertNotNull(result.controllerInitializer());
-    assertNotNull(result.selectedNoteIdProperty(),
-        "Outline supports selection");
-  }
+    @Test
+    @DisplayName("OutlineViewFactory returns result with all fields non-null")
+    void outlineFactory_shouldReturnCompleteResult() {
+        ViewCreationResult result =
+                registry.getFactory(ViewType.OUTLINE)
+                        .create(deps, baseNoteId, name -> { });
+        assertNotNull(result.tabTitle());
+        assertNotNull(result.viewRefresh());
+        assertNotNull(result.initialLoad());
+        assertNotNull(result.controllerInitializer());
+        assertNotNull(result.selectedNoteIdProperty(),
+                "Outline supports selection");
+    }
 
-  @Test
-  @DisplayName("TreemapViewFactory returns result with all fields non-null")
-  void treemapFactory_shouldReturnCompleteResult() {
-    ViewCreationResult result =
-        registry.getFactory(ViewType.TREEMAP)
-            .create(deps, baseNoteId, name -> { });
-    assertNotNull(result.tabTitle());
-    assertNotNull(result.viewRefresh());
-    assertNotNull(result.initialLoad());
-    assertNotNull(result.controllerInitializer());
-    assertNotNull(result.selectedNoteIdProperty(),
-        "Treemap supports selection");
-  }
+    @Test
+    @DisplayName("TreemapViewFactory returns result with all fields non-null")
+    void treemapFactory_shouldReturnCompleteResult() {
+        ViewCreationResult result =
+                registry.getFactory(ViewType.TREEMAP)
+                        .create(deps, baseNoteId, name -> { });
+        assertNotNull(result.tabTitle());
+        assertNotNull(result.viewRefresh());
+        assertNotNull(result.initialLoad());
+        assertNotNull(result.controllerInitializer());
+        assertNotNull(result.selectedNoteIdProperty(),
+                "Treemap supports selection");
+    }
 
-  @Test
-  @DisplayName("HyperbolicViewFactory returns result with all fields non-null")
-  void hyperbolicFactory_shouldReturnCompleteResult() {
-    ViewCreationResult result =
-        registry.getFactory(ViewType.HYPERBOLIC)
-            .create(deps, baseNoteId, name -> { });
-    assertNotNull(result.tabTitle());
-    assertNotNull(result.viewRefresh());
-    assertNotNull(result.initialLoad());
-    assertNotNull(result.controllerInitializer());
-    assertNotNull(result.selectedNoteIdProperty(),
-        "Hyperbolic supports selection");
-  }
+    @Test
+    @DisplayName("HyperbolicViewFactory returns result with all fields non-null")
+    void hyperbolicFactory_shouldReturnCompleteResult() {
+        ViewCreationResult result =
+                registry.getFactory(ViewType.HYPERBOLIC)
+                        .create(deps, baseNoteId, name -> { });
+        assertNotNull(result.tabTitle());
+        assertNotNull(result.viewRefresh());
+        assertNotNull(result.initialLoad());
+        assertNotNull(result.controllerInitializer());
+        assertNotNull(result.selectedNoteIdProperty(),
+                "Hyperbolic supports selection");
+    }
 
-  @Test
-  @DisplayName("AttributeBrowserViewFactory returns null selectedNoteIdProperty")
-  void browserFactory_shouldReturnNullSelectedNoteIdProperty() {
-    ViewCreationResult result =
-        registry.getFactory(ViewType.BROWSER)
-            .create(deps, baseNoteId, name -> { });
-    assertNotNull(result.tabTitle());
-    assertNotNull(result.viewRefresh());
-    assertNotNull(result.initialLoad());
-    assertNotNull(result.controllerInitializer());
-    assertNull(result.selectedNoteIdProperty(),
-        "Browser does not support selection");
-  }
+    @Test
+    @DisplayName("AttributeBrowserViewFactory returns null selectedNoteIdProperty")
+    void browserFactory_shouldReturnNullSelectedNoteIdProperty() {
+        ViewCreationResult result =
+                registry.getFactory(ViewType.BROWSER)
+                        .create(deps, baseNoteId, name -> { });
+        assertNotNull(result.tabTitle());
+        assertNotNull(result.viewRefresh());
+        assertNotNull(result.initialLoad());
+        assertNotNull(result.controllerInitializer());
+        assertNull(result.selectedNoteIdProperty(),
+                "Browser does not support selection");
+    }
 }

--- a/src/test/java/com/embervault/ViewFactoryRegistryTest.java
+++ b/src/test/java/com/embervault/ViewFactoryRegistryTest.java
@@ -1,7 +1,6 @@
 package com.embervault;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,20 +12,20 @@ import org.junit.jupiter.params.provider.EnumSource;
  */
 class ViewFactoryRegistryTest {
 
-  private ViewFactoryRegistry registry;
+    private ViewFactoryRegistry registry;
 
-  @BeforeEach
-  void setUp() {
-    registry = new ViewFactoryRegistry();
-  }
+    @BeforeEach
+    void setUp() {
+        registry = new ViewFactoryRegistry();
+    }
 
-  @ParameterizedTest
-  @EnumSource(ViewType.class)
-  @DisplayName("getFactory returns non-null factory for every ViewType")
-  void getFactory_shouldReturnNonNullForEveryViewType(
-      ViewType type) {
-    ViewFactory factory = registry.getFactory(type);
-    assertNotNull(factory,
-        "Factory should not be null for " + type);
-  }
+    @ParameterizedTest
+    @EnumSource(ViewType.class)
+    @DisplayName("getFactory returns non-null factory for every ViewType")
+    void getFactory_shouldReturnNonNullForEveryViewType(
+            ViewType type) {
+        ViewFactory factory = registry.getFactory(type);
+        assertNotNull(factory,
+                "Factory should not be null for " + type);
+    }
 }

--- a/src/test/java/com/embervault/ViewFactoryRegistryTest.java
+++ b/src/test/java/com/embervault/ViewFactoryRegistryTest.java
@@ -1,0 +1,32 @@
+package com.embervault;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Tests for {@link ViewFactoryRegistry}.
+ */
+class ViewFactoryRegistryTest {
+
+  private ViewFactoryRegistry registry;
+
+  @BeforeEach
+  void setUp() {
+    registry = new ViewFactoryRegistry();
+  }
+
+  @ParameterizedTest
+  @EnumSource(ViewType.class)
+  @DisplayName("getFactory returns non-null factory for every ViewType")
+  void getFactory_shouldReturnNonNullForEveryViewType(
+      ViewType type) {
+    ViewFactory factory = registry.getFactory(type);
+    assertNotNull(factory,
+        "Factory should not be null for " + type);
+  }
+}


### PR DESCRIPTION
## Summary

- Introduce `ViewFactory` interface and `ViewCreationResult` record to encapsulate view creation logic
- Add five concrete factory implementations (`MapViewFactory`, `OutlineViewFactory`, `TreemapViewFactory`, `HyperbolicViewFactory`, `AttributeBrowserViewFactory`) that extract creation logic from the switch cases
- Add `ViewFactoryRegistry` that maps each `ViewType` to its factory
- Refactor `ViewPaneContext.doSwitchView()` from a 100-line switch statement to a uniform 20-line method that delegates to the registry

## Test plan

- [x] `ViewFactoryRegistryTest`: verifies registry returns non-null factory for every `ViewType`
- [x] `ViewFactoryCreateTest`: verifies each factory produces correct `ViewCreationResult` fields (including null `selectedNoteIdProperty` for Browser)
- [x] All 908 existing tests pass (including all `ViewPaneContextTest` switch-view tests)
- [x] Checkstyle: 0 violations
- [x] JaCoCo coverage thresholds met
- [x] ArchUnit architecture rules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)