### PR TITLE
Add lightweight EventBus for ViewModel communication (#238)

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -8,6 +8,7 @@ import com.embervault.adapter.in.ui.view.OutlineViewController;
 import com.embervault.adapter.in.ui.view.SearchViewController;
 import com.embervault.adapter.in.ui.view.TextPaneViewController;
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
@@ -56,6 +57,7 @@ public class App extends Application {
         StringProperty rootNoteTitle = new SimpleStringProperty(
                 project.getRootNote().getTitle());
         AppState appState = new AppState();
+        EventBus eventBus = new EventBus();
 
         // Single Outline view
         OutlineViewModel outlineViewModel = new OutlineViewModel(
@@ -122,7 +124,7 @@ public class App extends Application {
         });
         ViewPaneDeps paneDeps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                appState, selectedNoteVm, rootNoteTitle);
+                appState, eventBus, selectedNoteVm, rootNoteTitle);
         outlinePane.setDeps(paneDeps);
 
         // Layout: outline + text pane

--- a/src/main/java/com/embervault/ViewPaneContext.java
+++ b/src/main/java/com/embervault/ViewPaneContext.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
@@ -41,6 +42,7 @@ public final class ViewPaneContext {
     private LinkService linkService;
     private AttributeSchemaRegistry schemaRegistry;
     private AppState appState;
+    private EventBus eventBus;
     private SelectedNoteViewModel selectedNoteVm;
     private StringProperty rootNoteTitle;
 
@@ -122,6 +124,7 @@ public final class ViewPaneContext {
         this.linkService = deps.linkService();
         this.schemaRegistry = deps.schemaRegistry();
         this.appState = deps.appState();
+        this.eventBus = deps.eventBus();
         this.selectedNoteVm = deps.selectedNoteVm();
         this.rootNoteTitle = deps.rootNoteTitle();
     }
@@ -158,7 +161,7 @@ public final class ViewPaneContext {
 
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                appState, selectedNoteVm, rootNoteTitle);
+                appState, eventBus, selectedNoteVm, rootNoteTitle);
         ViewFactory factory = registry.getFactory(newType);
         ViewCreationResult result = factory.create(
                 deps, baseNoteId,

--- a/src/main/java/com/embervault/ViewPaneDeps.java
+++ b/src/main/java/com/embervault/ViewPaneDeps.java
@@ -1,6 +1,7 @@
 package com.embervault;
 
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
@@ -15,6 +16,7 @@ import javafx.beans.property.StringProperty;
  * @param linkService    the link service
  * @param schemaRegistry the attribute schema registry
  * @param appState       the shared application state for data-change notification
+ * @param eventBus       the shared event bus for fire-and-forget events
  * @param selectedNoteVm the shared selected-note view model
  * @param rootNoteTitle  the root note title property
  */
@@ -23,6 +25,7 @@ public record ViewPaneDeps(
         LinkService linkService,
         AttributeSchemaRegistry schemaRegistry,
         AppState appState,
+        EventBus eventBus,
         SelectedNoteViewModel selectedNoteVm,
         StringProperty rootNoteTitle) {
 }

--- a/src/main/java/com/embervault/WindowFactory.java
+++ b/src/main/java/com/embervault/WindowFactory.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import com.embervault.adapter.in.ui.view.MapViewController;
 import com.embervault.adapter.in.ui.view.TextPaneViewController;
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.application.port.in.LinkService;
@@ -57,6 +58,7 @@ public final class WindowFactory {
         StringProperty rootNoteTitle = new SimpleStringProperty(
                 project.getRootNote().getTitle());
         AppState appState = new AppState();
+        EventBus eventBus = new EventBus();
         MapViewModel mapVm = new MapViewModel(
                 rootNoteTitle, noteService, appState);
         mapVm.setBaseNoteId(project.getRootNote().getId());
@@ -97,7 +99,7 @@ public final class WindowFactory {
                 (obs, oldVal, newVal) -> windowManager.notifyAllWindows());
         ViewPaneDeps paneDeps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                appState, selectedNoteVm, rootNoteTitle);
+                appState, eventBus, selectedNoteVm, rootNoteTitle);
         mapPane.setDeps(paneDeps);
         SplitPane mainSplitPane = new SplitPane();
         mainSplitPane.setOrientation(

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/EventBus.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/EventBus.java
@@ -1,0 +1,48 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/**
+ * Lightweight fire-and-forget event bus for cross-ViewModel communication.
+ *
+ * <p>Complements {@link AppState} (observable state) by providing a mechanism
+ * for one-shot event delivery. Subscribers register by event type and receive
+ * events synchronously when published.</p>
+ */
+public class EventBus {
+
+  private final Map<Class<?>, List<Consumer<?>>> subscribers =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Publishes an event to all subscribers of its type.
+   *
+   * @param event the event to publish
+   * @param <T>   the event type
+   */
+  @SuppressWarnings("unchecked")
+  public <T> void publish(T event) {
+    List<Consumer<?>> handlers = subscribers.get(event.getClass());
+    if (handlers != null) {
+      for (Consumer<?> handler : handlers) {
+        ((Consumer<T>) handler).accept(event);
+      }
+    }
+  }
+
+  /**
+   * Subscribes a handler for the given event type.
+   *
+   * @param eventType the class of the event to subscribe to
+   * @param handler   the handler to invoke when an event of this type is published
+   * @param <T>       the event type
+   */
+  public <T> void subscribe(Class<T> eventType, Consumer<T> handler) {
+    subscribers.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>())
+        .add(handler);
+  }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/EventBus.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/EventBus.java
@@ -15,50 +15,52 @@ import java.util.function.Consumer;
  */
 public class EventBus {
 
-  private final Map<Class<?>, List<Consumer<?>>> subscribers =
-      new ConcurrentHashMap<>();
+    private final Map<Class<?>, List<Consumer<?>>> subscribers =
+            new ConcurrentHashMap<>();
 
-  /**
-   * Publishes an event to all subscribers of its type.
-   *
-   * @param event the event to publish
-   * @param <T>   the event type
-   */
-  @SuppressWarnings("unchecked")
-  public <T> void publish(T event) {
-    List<Consumer<?>> handlers = subscribers.get(event.getClass());
-    if (handlers != null) {
-      for (Consumer<?> handler : handlers) {
-        ((Consumer<T>) handler).accept(event);
-      }
+    /**
+     * Publishes an event to all subscribers of its type.
+     *
+     * @param event the event to publish
+     * @param <T>   the event type
+     */
+    @SuppressWarnings("unchecked")
+    public <T> void publish(T event) {
+        List<Consumer<?>> handlers = subscribers.get(event.getClass());
+        if (handlers != null) {
+            for (Consumer<?> handler : handlers) {
+                ((Consumer<T>) handler).accept(event);
+            }
+        }
     }
-  }
 
-  /**
-   * Subscribes a handler for the given event type.
-   *
-   * @param eventType the class of the event to subscribe to
-   * @param handler   the handler to invoke when an event of this type is published
-   * @param <T>       the event type
-   */
-  public <T> void subscribe(Class<T> eventType, Consumer<T> handler) {
-    subscribers.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>())
-        .add(handler);
-  }
-
-  /**
-   * Unsubscribes a previously registered handler for the given event type.
-   *
-   * <p>If the handler was not subscribed, this method does nothing.</p>
-   *
-   * @param eventType the class of the event to unsubscribe from
-   * @param handler   the handler to remove
-   * @param <T>       the event type
-   */
-  public <T> void unsubscribe(Class<T> eventType, Consumer<T> handler) {
-    List<Consumer<?>> handlers = subscribers.get(eventType);
-    if (handlers != null) {
-      handlers.remove(handler);
+    /**
+     * Subscribes a handler for the given event type.
+     *
+     * @param eventType the class of the event to subscribe to
+     * @param handler   the handler to invoke when an event of this type
+     *                  is published
+     * @param <T>       the event type
+     */
+    public <T> void subscribe(Class<T> eventType, Consumer<T> handler) {
+        subscribers.computeIfAbsent(
+                eventType, k -> new CopyOnWriteArrayList<>()).add(handler);
     }
-  }
+
+    /**
+     * Unsubscribes a previously registered handler for the given event type.
+     *
+     * <p>If the handler was not subscribed, this method does nothing.</p>
+     *
+     * @param eventType the class of the event to unsubscribe from
+     * @param handler   the handler to remove
+     * @param <T>       the event type
+     */
+    public <T> void unsubscribe(Class<T> eventType,
+            Consumer<T> handler) {
+        List<Consumer<?>> handlers = subscribers.get(eventType);
+        if (handlers != null) {
+            handlers.remove(handler);
+        }
+    }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/EventBus.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/EventBus.java
@@ -45,4 +45,20 @@ public class EventBus {
     subscribers.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>())
         .add(handler);
   }
+
+  /**
+   * Unsubscribes a previously registered handler for the given event type.
+   *
+   * <p>If the handler was not subscribed, this method does nothing.</p>
+   *
+   * @param eventType the class of the event to unsubscribe from
+   * @param handler   the handler to remove
+   * @param <T>       the event type
+   */
+  public <T> void unsubscribe(Class<T> eventType, Consumer<T> handler) {
+    List<Consumer<?>> handlers = subscribers.get(eventType);
+    if (handlers != null) {
+      handlers.remove(handler);
+    }
+  }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDeletedEvent.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NoteDeletedEvent.java
@@ -1,0 +1,14 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.UUID;
+
+/**
+ * Event published when a note is deleted.
+ *
+ * <p>Allows ViewModels to react to note deletion without direct coupling
+ * to the ViewModel that performed the deletion.</p>
+ *
+ * @param noteId the ID of the deleted note
+ */
+public record NoteDeletedEvent(UUID noteId) {
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ViewRefreshedEvent.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ViewRefreshedEvent.java
@@ -1,0 +1,12 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+/**
+ * Event published when a view is refreshed.
+ *
+ * <p>Allows other components to react to view refresh events without
+ * direct coupling to the view that was refreshed.</p>
+ *
+ * @param viewTypeName the display name of the refreshed view type
+ */
+public record ViewRefreshedEvent(String viewTypeName) {
+}

--- a/src/test/java/com/embervault/ViewFactoryCreateTest.java
+++ b/src/test/java/com/embervault/ViewFactoryCreateTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.UUID;
 
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
@@ -51,7 +52,8 @@ class ViewFactoryCreateTest {
 
         deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                appState, selectedNoteVm, rootNoteTitle);
+                appState, new EventBus(), selectedNoteVm,
+                rootNoteTitle);
         registry = new ViewFactoryRegistry();
     }
 

--- a/src/test/java/com/embervault/ViewPaneContextBranchTest.java
+++ b/src/test/java/com/embervault/ViewPaneContextBranchTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
@@ -93,7 +94,8 @@ class ViewPaneContextBranchTest {
 
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                appState, selectedNoteVm, rootNoteTitle);
+                appState, new EventBus(), selectedNoteVm,
+                rootNoteTitle);
         paneContext.setDeps(deps);
     }
 

--- a/src/test/java/com/embervault/ViewPaneContextRefreshTest.java
+++ b/src/test/java/com/embervault/ViewPaneContextRefreshTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
@@ -86,7 +87,8 @@ class ViewPaneContextRefreshTest {
 
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                appState, selectedNoteVm, rootNoteTitle);
+                appState, new EventBus(), selectedNoteVm,
+                rootNoteTitle);
         paneContext.setDeps(deps);
     }
 

--- a/src/test/java/com/embervault/ViewPaneContextTest.java
+++ b/src/test/java/com/embervault/ViewPaneContextTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.MapViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
@@ -83,7 +84,8 @@ class ViewPaneContextTest {
 
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                new AppState(), selectedNoteVm, rootNoteTitle);
+                new AppState(), new EventBus(), selectedNoteVm,
+                rootNoteTitle);
         paneContext.setDeps(deps);
     }
 
@@ -165,7 +167,8 @@ class ViewPaneContextTest {
                 count::incrementAndGet);
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                new AppState(), selectedNoteVm, rootNoteTitle);
+                new AppState(), new EventBus(), selectedNoteVm,
+                rootNoteTitle);
         ctx.setDeps(deps);
 
         ctx.refreshCurrentView();

--- a/src/test/java/com/embervault/ViewPaneDepsEventBusTest.java
+++ b/src/test/java/com/embervault/ViewPaneDepsEventBusTest.java
@@ -1,0 +1,40 @@
+package com.embervault;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.adapter.in.ui.viewmodel.EventBus;
+import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.AttributeSchemaRegistry;
+import javafx.beans.property.SimpleStringProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that ViewPaneDeps carries EventBus reference.
+ */
+class ViewPaneDepsEventBusTest {
+
+  @Test
+  @DisplayName("ViewPaneDeps provides EventBus accessor")
+  void viewPaneDeps_providesEventBus() {
+    InMemoryNoteRepository noteRepo = new InMemoryNoteRepository();
+    NoteService noteService = new NoteServiceImpl(noteRepo);
+    AppState appState = new AppState();
+    EventBus eventBus = new EventBus();
+    SelectedNoteViewModel selectedNoteVm =
+        new SelectedNoteViewModel(noteService, appState);
+
+    ViewPaneDeps deps = new ViewPaneDeps(
+        noteService, null, new AttributeSchemaRegistry(),
+        appState, eventBus, selectedNoteVm,
+        new SimpleStringProperty("Root"));
+
+    assertNotNull(deps.eventBus());
+    assertSame(eventBus, deps.eventBus());
+  }
+}

--- a/src/test/java/com/embervault/ViewPaneDepsEventBusTest.java
+++ b/src/test/java/com/embervault/ViewPaneDepsEventBusTest.java
@@ -19,22 +19,23 @@ import org.junit.jupiter.api.Test;
  */
 class ViewPaneDepsEventBusTest {
 
-  @Test
-  @DisplayName("ViewPaneDeps provides EventBus accessor")
-  void viewPaneDeps_providesEventBus() {
-    InMemoryNoteRepository noteRepo = new InMemoryNoteRepository();
-    NoteService noteService = new NoteServiceImpl(noteRepo);
-    AppState appState = new AppState();
-    EventBus eventBus = new EventBus();
-    SelectedNoteViewModel selectedNoteVm =
-        new SelectedNoteViewModel(noteService, appState);
+    @Test
+    @DisplayName("ViewPaneDeps provides EventBus accessor")
+    void viewPaneDeps_providesEventBus() {
+        InMemoryNoteRepository noteRepo =
+                new InMemoryNoteRepository();
+        NoteService noteService = new NoteServiceImpl(noteRepo);
+        AppState appState = new AppState();
+        EventBus eventBus = new EventBus();
+        SelectedNoteViewModel selectedNoteVm =
+                new SelectedNoteViewModel(noteService, appState);
 
-    ViewPaneDeps deps = new ViewPaneDeps(
-        noteService, null, new AttributeSchemaRegistry(),
-        appState, eventBus, selectedNoteVm,
-        new SimpleStringProperty("Root"));
+        ViewPaneDeps deps = new ViewPaneDeps(
+                noteService, null, new AttributeSchemaRegistry(),
+                appState, eventBus, selectedNoteVm,
+                new SimpleStringProperty("Root"));
 
-    assertNotNull(deps.eventBus());
-    assertSame(eventBus, deps.eventBus());
-  }
+        assertNotNull(deps.eventBus());
+        assertSame(eventBus, deps.eventBus());
+    }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTest.java
@@ -1,0 +1,37 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for EventBus fire-and-forget event delivery.
+ */
+class EventBusTest {
+
+  private EventBus eventBus;
+
+  @BeforeEach
+  void setUp() {
+    eventBus = new EventBus();
+  }
+
+  @Test
+  @DisplayName("publish delivers event to subscriber")
+  void publish_deliversEventToSubscriber() {
+    List<String> received = new ArrayList<>();
+    eventBus.subscribe(String.class, received::add);
+
+    eventBus.publish("hello");
+
+    assertEquals(List.of("hello"), received);
+  }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,75 +16,75 @@ import org.junit.jupiter.api.Test;
  */
 class EventBusTest {
 
-  private EventBus eventBus;
+    private EventBus eventBus;
 
-  @BeforeEach
-  void setUp() {
-    eventBus = new EventBus();
-  }
+    @BeforeEach
+    void setUp() {
+        eventBus = new EventBus();
+    }
 
-  @Test
-  @DisplayName("publish delivers event to subscriber")
-  void publish_deliversEventToSubscriber() {
-    List<String> received = new ArrayList<>();
-    eventBus.subscribe(String.class, received::add);
+    @Test
+    @DisplayName("publish delivers event to subscriber")
+    void publish_deliversEventToSubscriber() {
+        List<String> received = new ArrayList<>();
+        eventBus.subscribe(String.class, received::add);
 
-    eventBus.publish("hello");
+        eventBus.publish("hello");
 
-    assertEquals(List.of("hello"), received);
-  }
+        assertEquals(List.of("hello"), received);
+    }
 
-  @Test
-  @DisplayName("publish delivers event to multiple subscribers")
-  void publish_deliversToMultipleSubscribers() {
-    List<String> first = new ArrayList<>();
-    List<String> second = new ArrayList<>();
-    eventBus.subscribe(String.class, first::add);
-    eventBus.subscribe(String.class, second::add);
+    @Test
+    @DisplayName("publish delivers event to multiple subscribers")
+    void publish_deliversToMultipleSubscribers() {
+        List<String> first = new ArrayList<>();
+        List<String> second = new ArrayList<>();
+        eventBus.subscribe(String.class, first::add);
+        eventBus.subscribe(String.class, second::add);
 
-    eventBus.publish("hi");
+        eventBus.publish("hi");
 
-    assertEquals(List.of("hi"), first);
-    assertEquals(List.of("hi"), second);
-  }
+        assertEquals(List.of("hi"), first);
+        assertEquals(List.of("hi"), second);
+    }
 
-  @Test
-  @DisplayName("publish with no subscribers does not throw")
-  void publish_withNoSubscribers_doesNotThrow() {
-    eventBus.publish("orphan");
-  }
+    @Test
+    @DisplayName("publish with no subscribers does not throw")
+    void publish_withNoSubscribers_doesNotThrow() {
+        eventBus.publish("orphan");
+    }
 
-  @Test
-  @DisplayName("unsubscribe removes handler so it no longer receives events")
-  void unsubscribe_removesHandler() {
-    List<String> received = new ArrayList<>();
-    Consumer<String> handler = received::add;
-    eventBus.subscribe(String.class, handler);
-    eventBus.unsubscribe(String.class, handler);
+    @Test
+    @DisplayName("unsubscribe removes handler so it no longer receives events")
+    void unsubscribe_removesHandler() {
+        List<String> received = new ArrayList<>();
+        Consumer<String> handler = received::add;
+        eventBus.subscribe(String.class, handler);
+        eventBus.unsubscribe(String.class, handler);
 
-    eventBus.publish("after-unsub");
+        eventBus.publish("after-unsub");
 
-    assertTrue(received.isEmpty());
-  }
+        assertTrue(received.isEmpty());
+    }
 
-  @Test
-  @DisplayName("subscribers only receive events of their registered type")
-  void subscribe_onlyReceivesMatchingType() {
-    List<String> strings = new ArrayList<>();
-    List<Integer> ints = new ArrayList<>();
-    eventBus.subscribe(String.class, strings::add);
-    eventBus.subscribe(Integer.class, ints::add);
+    @Test
+    @DisplayName("subscribers only receive events of their registered type")
+    void subscribe_onlyReceivesMatchingType() {
+        List<String> strings = new ArrayList<>();
+        List<Integer> ints = new ArrayList<>();
+        eventBus.subscribe(String.class, strings::add);
+        eventBus.subscribe(Integer.class, ints::add);
 
-    eventBus.publish("text");
-    eventBus.publish(42);
+        eventBus.publish("text");
+        eventBus.publish(42);
 
-    assertEquals(List.of("text"), strings);
-    assertEquals(List.of(42), ints);
-  }
+        assertEquals(List.of("text"), strings);
+        assertEquals(List.of(42), ints);
+    }
 
-  @Test
-  @DisplayName("unsubscribe for non-existent type does not throw")
-  void unsubscribe_nonExistentType_doesNotThrow() {
-    eventBus.unsubscribe(String.class, s -> { });
-  }
+    @Test
+    @DisplayName("unsubscribe for non-existent type does not throw")
+    void unsubscribe_nonExistentType_doesNotThrow() {
+        eventBus.unsubscribe(String.class, s -> { });
+    }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTest.java
@@ -34,4 +34,58 @@ class EventBusTest {
 
     assertEquals(List.of("hello"), received);
   }
+
+  @Test
+  @DisplayName("publish delivers event to multiple subscribers")
+  void publish_deliversToMultipleSubscribers() {
+    List<String> first = new ArrayList<>();
+    List<String> second = new ArrayList<>();
+    eventBus.subscribe(String.class, first::add);
+    eventBus.subscribe(String.class, second::add);
+
+    eventBus.publish("hi");
+
+    assertEquals(List.of("hi"), first);
+    assertEquals(List.of("hi"), second);
+  }
+
+  @Test
+  @DisplayName("publish with no subscribers does not throw")
+  void publish_withNoSubscribers_doesNotThrow() {
+    eventBus.publish("orphan");
+  }
+
+  @Test
+  @DisplayName("unsubscribe removes handler so it no longer receives events")
+  void unsubscribe_removesHandler() {
+    List<String> received = new ArrayList<>();
+    Consumer<String> handler = received::add;
+    eventBus.subscribe(String.class, handler);
+    eventBus.unsubscribe(String.class, handler);
+
+    eventBus.publish("after-unsub");
+
+    assertTrue(received.isEmpty());
+  }
+
+  @Test
+  @DisplayName("subscribers only receive events of their registered type")
+  void subscribe_onlyReceivesMatchingType() {
+    List<String> strings = new ArrayList<>();
+    List<Integer> ints = new ArrayList<>();
+    eventBus.subscribe(String.class, strings::add);
+    eventBus.subscribe(Integer.class, ints::add);
+
+    eventBus.publish("text");
+    eventBus.publish(42);
+
+    assertEquals(List.of("text"), strings);
+    assertEquals(List.of(42), ints);
+  }
+
+  @Test
+  @DisplayName("unsubscribe for non-existent type does not throw")
+  void unsubscribe_nonExistentType_doesNotThrow() {
+    eventBus.unsubscribe(String.class, s -> { });
+  }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTypedEventsTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTypedEventsTest.java
@@ -1,0 +1,65 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for typed event records used with EventBus.
+ */
+class EventBusTypedEventsTest {
+
+  private EventBus eventBus;
+
+  @BeforeEach
+  void setUp() {
+    eventBus = new EventBus();
+  }
+
+  @Test
+  @DisplayName("NoteDeletedEvent carries note ID through EventBus")
+  void noteDeletedEvent_carriesNoteId() {
+    UUID noteId = UUID.randomUUID();
+    List<UUID> deletedIds = new ArrayList<>();
+    eventBus.subscribe(NoteDeletedEvent.class,
+        e -> deletedIds.add(e.noteId()));
+
+    eventBus.publish(new NoteDeletedEvent(noteId));
+
+    assertEquals(List.of(noteId), deletedIds);
+  }
+
+  @Test
+  @DisplayName("ViewRefreshedEvent carries view type name through EventBus")
+  void viewRefreshedEvent_carriesViewType() {
+    List<String> refreshedViews = new ArrayList<>();
+    eventBus.subscribe(ViewRefreshedEvent.class,
+        e -> refreshedViews.add(e.viewTypeName()));
+
+    eventBus.publish(new ViewRefreshedEvent("Map"));
+
+    assertEquals(List.of("Map"), refreshedViews);
+  }
+
+  @Test
+  @DisplayName("different event types do not interfere")
+  void differentEventTypes_doNotInterfere() {
+    List<NoteDeletedEvent> deleted = new ArrayList<>();
+    List<ViewRefreshedEvent> refreshed = new ArrayList<>();
+    eventBus.subscribe(NoteDeletedEvent.class, deleted::add);
+    eventBus.subscribe(ViewRefreshedEvent.class, refreshed::add);
+
+    UUID noteId = UUID.randomUUID();
+    eventBus.publish(new NoteDeletedEvent(noteId));
+
+    assertEquals(1, deleted.size());
+    assertTrue(refreshed.isEmpty());
+  }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTypedEventsTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTypedEventsTest.java
@@ -16,50 +16,50 @@ import org.junit.jupiter.api.Test;
  */
 class EventBusTypedEventsTest {
 
-  private EventBus eventBus;
+    private EventBus eventBus;
 
-  @BeforeEach
-  void setUp() {
-    eventBus = new EventBus();
-  }
+    @BeforeEach
+    void setUp() {
+        eventBus = new EventBus();
+    }
 
-  @Test
-  @DisplayName("NoteDeletedEvent carries note ID through EventBus")
-  void noteDeletedEvent_carriesNoteId() {
-    UUID noteId = UUID.randomUUID();
-    List<UUID> deletedIds = new ArrayList<>();
-    eventBus.subscribe(NoteDeletedEvent.class,
-        e -> deletedIds.add(e.noteId()));
+    @Test
+    @DisplayName("NoteDeletedEvent carries note ID through EventBus")
+    void noteDeletedEvent_carriesNoteId() {
+        UUID noteId = UUID.randomUUID();
+        List<UUID> deletedIds = new ArrayList<>();
+        eventBus.subscribe(NoteDeletedEvent.class,
+                e -> deletedIds.add(e.noteId()));
 
-    eventBus.publish(new NoteDeletedEvent(noteId));
+        eventBus.publish(new NoteDeletedEvent(noteId));
 
-    assertEquals(List.of(noteId), deletedIds);
-  }
+        assertEquals(List.of(noteId), deletedIds);
+    }
 
-  @Test
-  @DisplayName("ViewRefreshedEvent carries view type name through EventBus")
-  void viewRefreshedEvent_carriesViewType() {
-    List<String> refreshedViews = new ArrayList<>();
-    eventBus.subscribe(ViewRefreshedEvent.class,
-        e -> refreshedViews.add(e.viewTypeName()));
+    @Test
+    @DisplayName("ViewRefreshedEvent carries view type name through EventBus")
+    void viewRefreshedEvent_carriesViewType() {
+        List<String> refreshedViews = new ArrayList<>();
+        eventBus.subscribe(ViewRefreshedEvent.class,
+                e -> refreshedViews.add(e.viewTypeName()));
 
-    eventBus.publish(new ViewRefreshedEvent("Map"));
+        eventBus.publish(new ViewRefreshedEvent("Map"));
 
-    assertEquals(List.of("Map"), refreshedViews);
-  }
+        assertEquals(List.of("Map"), refreshedViews);
+    }
 
-  @Test
-  @DisplayName("different event types do not interfere")
-  void differentEventTypes_doNotInterfere() {
-    List<NoteDeletedEvent> deleted = new ArrayList<>();
-    List<ViewRefreshedEvent> refreshed = new ArrayList<>();
-    eventBus.subscribe(NoteDeletedEvent.class, deleted::add);
-    eventBus.subscribe(ViewRefreshedEvent.class, refreshed::add);
+    @Test
+    @DisplayName("different event types do not interfere")
+    void differentEventTypes_doNotInterfere() {
+        List<NoteDeletedEvent> deleted = new ArrayList<>();
+        List<ViewRefreshedEvent> refreshed = new ArrayList<>();
+        eventBus.subscribe(NoteDeletedEvent.class, deleted::add);
+        eventBus.subscribe(ViewRefreshedEvent.class, refreshed::add);
 
-    UUID noteId = UUID.randomUUID();
-    eventBus.publish(new NoteDeletedEvent(noteId));
+        UUID noteId = UUID.randomUUID();
+        eventBus.publish(new NoteDeletedEvent(noteId));
 
-    assertEquals(1, deleted.size());
-    assertTrue(refreshed.isEmpty());
-  }
+        assertEquals(1, deleted.size());
+        assertTrue(refreshed.isEmpty());
+    }
 }


### PR DESCRIPTION
## Summary
- Add `EventBus` class with type-safe `subscribe`, `publish`, and `unsubscribe` methods for fire-and-forget cross-ViewModel communication
- Add `NoteDeletedEvent` and `ViewRefreshedEvent` typed event records
- Integrate `EventBus` into `ViewPaneDeps` (and all callers: `App`, `WindowFactory`, `ViewPaneContext`) so it is available during view creation

## Test plan
- [x] EventBus delivers events to single and multiple subscribers
- [x] EventBus isolates events by type — subscribers only receive their registered type
- [x] Unsubscribe removes handlers; no-op for unregistered types
- [x] Publishing with no subscribers does not throw
- [x] NoteDeletedEvent and ViewRefreshedEvent carry correct data through EventBus
- [x] ViewPaneDeps exposes EventBus via accessor
- [x] Full `mvn verify` passes (checkstyle, JaCoCo, ArchUnit, all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>