### PR TITLE
Extract Layout Strategy pattern for Hyperbolic view (#236)

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicLayoutStrategy.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicLayoutStrategy.java
@@ -1,0 +1,22 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * A {@link LayoutStrategy} that delegates to the hyperbolic (Poincare disk)
+ * layout algorithm.
+ *
+ * <p>Arranges linked notes radially using BFS from a focus node, with
+ * exponentially decreasing node sizes to simulate hyperbolic projection.</p>
+ */
+public final class HyperbolicLayoutStrategy implements LayoutStrategy {
+
+    @Override
+    public List<HyperbolicNode> layout(UUID focusId,
+            Map<UUID, Set<UUID>> adjacency, double viewportRadius) {
+        return HyperbolicLayout.layout(focusId, adjacency, viewportRadius);
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
@@ -49,9 +49,11 @@ public final class HyperbolicViewModel {
     private final NavigationStack navigationStack = new NavigationStack();
     private double viewportRadius = DEFAULT_VIEWPORT_RADIUS;
     private final AppState appState;
+    private final LayoutStrategy layoutStrategy;
 
     /**
-     * Constructs a HyperbolicViewModel with the given services.
+     * Constructs a HyperbolicViewModel with the given services and
+     * default hyperbolic layout strategy.
      *
      * @param noteService the note service for querying notes
      * @param linkService the link service for querying links
@@ -59,12 +61,28 @@ public final class HyperbolicViewModel {
      */
     public HyperbolicViewModel(NoteService noteService, LinkService linkService,
             AppState appState) {
+        this(noteService, linkService, appState, new HyperbolicLayoutStrategy());
+    }
+
+    /**
+     * Constructs a HyperbolicViewModel with the given services and
+     * layout strategy.
+     *
+     * @param noteService    the note service for querying notes
+     * @param linkService    the link service for querying links
+     * @param appState       the shared application state for data-change notification
+     * @param layoutStrategy the strategy for computing node positions
+     */
+    public HyperbolicViewModel(NoteService noteService, LinkService linkService,
+            AppState appState, LayoutStrategy layoutStrategy) {
         this.noteService = Objects.requireNonNull(noteService,
                 "noteService must not be null");
         this.linkService = Objects.requireNonNull(linkService,
                 "linkService must not be null");
         this.appState = Objects.requireNonNull(appState,
                 "appState must not be null");
+        this.layoutStrategy = Objects.requireNonNull(layoutStrategy,
+                "layoutStrategy must not be null");
         tabTitle.set("Hyperbolic");
     }
 
@@ -236,7 +254,7 @@ public final class HyperbolicViewModel {
             }
         }
 
-        List<HyperbolicNode> layoutNodes = HyperbolicLayout.layout(
+        List<HyperbolicNode> layoutNodes = layoutStrategy.layout(
                 focus, adjacency, viewportRadius);
 
         nodes.setAll(layoutNodes);

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/LayoutStrategy.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/LayoutStrategy.java
@@ -1,0 +1,27 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Strategy interface for computing the spatial layout of graph nodes.
+ *
+ * <p>Implementations position nodes from an adjacency graph within a
+ * viewport of the given radius. The Strategy pattern decouples layout
+ * algorithms from the ViewModel that holds graph data.</p>
+ */
+public interface LayoutStrategy {
+
+    /**
+     * Computes the layout for the given graph.
+     *
+     * @param focusId        the focus node id (placed at center)
+     * @param adjacency      adjacency list (node id to set of neighbor ids)
+     * @param viewportRadius the viewport radius in pixels
+     * @return the list of positioned nodes
+     */
+    List<HyperbolicNode> layout(UUID focusId,
+            Map<UUID, Set<UUID>> adjacency, double viewportRadius);
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicLayoutStrategyTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicLayoutStrategyTest.java
@@ -1,0 +1,62 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HyperbolicLayoutStrategyTest {
+
+    private static final double VIEWPORT_RADIUS = 300.0;
+
+    @Test
+    @DisplayName("implements LayoutStrategy interface")
+    void shouldImplementLayoutStrategy() {
+        LayoutStrategy strategy = new HyperbolicLayoutStrategy();
+        assertTrue(strategy instanceof LayoutStrategy);
+    }
+
+    @Test
+    @DisplayName("single node is placed at origin via strategy")
+    void singleNode_shouldBePlacedAtOrigin() {
+        LayoutStrategy strategy = new HyperbolicLayoutStrategy();
+        UUID focus = UUID.randomUUID();
+        Map<UUID, Set<UUID>> adjacency = new HashMap<>();
+
+        List<HyperbolicNode> nodes = strategy.layout(
+                focus, adjacency, VIEWPORT_RADIUS);
+
+        assertEquals(1, nodes.size());
+        HyperbolicNode node = nodes.get(0);
+        assertEquals(focus, node.noteId());
+        assertEquals(0, node.x(), 0.001);
+        assertEquals(0, node.y(), 0.001);
+    }
+
+    @Test
+    @DisplayName("star graph produces correct number of nodes via strategy")
+    void starGraph_shouldProduceCorrectNodeCount() {
+        LayoutStrategy strategy = new HyperbolicLayoutStrategy();
+        UUID focus = UUID.randomUUID();
+        UUID n1 = UUID.randomUUID();
+        UUID n2 = UUID.randomUUID();
+
+        Map<UUID, Set<UUID>> adjacency = new HashMap<>();
+        adjacency.put(focus, new HashSet<>(Set.of(n1, n2)));
+        adjacency.put(n1, new HashSet<>(Set.of(focus)));
+        adjacency.put(n2, new HashSet<>(Set.of(focus)));
+
+        List<HyperbolicNode> nodes = strategy.layout(
+                focus, adjacency, VIEWPORT_RADIUS);
+
+        assertEquals(3, nodes.size());
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelLayoutStrategyTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelLayoutStrategyTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelLayoutStrategyTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelLayoutStrategyTest.java
@@ -1,0 +1,100 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.LinkServiceImpl;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.LinkService;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HyperbolicViewModelLayoutStrategyTest {
+
+    private NoteService noteService;
+    private LinkService linkService;
+    private AppState appState;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository noteRepo = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(noteRepo);
+        InMemoryLinkRepository linkRepo = new InMemoryLinkRepository();
+        linkService = new LinkServiceImpl(linkRepo);
+        appState = new AppState();
+    }
+
+    @Test
+    @DisplayName("constructor rejects null layoutStrategy")
+    void constructor_shouldRejectNullLayoutStrategy() {
+        assertThrows(NullPointerException.class,
+                () -> new HyperbolicViewModel(
+                        noteService, linkService, appState, null));
+    }
+
+    @Test
+    @DisplayName("setFocusNote delegates to injected LayoutStrategy")
+    void setFocusNote_shouldDelegateToInjectedStrategy() {
+        List<UUID> capturedFocusIds = new ArrayList<>();
+        LayoutStrategy spyStrategy = (focusId, adjacency, viewportRadius) -> {
+            capturedFocusIds.add(focusId);
+            return List.of(new HyperbolicNode(focusId, 0, 0, 36.0, 0));
+        };
+
+        HyperbolicViewModel vm = new HyperbolicViewModel(
+                noteService, linkService, appState, spyStrategy);
+        Note note = noteService.createNote("Test", "");
+
+        vm.setFocusNote(note.getId());
+
+        assertEquals(1, capturedFocusIds.size());
+        assertEquals(note.getId(), capturedFocusIds.get(0));
+        assertEquals(1, vm.getNodes().size());
+    }
+
+    @Test
+    @DisplayName("custom strategy result is reflected in ViewModel nodes")
+    void customStrategy_shouldPopulateViewModelNodes() {
+        UUID fakeId = UUID.randomUUID();
+        LayoutStrategy customStrategy = (focusId, adjacency, viewportRadius) ->
+                List.of(
+                        new HyperbolicNode(focusId, 0, 0, 50.0, 0),
+                        new HyperbolicNode(fakeId, 10, 20, 25.0, 1)
+                );
+
+        HyperbolicViewModel vm = new HyperbolicViewModel(
+                noteService, linkService, appState, customStrategy);
+        Note note = noteService.createNote("Test", "");
+
+        vm.setFocusNote(note.getId());
+
+        assertEquals(2, vm.getNodes().size());
+        assertEquals(fakeId, vm.getNodes().get(1).noteId());
+        assertEquals(10, vm.getNodes().get(1).x(), 0.001);
+    }
+
+    @Test
+    @DisplayName("three-arg constructor still works with default strategy")
+    void threeArgConstructor_shouldUseDefaultStrategy() {
+        HyperbolicViewModel vm = new HyperbolicViewModel(
+                noteService, linkService, appState);
+        Note note = noteService.createNote("Solo", "");
+
+        vm.setFocusNote(note.getId());
+
+        assertEquals(1, vm.getNodes().size());
+        assertTrue(vm.getEdges().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `LayoutStrategy` interface defining the contract for graph layout computation
- Add `HyperbolicLayoutStrategy` implementation that delegates to the existing `HyperbolicLayout` utility
- Refactor `HyperbolicViewModel` to accept `LayoutStrategy` via constructor injection, with a convenience constructor that defaults to `HyperbolicLayoutStrategy`
- Existing behavior is fully preserved; the 3-arg constructor used by `HyperbolicViewFactory` continues to work unchanged

## Test plan
- [x] `HyperbolicLayoutStrategyTest` verifies the strategy implements the interface and delegates correctly
- [x] `HyperbolicViewModelLayoutStrategyTest` verifies constructor injection, null rejection, custom strategy delegation, and backward compatibility of the 3-arg constructor
- [x] All existing `HyperbolicViewModelTest` and `HyperbolicLayoutTest` tests continue to pass
- [x] Full `mvn verify` passes (checkstyle, JaCoCo coverage, ArchUnit architecture rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>