### PR TITLE
Decompose NoteService into single-use-case interfaces (#237)

### DIFF
--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
+import com.embervault.application.port.in.CreateNoteUseCase;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeMap;
@@ -35,7 +36,8 @@ import com.embervault.domain.UuidGenerator;
  *
  * <p>Delegates persistence to the {@link NoteRepository} outbound port.</p>
  */
-public final class NoteServiceImpl implements NoteService {
+public final class NoteServiceImpl implements NoteService,
+        CreateNoteUseCase {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.GetNoteQuery;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeMap;
@@ -37,7 +38,7 @@ import com.embervault.domain.UuidGenerator;
  * <p>Delegates persistence to the {@link NoteRepository} outbound port.</p>
  */
 public final class NoteServiceImpl implements NoteService,
-        CreateNoteUseCase {
+        CreateNoteUseCase, GetNoteQuery {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -29,6 +29,7 @@ import com.embervault.application.port.in.GetNoteQuery;
 import com.embervault.application.port.in.MoveNoteUseCase;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.RenameNoteUseCase;
+import com.embervault.application.port.in.SearchNotesQuery;
 import com.embervault.application.port.in.UpdateNoteUseCase;
 import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeMap;
@@ -43,7 +44,8 @@ import com.embervault.domain.UuidGenerator;
  */
 public final class NoteServiceImpl implements NoteService,
         CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase,
-        RenameNoteUseCase, MoveNoteUseCase, UpdateNoteUseCase {
+        RenameNoteUseCase, MoveNoteUseCase, UpdateNoteUseCase,
+        SearchNotesQuery {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -23,15 +23,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
-import com.embervault.application.port.in.CreateNoteUseCase;
-import com.embervault.application.port.in.DeleteNoteUseCase;
-import com.embervault.application.port.in.GetNoteQuery;
-import com.embervault.application.port.in.GetOutlineNavigationQuery;
-import com.embervault.application.port.in.MoveNoteUseCase;
 import com.embervault.application.port.in.NoteService;
-import com.embervault.application.port.in.RenameNoteUseCase;
-import com.embervault.application.port.in.SearchNotesQuery;
-import com.embervault.application.port.in.UpdateNoteUseCase;
 import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeMap;
 import com.embervault.domain.AttributeValue;
@@ -43,10 +35,7 @@ import com.embervault.domain.UuidGenerator;
  *
  * <p>Delegates persistence to the {@link NoteRepository} outbound port.</p>
  */
-public final class NoteServiceImpl implements NoteService,
-        CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase,
-        RenameNoteUseCase, MoveNoteUseCase, UpdateNoteUseCase,
-        SearchNotesQuery, GetOutlineNavigationQuery {
+public final class NoteServiceImpl implements NoteService {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -27,6 +27,7 @@ import com.embervault.application.port.in.CreateNoteUseCase;
 import com.embervault.application.port.in.DeleteNoteUseCase;
 import com.embervault.application.port.in.GetNoteQuery;
 import com.embervault.application.port.in.NoteService;
+import com.embervault.application.port.in.RenameNoteUseCase;
 import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeMap;
 import com.embervault.domain.AttributeValue;
@@ -39,7 +40,8 @@ import com.embervault.domain.UuidGenerator;
  * <p>Delegates persistence to the {@link NoteRepository} outbound port.</p>
  */
 public final class NoteServiceImpl implements NoteService,
-        CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase {
+        CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase,
+        RenameNoteUseCase {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.DeleteNoteUseCase;
 import com.embervault.application.port.in.GetNoteQuery;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.out.NoteRepository;
@@ -38,7 +39,7 @@ import com.embervault.domain.UuidGenerator;
  * <p>Delegates persistence to the {@link NoteRepository} outbound port.</p>
  */
 public final class NoteServiceImpl implements NoteService,
-        CreateNoteUseCase, GetNoteQuery {
+        CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -29,6 +29,7 @@ import com.embervault.application.port.in.GetNoteQuery;
 import com.embervault.application.port.in.MoveNoteUseCase;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.RenameNoteUseCase;
+import com.embervault.application.port.in.UpdateNoteUseCase;
 import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeMap;
 import com.embervault.domain.AttributeValue;
@@ -42,7 +43,7 @@ import com.embervault.domain.UuidGenerator;
  */
 public final class NoteServiceImpl implements NoteService,
         CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase,
-        RenameNoteUseCase, MoveNoteUseCase {
+        RenameNoteUseCase, MoveNoteUseCase, UpdateNoteUseCase {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import com.embervault.application.port.in.CreateNoteUseCase;
 import com.embervault.application.port.in.DeleteNoteUseCase;
 import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.GetOutlineNavigationQuery;
 import com.embervault.application.port.in.MoveNoteUseCase;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.RenameNoteUseCase;
@@ -45,7 +46,7 @@ import com.embervault.domain.UuidGenerator;
 public final class NoteServiceImpl implements NoteService,
         CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase,
         RenameNoteUseCase, MoveNoteUseCase, UpdateNoteUseCase,
-        SearchNotesQuery {
+        SearchNotesQuery, GetOutlineNavigationQuery {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import com.embervault.application.port.in.CreateNoteUseCase;
 import com.embervault.application.port.in.DeleteNoteUseCase;
 import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.MoveNoteUseCase;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.RenameNoteUseCase;
 import com.embervault.application.port.out.NoteRepository;
@@ -41,7 +42,7 @@ import com.embervault.domain.UuidGenerator;
  */
 public final class NoteServiceImpl implements NoteService,
         CreateNoteUseCase, GetNoteQuery, DeleteNoteUseCase,
-        RenameNoteUseCase {
+        RenameNoteUseCase, MoveNoteUseCase {
 
     private static final double MAX_XPOS = 12.0;
     private static final double MAX_YPOS = 8.0;

--- a/src/main/java/com/embervault/application/port/in/CreateNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/CreateNoteUseCase.java
@@ -1,0 +1,41 @@
+package com.embervault.application.port.in;
+
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Use case for creating notes.
+ *
+ * <p>Supports creating top-level notes, child notes under a parent,
+ * and sibling notes adjacent to an existing note.</p>
+ */
+public interface CreateNoteUseCase {
+
+  /**
+   * Creates a new note with the given title and content.
+   *
+   * @param title   the note title
+   * @param content the note content
+   * @return the created note
+   */
+  Note createNote(String title, String content);
+
+  /**
+   * Creates a new child note under the given parent.
+   *
+   * @param parentId the parent note id
+   * @param title    the title for the new note
+   * @return the newly created child note
+   */
+  Note createChildNote(UUID parentId, String title);
+
+  /**
+   * Creates a new sibling note directly after the given sibling in outline order.
+   *
+   * @param siblingId the id of the note to create a sibling after
+   * @param title     the title for the new note (may be empty for rapid entry)
+   * @return the newly created sibling note
+   */
+  Note createSiblingNote(UUID siblingId, String title);
+}

--- a/src/main/java/com/embervault/application/port/in/CreateNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/CreateNoteUseCase.java
@@ -12,30 +12,30 @@ import com.embervault.domain.Note;
  */
 public interface CreateNoteUseCase {
 
-  /**
-   * Creates a new note with the given title and content.
-   *
-   * @param title   the note title
-   * @param content the note content
-   * @return the created note
-   */
-  Note createNote(String title, String content);
+    /**
+     * Creates a new note with the given title and content.
+     *
+     * @param title   the note title
+     * @param content the note content
+     * @return the created note
+     */
+    Note createNote(String title, String content);
 
-  /**
-   * Creates a new child note under the given parent.
-   *
-   * @param parentId the parent note id
-   * @param title    the title for the new note
-   * @return the newly created child note
-   */
-  Note createChildNote(UUID parentId, String title);
+    /**
+     * Creates a new child note under the given parent.
+     *
+     * @param parentId the parent note id
+     * @param title    the title for the new note
+     * @return the newly created child note
+     */
+    Note createChildNote(UUID parentId, String title);
 
-  /**
-   * Creates a new sibling note directly after the given sibling in outline order.
-   *
-   * @param siblingId the id of the note to create a sibling after
-   * @param title     the title for the new note (may be empty for rapid entry)
-   * @return the newly created sibling note
-   */
-  Note createSiblingNote(UUID siblingId, String title);
+    /**
+     * Creates a new sibling note directly after the given sibling in outline order.
+     *
+     * @param siblingId the id of the note to create a sibling after
+     * @param title     the title for the new note (may be empty for rapid entry)
+     * @return the newly created sibling note
+     */
+    Note createSiblingNote(UUID siblingId, String title);
 }

--- a/src/main/java/com/embervault/application/port/in/DeleteNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/DeleteNoteUseCase.java
@@ -9,18 +9,18 @@ import java.util.UUID;
  */
 public interface DeleteNoteUseCase {
 
-  /**
-   * Deletes the note with the given id.
-   *
-   * @param id the note id
-   */
-  void deleteNote(UUID id);
+    /**
+     * Deletes the note with the given id.
+     *
+     * @param id the note id
+     */
+    void deleteNote(UUID id);
 
-  /**
-   * Deletes the note only if it is a leaf (has no children).
-   *
-   * @param noteId the note id
-   * @return true if the note was deleted, false if it has children or does not exist
-   */
-  boolean deleteNoteIfLeaf(UUID noteId);
+    /**
+     * Deletes the note only if it is a leaf (has no children).
+     *
+     * @param noteId the note id
+     * @return true if the note was deleted, false if it has children or does not exist
+     */
+    boolean deleteNoteIfLeaf(UUID noteId);
 }

--- a/src/main/java/com/embervault/application/port/in/DeleteNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/DeleteNoteUseCase.java
@@ -1,0 +1,26 @@
+package com.embervault.application.port.in;
+
+import java.util.UUID;
+
+/**
+ * Use case for deleting notes.
+ *
+ * <p>Supports unconditional deletion and conditional leaf-only deletion.</p>
+ */
+public interface DeleteNoteUseCase {
+
+  /**
+   * Deletes the note with the given id.
+   *
+   * @param id the note id
+   */
+  void deleteNote(UUID id);
+
+  /**
+   * Deletes the note only if it is a leaf (has no children).
+   *
+   * @param noteId the note id
+   * @return true if the note was deleted, false if it has children or does not exist
+   */
+  boolean deleteNoteIfLeaf(UUID noteId);
+}

--- a/src/main/java/com/embervault/application/port/in/GetNoteQuery.java
+++ b/src/main/java/com/embervault/application/port/in/GetNoteQuery.java
@@ -1,0 +1,57 @@
+package com.embervault.application.port.in;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Query interface for reading notes and their relationships.
+ *
+ * <p>Provides read-only access to notes, their children, and
+ * batch queries for children existence checks.</p>
+ */
+public interface GetNoteQuery {
+
+  /**
+   * Retrieves a note by its id.
+   *
+   * @param id the note id
+   * @return the note, or empty if not found
+   */
+  Optional<Note> getNote(UUID id);
+
+  /**
+   * Retrieves all notes.
+   *
+   * @return all notes
+   */
+  List<Note> getAllNotes();
+
+  /**
+   * Returns the children of the note with the given id, ordered by $OutlineOrder.
+   *
+   * @param parentId the parent note id
+   * @return the list of child notes
+   */
+  List<Note> getChildren(UUID parentId);
+
+  /**
+   * Returns whether the note with the given id has any children.
+   *
+   * @param noteId the note id
+   * @return true if the note has children
+   */
+  boolean hasChildren(UUID noteId);
+
+  /**
+   * Batch-checks which of the given note ids have children.
+   *
+   * @param noteIds the note ids to check
+   * @return a map from each input id to whether it has children
+   */
+  Map<UUID, Boolean> hasChildrenBatch(Collection<UUID> noteIds);
+}

--- a/src/main/java/com/embervault/application/port/in/GetNoteQuery.java
+++ b/src/main/java/com/embervault/application/port/in/GetNoteQuery.java
@@ -16,42 +16,42 @@ import com.embervault.domain.Note;
  */
 public interface GetNoteQuery {
 
-  /**
-   * Retrieves a note by its id.
-   *
-   * @param id the note id
-   * @return the note, or empty if not found
-   */
-  Optional<Note> getNote(UUID id);
+    /**
+     * Retrieves a note by its id.
+     *
+     * @param id the note id
+     * @return the note, or empty if not found
+     */
+    Optional<Note> getNote(UUID id);
 
-  /**
-   * Retrieves all notes.
-   *
-   * @return all notes
-   */
-  List<Note> getAllNotes();
+    /**
+     * Retrieves all notes.
+     *
+     * @return all notes
+     */
+    List<Note> getAllNotes();
 
-  /**
-   * Returns the children of the note with the given id, ordered by $OutlineOrder.
-   *
-   * @param parentId the parent note id
-   * @return the list of child notes
-   */
-  List<Note> getChildren(UUID parentId);
+    /**
+     * Returns the children of the note with the given id, ordered by $OutlineOrder.
+     *
+     * @param parentId the parent note id
+     * @return the list of child notes
+     */
+    List<Note> getChildren(UUID parentId);
 
-  /**
-   * Returns whether the note with the given id has any children.
-   *
-   * @param noteId the note id
-   * @return true if the note has children
-   */
-  boolean hasChildren(UUID noteId);
+    /**
+     * Returns whether the note with the given id has any children.
+     *
+     * @param noteId the note id
+     * @return true if the note has children
+     */
+    boolean hasChildren(UUID noteId);
 
-  /**
-   * Batch-checks which of the given note ids have children.
-   *
-   * @param noteIds the note ids to check
-   * @return a map from each input id to whether it has children
-   */
-  Map<UUID, Boolean> hasChildrenBatch(Collection<UUID> noteIds);
+    /**
+     * Batch-checks which of the given note ids have children.
+     *
+     * @param noteIds the note ids to check
+     * @return a map from each input id to whether it has children
+     */
+    Map<UUID, Boolean> hasChildrenBatch(Collection<UUID> noteIds);
 }

--- a/src/main/java/com/embervault/application/port/in/GetOutlineNavigationQuery.java
+++ b/src/main/java/com/embervault/application/port/in/GetOutlineNavigationQuery.java
@@ -1,0 +1,24 @@
+package com.embervault.application.port.in;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Query interface for outline navigation operations.
+ */
+public interface GetOutlineNavigationQuery {
+
+  /**
+   * Returns the previous note in outline order for the given note.
+   *
+   * <p>The previous note is the sibling with the next-lower {@code $OutlineOrder}
+   * within the same {@code $Container}. If no previous sibling exists, the parent
+   * note is returned. If there is no parent, {@code Optional.empty()} is returned.</p>
+   *
+   * @param noteId the note id
+   * @return the previous note, or empty if none
+   */
+  Optional<Note> getPreviousInOutline(UUID noteId);
+}

--- a/src/main/java/com/embervault/application/port/in/GetOutlineNavigationQuery.java
+++ b/src/main/java/com/embervault/application/port/in/GetOutlineNavigationQuery.java
@@ -10,15 +10,15 @@ import com.embervault.domain.Note;
  */
 public interface GetOutlineNavigationQuery {
 
-  /**
-   * Returns the previous note in outline order for the given note.
-   *
-   * <p>The previous note is the sibling with the next-lower {@code $OutlineOrder}
-   * within the same {@code $Container}. If no previous sibling exists, the parent
-   * note is returned. If there is no parent, {@code Optional.empty()} is returned.</p>
-   *
-   * @param noteId the note id
-   * @return the previous note, or empty if none
-   */
-  Optional<Note> getPreviousInOutline(UUID noteId);
+    /**
+     * Returns the previous note in outline order for the given note.
+     *
+     * <p>The previous note is the sibling with the next-lower {@code $OutlineOrder}
+     * within the same {@code $Container}. If no previous sibling exists, the parent
+     * note is returned. If there is no parent, {@code Optional.empty()} is returned.</p>
+     *
+     * @param noteId the note id
+     * @return the previous note, or empty if none
+     */
+    Optional<Note> getPreviousInOutline(UUID noteId);
 }

--- a/src/main/java/com/embervault/application/port/in/MoveNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/MoveNoteUseCase.java
@@ -1,0 +1,48 @@
+package com.embervault.application.port.in;
+
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Use case for moving notes within the hierarchy.
+ *
+ * <p>Supports reparenting, positional moves, indentation, and outdentation.</p>
+ */
+public interface MoveNoteUseCase {
+
+  /**
+   * Moves a note to a new parent.
+   *
+   * @param noteId      the note to move
+   * @param newParentId the new parent note id
+   * @return the updated note
+   */
+  Note moveNote(UUID noteId, UUID newParentId);
+
+  /**
+   * Moves a note to a specific position within a parent.
+   *
+   * @param noteId      the note to move
+   * @param newParentId the target parent note id
+   * @param position    the zero-based position among siblings
+   * @return the updated note
+   */
+  Note moveNoteToPosition(UUID noteId, UUID newParentId, int position);
+
+  /**
+   * Indents a note by making it a child of the note directly above it.
+   *
+   * @param noteId the id of the note to indent
+   * @return the updated note
+   */
+  Note indentNote(UUID noteId);
+
+  /**
+   * Outdents a note by moving it to be a sibling of its current parent.
+   *
+   * @param noteId the id of the note to outdent
+   * @return the updated note
+   */
+  Note outdentNote(UUID noteId);
+}

--- a/src/main/java/com/embervault/application/port/in/MoveNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/MoveNoteUseCase.java
@@ -11,38 +11,38 @@ import com.embervault.domain.Note;
  */
 public interface MoveNoteUseCase {
 
-  /**
-   * Moves a note to a new parent.
-   *
-   * @param noteId      the note to move
-   * @param newParentId the new parent note id
-   * @return the updated note
-   */
-  Note moveNote(UUID noteId, UUID newParentId);
+    /**
+     * Moves a note to a new parent.
+     *
+     * @param noteId      the note to move
+     * @param newParentId the new parent note id
+     * @return the updated note
+     */
+    Note moveNote(UUID noteId, UUID newParentId);
 
-  /**
-   * Moves a note to a specific position within a parent.
-   *
-   * @param noteId      the note to move
-   * @param newParentId the target parent note id
-   * @param position    the zero-based position among siblings
-   * @return the updated note
-   */
-  Note moveNoteToPosition(UUID noteId, UUID newParentId, int position);
+    /**
+     * Moves a note to a specific position within a parent.
+     *
+     * @param noteId      the note to move
+     * @param newParentId the target parent note id
+     * @param position    the zero-based position among siblings
+     * @return the updated note
+     */
+    Note moveNoteToPosition(UUID noteId, UUID newParentId, int position);
 
-  /**
-   * Indents a note by making it a child of the note directly above it.
-   *
-   * @param noteId the id of the note to indent
-   * @return the updated note
-   */
-  Note indentNote(UUID noteId);
+    /**
+     * Indents a note by making it a child of the note directly above it.
+     *
+     * @param noteId the id of the note to indent
+     * @return the updated note
+     */
+    Note indentNote(UUID noteId);
 
-  /**
-   * Outdents a note by moving it to be a sibling of its current parent.
-   *
-   * @param noteId the id of the note to outdent
-   * @return the updated note
-   */
-  Note outdentNote(UUID noteId);
+    /**
+     * Outdents a note by moving it to be a sibling of its current parent.
+     *
+     * @param noteId the id of the note to outdent
+     * @return the updated note
+     */
+    Note outdentNote(UUID noteId);
 }

--- a/src/main/java/com/embervault/application/port/in/NoteService.java
+++ b/src/main/java/com/embervault/application/port/in/NoteService.java
@@ -1,177 +1,24 @@
 package com.embervault.application.port.in;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-
-import com.embervault.domain.Note;
-
 /**
- * Inbound port defining the note management use cases.
+ * Composite inbound port aggregating all note-related use cases.
+ *
+ * <p>This interface exists as a convenience for consumers that need
+ * access to multiple use cases. New code should prefer depending on
+ * the narrowest use case interface (e.g., {@link CreateNoteUseCase},
+ * {@link GetNoteQuery}) following the Interface Segregation Principle.</p>
+ *
+ * <p>Extends all individual use case and query interfaces so that
+ * existing consumers that depend on {@code NoteService} continue
+ * to work without changes.</p>
  */
-public interface NoteService {
-
-    /**
-     * Creates a new note with the given title and content.
-     */
-    Note createNote(String title, String content);
-
-    /**
-     * Retrieves a note by its id.
-     */
-    Optional<Note> getNote(UUID id);
-
-    /**
-     * Retrieves all notes.
-     */
-    List<Note> getAllNotes();
-
-    /**
-     * Updates an existing note's title and content.
-     */
-    Note updateNote(UUID id, String title, String content);
-
-    /**
-     * Creates a new child note under the given parent.
-     *
-     * @param parentId the parent note id
-     * @param title    the title for the new note
-     * @return the newly created child note
-     */
-    Note createChildNote(UUID parentId, String title);
-
-    /**
-     * Returns the children of the note with the given id, ordered by $OutlineOrder.
-     *
-     * @param parentId the parent note id
-     * @return the list of child notes
-     */
-    List<Note> getChildren(UUID parentId);
-
-    /**
-     * Returns whether the note with the given id has any children.
-     *
-     * @param noteId the note id
-     * @return true if the note has children
-     */
-    boolean hasChildren(UUID noteId);
-
-    /**
-     * Batch-checks which of the given note ids have children.
-     *
-     * <p>Performs a single repository scan instead of one per id, making it
-     * O(M) where M is the total number of notes, regardless of input size.</p>
-     *
-     * @param noteIds the note ids to check
-     * @return a map from each input id to whether it has children
-     */
-    Map<UUID, Boolean> hasChildrenBatch(Collection<UUID> noteIds);
-
-    /**
-     * Moves a note to a new parent by changing its $Container attribute.
-     *
-     * @param noteId      the note to move
-     * @param newParentId the new parent note id
-     * @return the updated note
-     */
-    Note moveNote(UUID noteId, UUID newParentId);
-
-    /**
-     * Moves a note to a specific position within a parent.
-     *
-     * <p>If the parent differs from the note's current container,
-     * the note is reparented. The note is placed at the given
-     * position index among the parent's children, and sibling
-     * orders are recalculated.</p>
-     *
-     * @param noteId      the note to move
-     * @param newParentId the target parent note id
-     * @param position    the zero-based position among siblings
-     * @return the updated note
-     */
-    Note moveNoteToPosition(UUID noteId, UUID newParentId,
-            int position);
-
-    /**
-     * Renames the note with the given id.
-     *
-     * @param noteId   the note id
-     * @param newTitle the new title (must not be blank)
-     * @return the updated note
-     */
-    Note renameNote(UUID noteId, String newTitle);
-
-    /**
-     * Creates a new sibling note directly after the given sibling in outline order.
-     *
-     * <p>The new note will have the same {@code $Container} as the sibling.
-     * Subsequent siblings have their {@code $OutlineOrder} incremented to make room.</p>
-     *
-     * @param siblingId the id of the note to create a sibling after
-     * @param title     the title for the new note (may be empty for rapid entry)
-     * @return the newly created sibling note
-     */
-    Note createSiblingNote(UUID siblingId, String title);
-
-    /**
-     * Indents a note by making it a child of the note directly above it in outline order.
-     *
-     * <p>If the note is the first child (no note above), it is returned unchanged.</p>
-     *
-     * @param noteId the id of the note to indent
-     * @return the updated note
-     */
-    Note indentNote(UUID noteId);
-
-    /**
-     * Outdents a note by moving it to be a sibling of its current parent.
-     *
-     * <p>The note is placed just after its old parent in the grandparent's children.
-     * If the note has no parent or the parent has no grandparent, the note is returned
-     * unchanged.</p>
-     *
-     * @param noteId the id of the note to outdent
-     * @return the updated note
-     */
-    Note outdentNote(UUID noteId);
-
-    /**
-     * Deletes the note with the given id.
-     */
-    void deleteNote(UUID id);
-
-    /**
-     * Returns the previous note in outline order for the given note.
-     *
-     * <p>The previous note is the sibling with the next-lower {@code $OutlineOrder}
-     * within the same {@code $Container}. If no previous sibling exists, the parent
-     * note (the {@code $Container} note) is returned. If there is no parent,
-     * {@code Optional.empty()} is returned.</p>
-     *
-     * @param noteId the note id
-     * @return the previous note, or empty if none
-     */
-    Optional<Note> getPreviousInOutline(UUID noteId);
-
-    /**
-     * Deletes the note only if it is a leaf (has no children).
-     *
-     * @param noteId the note id
-     * @return true if the note was deleted, false if it has children or does not exist
-     */
-    boolean deleteNoteIfLeaf(UUID noteId);
-
-    /**
-     * Searches all notes by case-insensitive substring matching on $Name and $Text.
-     *
-     * <p>Returns notes whose title or content contain the query string.
-     * Title matches appear before text-only matches. Returns an empty list
-     * if the query is null, empty, or blank.</p>
-     *
-     * @param query the search query
-     * @return matching notes ordered by relevance (title matches first)
-     */
-    List<Note> searchNotes(String query);
+public interface NoteService extends
+        CreateNoteUseCase,
+        GetNoteQuery,
+        DeleteNoteUseCase,
+        RenameNoteUseCase,
+        MoveNoteUseCase,
+        UpdateNoteUseCase,
+        SearchNotesQuery,
+        GetOutlineNavigationQuery {
 }

--- a/src/main/java/com/embervault/application/port/in/RenameNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/RenameNoteUseCase.java
@@ -1,0 +1,20 @@
+package com.embervault.application.port.in;
+
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Use case for renaming a note.
+ */
+public interface RenameNoteUseCase {
+
+  /**
+   * Renames the note with the given id.
+   *
+   * @param noteId   the note id
+   * @param newTitle the new title (must not be blank)
+   * @return the updated note
+   */
+  Note renameNote(UUID noteId, String newTitle);
+}

--- a/src/main/java/com/embervault/application/port/in/RenameNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/RenameNoteUseCase.java
@@ -9,12 +9,12 @@ import com.embervault.domain.Note;
  */
 public interface RenameNoteUseCase {
 
-  /**
-   * Renames the note with the given id.
-   *
-   * @param noteId   the note id
-   * @param newTitle the new title (must not be blank)
-   * @return the updated note
-   */
-  Note renameNote(UUID noteId, String newTitle);
+    /**
+     * Renames the note with the given id.
+     *
+     * @param noteId   the note id
+     * @param newTitle the new title (must not be blank)
+     * @return the updated note
+     */
+    Note renameNote(UUID noteId, String newTitle);
 }

--- a/src/main/java/com/embervault/application/port/in/SearchNotesQuery.java
+++ b/src/main/java/com/embervault/application/port/in/SearchNotesQuery.java
@@ -9,15 +9,15 @@ import com.embervault.domain.Note;
  */
 public interface SearchNotesQuery {
 
-  /**
-   * Searches all notes by case-insensitive substring matching on $Name and $Text.
-   *
-   * <p>Returns notes whose title or content contain the query string.
-   * Title matches appear before text-only matches. Returns an empty list
-   * if the query is null, empty, or blank.</p>
-   *
-   * @param query the search query
-   * @return matching notes ordered by relevance (title matches first)
-   */
-  List<Note> searchNotes(String query);
+    /**
+     * Searches all notes by case-insensitive substring matching on $Name and $Text.
+     *
+     * <p>Returns notes whose title or content contain the query string.
+     * Title matches appear before text-only matches. Returns an empty list
+     * if the query is null, empty, or blank.</p>
+     *
+     * @param query the search query
+     * @return matching notes ordered by relevance (title matches first)
+     */
+    List<Note> searchNotes(String query);
 }

--- a/src/main/java/com/embervault/application/port/in/SearchNotesQuery.java
+++ b/src/main/java/com/embervault/application/port/in/SearchNotesQuery.java
@@ -1,0 +1,23 @@
+package com.embervault.application.port.in;
+
+import java.util.List;
+
+import com.embervault.domain.Note;
+
+/**
+ * Query interface for searching notes by text content.
+ */
+public interface SearchNotesQuery {
+
+  /**
+   * Searches all notes by case-insensitive substring matching on $Name and $Text.
+   *
+   * <p>Returns notes whose title or content contain the query string.
+   * Title matches appear before text-only matches. Returns an empty list
+   * if the query is null, empty, or blank.</p>
+   *
+   * @param query the search query
+   * @return matching notes ordered by relevance (title matches first)
+   */
+  List<Note> searchNotes(String query);
+}

--- a/src/main/java/com/embervault/application/port/in/UpdateNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/UpdateNoteUseCase.java
@@ -9,13 +9,13 @@ import com.embervault.domain.Note;
  */
 public interface UpdateNoteUseCase {
 
-  /**
-   * Updates an existing note's title and content.
-   *
-   * @param id      the note id
-   * @param title   the new title
-   * @param content the new content
-   * @return the updated note
-   */
-  Note updateNote(UUID id, String title, String content);
+    /**
+     * Updates an existing note's title and content.
+     *
+     * @param id      the note id
+     * @param title   the new title
+     * @param content the new content
+     * @return the updated note
+     */
+    Note updateNote(UUID id, String title, String content);
 }

--- a/src/main/java/com/embervault/application/port/in/UpdateNoteUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/UpdateNoteUseCase.java
@@ -1,0 +1,21 @@
+package com.embervault.application.port.in;
+
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+
+/**
+ * Use case for updating a note's title and content.
+ */
+public interface UpdateNoteUseCase {
+
+  /**
+   * Updates an existing note's title and content.
+   *
+   * @param id      the note id
+   * @param title   the new title
+   * @param content the new content
+   * @return the updated note
+   */
+  Note updateNote(UUID id, String title, String content);
+}

--- a/src/test/java/com/embervault/application/CreateNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/CreateNoteUseCaseTest.java
@@ -1,0 +1,64 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CreateNoteUseCaseTest {
+
+  private CreateNoteUseCase useCase;
+  private InMemoryNoteRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new InMemoryNoteRepository();
+    useCase = new NoteServiceImpl(repository);
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements CreateNoteUseCase")
+  void noteServiceImpl_shouldImplementCreateNoteUseCase() {
+    assertNotNull(useCase);
+    assertTrue(useCase instanceof CreateNoteUseCase);
+  }
+
+  @Test
+  @DisplayName("createNote() via CreateNoteUseCase returns a persisted note")
+  void createNote_shouldPersistAndReturn() {
+    Note note = useCase.createNote("Title", "Content");
+
+    assertNotNull(note);
+    assertEquals("Title", note.getTitle());
+    assertTrue(repository.findById(note.getId()).isPresent());
+  }
+
+  @Test
+  @DisplayName("createChildNote() via CreateNoteUseCase creates a child")
+  void createChildNote_shouldCreateChild() {
+    Note parent = useCase.createNote("Parent", "");
+
+    Note child = useCase.createChildNote(parent.getId(), "Child");
+
+    assertNotNull(child);
+    assertEquals("Child", child.getTitle());
+  }
+
+  @Test
+  @DisplayName("createSiblingNote() via CreateNoteUseCase creates a sibling")
+  void createSiblingNote_shouldCreateSibling() {
+    Note parent = useCase.createNote("Parent", "");
+    Note child = useCase.createChildNote(parent.getId(), "First");
+
+    Note sibling = useCase.createSiblingNote(child.getId(), "Second");
+
+    assertNotNull(sibling);
+    assertEquals("Second", sibling.getTitle());
+  }
+}

--- a/src/test/java/com/embervault/application/CreateNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/CreateNoteUseCaseTest.java
@@ -13,52 +13,52 @@ import org.junit.jupiter.api.Test;
 
 class CreateNoteUseCaseTest {
 
-  private CreateNoteUseCase useCase;
-  private InMemoryNoteRepository repository;
+    private CreateNoteUseCase useCase;
+    private InMemoryNoteRepository repository;
 
-  @BeforeEach
-  void setUp() {
-    repository = new InMemoryNoteRepository();
-    useCase = new NoteServiceImpl(repository);
-  }
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        useCase = new NoteServiceImpl(repository);
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements CreateNoteUseCase")
-  void noteServiceImpl_shouldImplementCreateNoteUseCase() {
-    assertNotNull(useCase);
-    assertTrue(useCase instanceof CreateNoteUseCase);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements CreateNoteUseCase")
+    void noteServiceImpl_shouldImplementCreateNoteUseCase() {
+        assertNotNull(useCase);
+        assertTrue(useCase instanceof CreateNoteUseCase);
+    }
 
-  @Test
-  @DisplayName("createNote() via CreateNoteUseCase returns a persisted note")
-  void createNote_shouldPersistAndReturn() {
-    Note note = useCase.createNote("Title", "Content");
+    @Test
+    @DisplayName("createNote() via CreateNoteUseCase returns a persisted note")
+    void createNote_shouldPersistAndReturn() {
+        Note note = useCase.createNote("Title", "Content");
 
-    assertNotNull(note);
-    assertEquals("Title", note.getTitle());
-    assertTrue(repository.findById(note.getId()).isPresent());
-  }
+        assertNotNull(note);
+        assertEquals("Title", note.getTitle());
+        assertTrue(repository.findById(note.getId()).isPresent());
+    }
 
-  @Test
-  @DisplayName("createChildNote() via CreateNoteUseCase creates a child")
-  void createChildNote_shouldCreateChild() {
-    Note parent = useCase.createNote("Parent", "");
+    @Test
+    @DisplayName("createChildNote() via CreateNoteUseCase creates a child")
+    void createChildNote_shouldCreateChild() {
+        Note parent = useCase.createNote("Parent", "");
 
-    Note child = useCase.createChildNote(parent.getId(), "Child");
+        Note child = useCase.createChildNote(parent.getId(), "Child");
 
-    assertNotNull(child);
-    assertEquals("Child", child.getTitle());
-  }
+        assertNotNull(child);
+        assertEquals("Child", child.getTitle());
+    }
 
-  @Test
-  @DisplayName("createSiblingNote() via CreateNoteUseCase creates a sibling")
-  void createSiblingNote_shouldCreateSibling() {
-    Note parent = useCase.createNote("Parent", "");
-    Note child = useCase.createChildNote(parent.getId(), "First");
+    @Test
+    @DisplayName("createSiblingNote() via CreateNoteUseCase creates a sibling")
+    void createSiblingNote_shouldCreateSibling() {
+        Note parent = useCase.createNote("Parent", "");
+        Note child = useCase.createChildNote(parent.getId(), "First");
 
-    Note sibling = useCase.createSiblingNote(child.getId(), "Second");
+        Note sibling = useCase.createSiblingNote(child.getId(), "Second");
 
-    assertNotNull(sibling);
-    assertEquals("Second", sibling.getTitle());
-  }
+        assertNotNull(sibling);
+        assertEquals("Second", sibling.getTitle());
+    }
 }

--- a/src/test/java/com/embervault/application/DeleteNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/DeleteNoteUseCaseTest.java
@@ -1,0 +1,78 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.DeleteNoteUseCase;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DeleteNoteUseCaseTest {
+
+  private DeleteNoteUseCase deleteUseCase;
+  private CreateNoteUseCase creator;
+  private GetNoteQuery query;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryNoteRepository repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    deleteUseCase = service;
+    creator = service;
+    query = service;
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements DeleteNoteUseCase")
+  void noteServiceImpl_shouldImplementDeleteNoteUseCase() {
+    assertTrue(deleteUseCase instanceof DeleteNoteUseCase);
+  }
+
+  @Test
+  @DisplayName("deleteNote() removes the note")
+  void deleteNote_shouldRemoveNote() {
+    Note note = creator.createNote("Title", "Content");
+
+    deleteUseCase.deleteNote(note.getId());
+
+    assertTrue(query.getNote(note.getId()).isEmpty());
+  }
+
+  @Test
+  @DisplayName("deleteNoteIfLeaf() deletes leaf note and returns true")
+  void deleteNoteIfLeaf_shouldDeleteLeaf() {
+    Note parent = creator.createNote("Parent", "");
+    Note child = creator.createChildNote(parent.getId(), "Child");
+
+    boolean result = deleteUseCase.deleteNoteIfLeaf(child.getId());
+
+    assertTrue(result);
+    assertTrue(query.getNote(child.getId()).isEmpty());
+  }
+
+  @Test
+  @DisplayName("deleteNoteIfLeaf() does not delete note with children")
+  void deleteNoteIfLeaf_shouldNotDeleteParent() {
+    Note parent = creator.createNote("Parent", "");
+    Note child = creator.createChildNote(parent.getId(), "Child");
+    creator.createChildNote(child.getId(), "Grandchild");
+
+    boolean result = deleteUseCase.deleteNoteIfLeaf(child.getId());
+
+    assertFalse(result);
+    assertTrue(query.getNote(child.getId()).isPresent());
+  }
+
+  @Test
+  @DisplayName("deleteNoteIfLeaf() returns false for missing note")
+  void deleteNoteIfLeaf_shouldReturnFalseForMissing() {
+    assertFalse(deleteUseCase.deleteNoteIfLeaf(UUID.randomUUID()));
+  }
+}

--- a/src/test/java/com/embervault/application/DeleteNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/DeleteNoteUseCaseTest.java
@@ -16,63 +16,63 @@ import org.junit.jupiter.api.Test;
 
 class DeleteNoteUseCaseTest {
 
-  private DeleteNoteUseCase deleteUseCase;
-  private CreateNoteUseCase creator;
-  private GetNoteQuery query;
+    private DeleteNoteUseCase deleteUseCase;
+    private CreateNoteUseCase creator;
+    private GetNoteQuery query;
 
-  @BeforeEach
-  void setUp() {
-    InMemoryNoteRepository repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    deleteUseCase = service;
-    creator = service;
-    query = service;
-  }
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        deleteUseCase = service;
+        creator = service;
+        query = service;
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements DeleteNoteUseCase")
-  void noteServiceImpl_shouldImplementDeleteNoteUseCase() {
-    assertTrue(deleteUseCase instanceof DeleteNoteUseCase);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements DeleteNoteUseCase")
+    void noteServiceImpl_shouldImplementDeleteNoteUseCase() {
+        assertTrue(deleteUseCase instanceof DeleteNoteUseCase);
+    }
 
-  @Test
-  @DisplayName("deleteNote() removes the note")
-  void deleteNote_shouldRemoveNote() {
-    Note note = creator.createNote("Title", "Content");
+    @Test
+    @DisplayName("deleteNote() removes the note")
+    void deleteNote_shouldRemoveNote() {
+        Note note = creator.createNote("Title", "Content");
 
-    deleteUseCase.deleteNote(note.getId());
+        deleteUseCase.deleteNote(note.getId());
 
-    assertTrue(query.getNote(note.getId()).isEmpty());
-  }
+        assertTrue(query.getNote(note.getId()).isEmpty());
+    }
 
-  @Test
-  @DisplayName("deleteNoteIfLeaf() deletes leaf note and returns true")
-  void deleteNoteIfLeaf_shouldDeleteLeaf() {
-    Note parent = creator.createNote("Parent", "");
-    Note child = creator.createChildNote(parent.getId(), "Child");
+    @Test
+    @DisplayName("deleteNoteIfLeaf() deletes leaf note and returns true")
+    void deleteNoteIfLeaf_shouldDeleteLeaf() {
+        Note parent = creator.createNote("Parent", "");
+        Note child = creator.createChildNote(parent.getId(), "Child");
 
-    boolean result = deleteUseCase.deleteNoteIfLeaf(child.getId());
+        boolean result = deleteUseCase.deleteNoteIfLeaf(child.getId());
 
-    assertTrue(result);
-    assertTrue(query.getNote(child.getId()).isEmpty());
-  }
+        assertTrue(result);
+        assertTrue(query.getNote(child.getId()).isEmpty());
+    }
 
-  @Test
-  @DisplayName("deleteNoteIfLeaf() does not delete note with children")
-  void deleteNoteIfLeaf_shouldNotDeleteParent() {
-    Note parent = creator.createNote("Parent", "");
-    Note child = creator.createChildNote(parent.getId(), "Child");
-    creator.createChildNote(child.getId(), "Grandchild");
+    @Test
+    @DisplayName("deleteNoteIfLeaf() does not delete note with children")
+    void deleteNoteIfLeaf_shouldNotDeleteParent() {
+        Note parent = creator.createNote("Parent", "");
+        Note child = creator.createChildNote(parent.getId(), "Child");
+        creator.createChildNote(child.getId(), "Grandchild");
 
-    boolean result = deleteUseCase.deleteNoteIfLeaf(child.getId());
+        boolean result = deleteUseCase.deleteNoteIfLeaf(child.getId());
 
-    assertFalse(result);
-    assertTrue(query.getNote(child.getId()).isPresent());
-  }
+        assertFalse(result);
+        assertTrue(query.getNote(child.getId()).isPresent());
+    }
 
-  @Test
-  @DisplayName("deleteNoteIfLeaf() returns false for missing note")
-  void deleteNoteIfLeaf_shouldReturnFalseForMissing() {
-    assertFalse(deleteUseCase.deleteNoteIfLeaf(UUID.randomUUID()));
-  }
+    @Test
+    @DisplayName("deleteNoteIfLeaf() returns false for missing note")
+    void deleteNoteIfLeaf_shouldReturnFalseForMissing() {
+        assertFalse(deleteUseCase.deleteNoteIfLeaf(UUID.randomUUID()));
+    }
 }

--- a/src/test/java/com/embervault/application/GetNoteQueryTest.java
+++ b/src/test/java/com/embervault/application/GetNoteQueryTest.java
@@ -1,0 +1,111 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GetNoteQueryTest {
+
+  private GetNoteQuery query;
+  private CreateNoteUseCase creator;
+  private InMemoryNoteRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    query = service;
+    creator = service;
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements GetNoteQuery")
+  void noteServiceImpl_shouldImplementGetNoteQuery() {
+    assertTrue(query instanceof GetNoteQuery);
+  }
+
+  @Test
+  @DisplayName("getNote() returns the note when it exists")
+  void getNote_shouldReturnExistingNote() {
+    Note created = creator.createNote("Title", "Content");
+
+    Optional<Note> found = query.getNote(created.getId());
+
+    assertTrue(found.isPresent());
+    assertEquals(created, found.get());
+  }
+
+  @Test
+  @DisplayName("getNote() returns empty when note does not exist")
+  void getNote_shouldReturnEmptyForMissing() {
+    assertTrue(query.getNote(UUID.randomUUID()).isEmpty());
+  }
+
+  @Test
+  @DisplayName("getAllNotes() returns all created notes")
+  void getAllNotes_shouldReturnAll() {
+    creator.createNote("A", "a");
+    creator.createNote("B", "b");
+
+    List<Note> all = query.getAllNotes();
+
+    assertEquals(2, all.size());
+  }
+
+  @Test
+  @DisplayName("getChildren() returns children of a parent note")
+  void getChildren_shouldReturnChildren() {
+    Note parent = creator.createNote("Parent", "");
+    creator.createChildNote(parent.getId(), "Child1");
+    creator.createChildNote(parent.getId(), "Child2");
+
+    List<Note> children = query.getChildren(parent.getId());
+
+    assertEquals(2, children.size());
+  }
+
+  @Test
+  @DisplayName("hasChildren() returns true when note has children")
+  void hasChildren_shouldReturnTrue() {
+    Note parent = creator.createNote("Parent", "");
+    creator.createChildNote(parent.getId(), "Child");
+
+    assertTrue(query.hasChildren(parent.getId()));
+  }
+
+  @Test
+  @DisplayName("hasChildren() returns false when note has no children")
+  void hasChildren_shouldReturnFalse() {
+    Note note = creator.createNote("Lonely", "");
+
+    assertFalse(query.hasChildren(note.getId()));
+  }
+
+  @Test
+  @DisplayName("hasChildrenBatch() returns correct map")
+  void hasChildrenBatch_shouldReturnCorrectMap() {
+    Note parent = creator.createNote("Parent", "");
+    Note childless = creator.createNote("Childless", "");
+    creator.createChildNote(parent.getId(), "Child");
+
+    Map<UUID, Boolean> result = query.hasChildrenBatch(
+        List.of(parent.getId(), childless.getId()));
+
+    assertTrue(result.get(parent.getId()));
+    assertFalse(result.get(childless.getId()));
+  }
+}

--- a/src/test/java/com/embervault/application/GetNoteQueryTest.java
+++ b/src/test/java/com/embervault/application/GetNoteQueryTest.java
@@ -2,7 +2,6 @@ package com.embervault.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -20,92 +19,92 @@ import org.junit.jupiter.api.Test;
 
 class GetNoteQueryTest {
 
-  private GetNoteQuery query;
-  private CreateNoteUseCase creator;
-  private InMemoryNoteRepository repository;
+    private GetNoteQuery query;
+    private CreateNoteUseCase creator;
+    private InMemoryNoteRepository repository;
 
-  @BeforeEach
-  void setUp() {
-    repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    query = service;
-    creator = service;
-  }
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        query = service;
+        creator = service;
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements GetNoteQuery")
-  void noteServiceImpl_shouldImplementGetNoteQuery() {
-    assertTrue(query instanceof GetNoteQuery);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements GetNoteQuery")
+    void noteServiceImpl_shouldImplementGetNoteQuery() {
+        assertTrue(query instanceof GetNoteQuery);
+    }
 
-  @Test
-  @DisplayName("getNote() returns the note when it exists")
-  void getNote_shouldReturnExistingNote() {
-    Note created = creator.createNote("Title", "Content");
+    @Test
+    @DisplayName("getNote() returns the note when it exists")
+    void getNote_shouldReturnExistingNote() {
+        Note created = creator.createNote("Title", "Content");
 
-    Optional<Note> found = query.getNote(created.getId());
+        Optional<Note> found = query.getNote(created.getId());
 
-    assertTrue(found.isPresent());
-    assertEquals(created, found.get());
-  }
+        assertTrue(found.isPresent());
+        assertEquals(created, found.get());
+    }
 
-  @Test
-  @DisplayName("getNote() returns empty when note does not exist")
-  void getNote_shouldReturnEmptyForMissing() {
-    assertTrue(query.getNote(UUID.randomUUID()).isEmpty());
-  }
+    @Test
+    @DisplayName("getNote() returns empty when note does not exist")
+    void getNote_shouldReturnEmptyForMissing() {
+        assertTrue(query.getNote(UUID.randomUUID()).isEmpty());
+    }
 
-  @Test
-  @DisplayName("getAllNotes() returns all created notes")
-  void getAllNotes_shouldReturnAll() {
-    creator.createNote("A", "a");
-    creator.createNote("B", "b");
+    @Test
+    @DisplayName("getAllNotes() returns all created notes")
+    void getAllNotes_shouldReturnAll() {
+        creator.createNote("A", "a");
+        creator.createNote("B", "b");
 
-    List<Note> all = query.getAllNotes();
+        List<Note> all = query.getAllNotes();
 
-    assertEquals(2, all.size());
-  }
+        assertEquals(2, all.size());
+    }
 
-  @Test
-  @DisplayName("getChildren() returns children of a parent note")
-  void getChildren_shouldReturnChildren() {
-    Note parent = creator.createNote("Parent", "");
-    creator.createChildNote(parent.getId(), "Child1");
-    creator.createChildNote(parent.getId(), "Child2");
+    @Test
+    @DisplayName("getChildren() returns children of a parent note")
+    void getChildren_shouldReturnChildren() {
+        Note parent = creator.createNote("Parent", "");
+        creator.createChildNote(parent.getId(), "Child1");
+        creator.createChildNote(parent.getId(), "Child2");
 
-    List<Note> children = query.getChildren(parent.getId());
+        List<Note> children = query.getChildren(parent.getId());
 
-    assertEquals(2, children.size());
-  }
+        assertEquals(2, children.size());
+    }
 
-  @Test
-  @DisplayName("hasChildren() returns true when note has children")
-  void hasChildren_shouldReturnTrue() {
-    Note parent = creator.createNote("Parent", "");
-    creator.createChildNote(parent.getId(), "Child");
+    @Test
+    @DisplayName("hasChildren() returns true when note has children")
+    void hasChildren_shouldReturnTrue() {
+        Note parent = creator.createNote("Parent", "");
+        creator.createChildNote(parent.getId(), "Child");
 
-    assertTrue(query.hasChildren(parent.getId()));
-  }
+        assertTrue(query.hasChildren(parent.getId()));
+    }
 
-  @Test
-  @DisplayName("hasChildren() returns false when note has no children")
-  void hasChildren_shouldReturnFalse() {
-    Note note = creator.createNote("Lonely", "");
+    @Test
+    @DisplayName("hasChildren() returns false when note has no children")
+    void hasChildren_shouldReturnFalse() {
+        Note note = creator.createNote("Lonely", "");
 
-    assertFalse(query.hasChildren(note.getId()));
-  }
+        assertFalse(query.hasChildren(note.getId()));
+    }
 
-  @Test
-  @DisplayName("hasChildrenBatch() returns correct map")
-  void hasChildrenBatch_shouldReturnCorrectMap() {
-    Note parent = creator.createNote("Parent", "");
-    Note childless = creator.createNote("Childless", "");
-    creator.createChildNote(parent.getId(), "Child");
+    @Test
+    @DisplayName("hasChildrenBatch() returns correct map")
+    void hasChildrenBatch_shouldReturnCorrectMap() {
+        Note parent = creator.createNote("Parent", "");
+        Note childless = creator.createNote("Childless", "");
+        creator.createChildNote(parent.getId(), "Child");
 
-    Map<UUID, Boolean> result = query.hasChildrenBatch(
-        List.of(parent.getId(), childless.getId()));
+        Map<UUID, Boolean> result = query.hasChildrenBatch(
+                List.of(parent.getId(), childless.getId()));
 
-    assertTrue(result.get(parent.getId()));
-    assertFalse(result.get(childless.getId()));
-  }
+        assertTrue(result.get(parent.getId()));
+        assertFalse(result.get(childless.getId()));
+    }
 }

--- a/src/test/java/com/embervault/application/GetOutlineNavigationQueryTest.java
+++ b/src/test/java/com/embervault/application/GetOutlineNavigationQueryTest.java
@@ -1,0 +1,79 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.GetOutlineNavigationQuery;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GetOutlineNavigationQueryTest {
+
+  private GetOutlineNavigationQuery navQuery;
+  private CreateNoteUseCase creator;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryNoteRepository repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    navQuery = service;
+    creator = service;
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements GetOutlineNavigationQuery")
+  void noteServiceImpl_shouldImplementGetOutlineNavigationQuery() {
+    assertTrue(navQuery instanceof GetOutlineNavigationQuery);
+  }
+
+  @Test
+  @DisplayName("getPreviousInOutline() returns previous sibling")
+  void getPreviousInOutline_shouldReturnPreviousSibling() {
+    Note parent = creator.createNote("Parent", "");
+    Note child1 = creator.createChildNote(parent.getId(), "Child1");
+    Note child2 = creator.createChildNote(parent.getId(), "Child2");
+
+    Optional<Note> previous = navQuery.getPreviousInOutline(
+        child2.getId());
+
+    assertTrue(previous.isPresent());
+    assertEquals(child1.getId(), previous.get().getId());
+  }
+
+  @Test
+  @DisplayName("getPreviousInOutline() returns parent when first child")
+  void getPreviousInOutline_shouldReturnParent() {
+    Note parent = creator.createNote("Parent", "");
+    Note child = creator.createChildNote(parent.getId(), "Child");
+
+    Optional<Note> previous = navQuery.getPreviousInOutline(
+        child.getId());
+
+    assertTrue(previous.isPresent());
+    assertEquals(parent.getId(), previous.get().getId());
+  }
+
+  @Test
+  @DisplayName("getPreviousInOutline() returns empty for root note")
+  void getPreviousInOutline_shouldReturnEmptyForRoot() {
+    Note root = creator.createNote("Root", "");
+
+    assertTrue(navQuery.getPreviousInOutline(root.getId()).isEmpty());
+  }
+
+  @Test
+  @DisplayName("getPreviousInOutline() throws for missing note")
+  void getPreviousInOutline_shouldThrowForMissing() {
+    assertThrows(NoSuchElementException.class,
+        () -> navQuery.getPreviousInOutline(UUID.randomUUID()));
+  }
+}

--- a/src/test/java/com/embervault/application/GetOutlineNavigationQueryTest.java
+++ b/src/test/java/com/embervault/application/GetOutlineNavigationQueryTest.java
@@ -18,62 +18,68 @@ import org.junit.jupiter.api.Test;
 
 class GetOutlineNavigationQueryTest {
 
-  private GetOutlineNavigationQuery navQuery;
-  private CreateNoteUseCase creator;
+    private GetOutlineNavigationQuery navQuery;
+    private CreateNoteUseCase creator;
 
-  @BeforeEach
-  void setUp() {
-    InMemoryNoteRepository repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    navQuery = service;
-    creator = service;
-  }
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        navQuery = service;
+        creator = service;
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements GetOutlineNavigationQuery")
-  void noteServiceImpl_shouldImplementGetOutlineNavigationQuery() {
-    assertTrue(navQuery instanceof GetOutlineNavigationQuery);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements GetOutlineNavigationQuery")
+    void noteServiceImpl_shouldImplementGetOutlineNavigationQuery() {
+        assertTrue(
+                navQuery instanceof GetOutlineNavigationQuery);
+    }
 
-  @Test
-  @DisplayName("getPreviousInOutline() returns previous sibling")
-  void getPreviousInOutline_shouldReturnPreviousSibling() {
-    Note parent = creator.createNote("Parent", "");
-    Note child1 = creator.createChildNote(parent.getId(), "Child1");
-    Note child2 = creator.createChildNote(parent.getId(), "Child2");
+    @Test
+    @DisplayName("getPreviousInOutline() returns previous sibling")
+    void getPreviousInOutline_shouldReturnPreviousSibling() {
+        Note parent = creator.createNote("Parent", "");
+        Note child1 = creator.createChildNote(
+                parent.getId(), "Child1");
+        Note child2 = creator.createChildNote(
+                parent.getId(), "Child2");
 
-    Optional<Note> previous = navQuery.getPreviousInOutline(
-        child2.getId());
+        Optional<Note> previous = navQuery.getPreviousInOutline(
+                child2.getId());
 
-    assertTrue(previous.isPresent());
-    assertEquals(child1.getId(), previous.get().getId());
-  }
+        assertTrue(previous.isPresent());
+        assertEquals(child1.getId(), previous.get().getId());
+    }
 
-  @Test
-  @DisplayName("getPreviousInOutline() returns parent when first child")
-  void getPreviousInOutline_shouldReturnParent() {
-    Note parent = creator.createNote("Parent", "");
-    Note child = creator.createChildNote(parent.getId(), "Child");
+    @Test
+    @DisplayName("getPreviousInOutline() returns parent when first child")
+    void getPreviousInOutline_shouldReturnParent() {
+        Note parent = creator.createNote("Parent", "");
+        Note child = creator.createChildNote(
+                parent.getId(), "Child");
 
-    Optional<Note> previous = navQuery.getPreviousInOutline(
-        child.getId());
+        Optional<Note> previous = navQuery.getPreviousInOutline(
+                child.getId());
 
-    assertTrue(previous.isPresent());
-    assertEquals(parent.getId(), previous.get().getId());
-  }
+        assertTrue(previous.isPresent());
+        assertEquals(parent.getId(), previous.get().getId());
+    }
 
-  @Test
-  @DisplayName("getPreviousInOutline() returns empty for root note")
-  void getPreviousInOutline_shouldReturnEmptyForRoot() {
-    Note root = creator.createNote("Root", "");
+    @Test
+    @DisplayName("getPreviousInOutline() returns empty for root note")
+    void getPreviousInOutline_shouldReturnEmptyForRoot() {
+        Note root = creator.createNote("Root", "");
 
-    assertTrue(navQuery.getPreviousInOutline(root.getId()).isEmpty());
-  }
+        assertTrue(
+                navQuery.getPreviousInOutline(root.getId()).isEmpty());
+    }
 
-  @Test
-  @DisplayName("getPreviousInOutline() throws for missing note")
-  void getPreviousInOutline_shouldThrowForMissing() {
-    assertThrows(NoSuchElementException.class,
-        () -> navQuery.getPreviousInOutline(UUID.randomUUID()));
-  }
+    @Test
+    @DisplayName("getPreviousInOutline() throws for missing note")
+    void getPreviousInOutline_shouldThrowForMissing() {
+        assertThrows(NoSuchElementException.class,
+                () -> navQuery.getPreviousInOutline(
+                        UUID.randomUUID()));
+    }
 }

--- a/src/test/java/com/embervault/application/MoveNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/MoveNoteUseCaseTest.java
@@ -20,91 +20,92 @@ import org.junit.jupiter.api.Test;
 
 class MoveNoteUseCaseTest {
 
-  private MoveNoteUseCase moveUseCase;
-  private CreateNoteUseCase creator;
-  private GetNoteQuery query;
+    private MoveNoteUseCase moveUseCase;
+    private CreateNoteUseCase creator;
+    private GetNoteQuery query;
 
-  @BeforeEach
-  void setUp() {
-    InMemoryNoteRepository repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    moveUseCase = service;
-    creator = service;
-    query = service;
-  }
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        moveUseCase = service;
+        creator = service;
+        query = service;
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements MoveNoteUseCase")
-  void noteServiceImpl_shouldImplementMoveNoteUseCase() {
-    assertTrue(moveUseCase instanceof MoveNoteUseCase);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements MoveNoteUseCase")
+    void noteServiceImpl_shouldImplementMoveNoteUseCase() {
+        assertTrue(moveUseCase instanceof MoveNoteUseCase);
+    }
 
-  @Test
-  @DisplayName("moveNote() changes container to new parent")
-  void moveNote_shouldChangeContainer() {
-    Note parent1 = creator.createNote("Parent1", "");
-    Note parent2 = creator.createNote("Parent2", "");
-    Note child = creator.createChildNote(parent1.getId(), "Child");
+    @Test
+    @DisplayName("moveNote() changes container to new parent")
+    void moveNote_shouldChangeContainer() {
+        Note parent1 = creator.createNote("Parent1", "");
+        Note parent2 = creator.createNote("Parent2", "");
+        Note child = creator.createChildNote(parent1.getId(), "Child");
 
-    Note moved = moveUseCase.moveNote(child.getId(), parent2.getId());
+        Note moved = moveUseCase.moveNote(child.getId(), parent2.getId());
 
-    String container = ((AttributeValue.StringValue)
-        moved.getAttribute("$Container").orElseThrow()).value();
-    assertEquals(parent2.getId().toString(), container);
-  }
+        String container = ((AttributeValue.StringValue)
+                moved.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(parent2.getId().toString(), container);
+    }
 
-  @Test
-  @DisplayName("moveNoteToPosition() places note at correct position")
-  void moveNoteToPosition_shouldPlaceCorrectly() {
-    Note parent = creator.createNote("Parent", "");
-    creator.createChildNote(parent.getId(), "A");
-    creator.createChildNote(parent.getId(), "B");
-    Note parent2 = creator.createNote("Parent2", "");
-    Note child = creator.createChildNote(parent2.getId(), "C");
+    @Test
+    @DisplayName("moveNoteToPosition() places note at correct position")
+    void moveNoteToPosition_shouldPlaceCorrectly() {
+        Note parent = creator.createNote("Parent", "");
+        creator.createChildNote(parent.getId(), "A");
+        creator.createChildNote(parent.getId(), "B");
+        Note parent2 = creator.createNote("Parent2", "");
+        Note child = creator.createChildNote(parent2.getId(), "C");
 
-    moveUseCase.moveNoteToPosition(child.getId(), parent.getId(), 1);
+        moveUseCase.moveNoteToPosition(child.getId(), parent.getId(), 1);
 
-    List<Note> children = query.getChildren(parent.getId());
-    assertEquals(3, children.size());
-    assertEquals("A", children.get(0).getTitle());
-    assertEquals("C", children.get(1).getTitle());
-    assertEquals("B", children.get(2).getTitle());
-  }
+        List<Note> children = query.getChildren(parent.getId());
+        assertEquals(3, children.size());
+        assertEquals("A", children.get(0).getTitle());
+        assertEquals("C", children.get(1).getTitle());
+        assertEquals("B", children.get(2).getTitle());
+    }
 
-  @Test
-  @DisplayName("indentNote() makes note a child of the note above")
-  void indentNote_shouldMoveUnderNoteAbove() {
-    Note parent = creator.createNote("Parent", "");
-    Note child1 = creator.createChildNote(parent.getId(), "Child1");
-    Note child2 = creator.createChildNote(parent.getId(), "Child2");
+    @Test
+    @DisplayName("indentNote() makes note a child of the note above")
+    void indentNote_shouldMoveUnderNoteAbove() {
+        Note parent = creator.createNote("Parent", "");
+        Note child1 = creator.createChildNote(parent.getId(), "Child1");
+        Note child2 = creator.createChildNote(parent.getId(), "Child2");
 
-    Note indented = moveUseCase.indentNote(child2.getId());
+        Note indented = moveUseCase.indentNote(child2.getId());
 
-    String container = ((AttributeValue.StringValue)
-        indented.getAttribute("$Container").orElseThrow()).value();
-    assertEquals(child1.getId().toString(), container);
-  }
+        String container = ((AttributeValue.StringValue)
+                indented.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(child1.getId().toString(), container);
+    }
 
-  @Test
-  @DisplayName("outdentNote() moves note to be sibling of parent")
-  void outdentNote_shouldMoveToGrandparent() {
-    Note root = creator.createNote("Root", "");
-    Note parent = creator.createChildNote(root.getId(), "Parent");
-    Note child = creator.createChildNote(parent.getId(), "Child");
+    @Test
+    @DisplayName("outdentNote() moves note to be sibling of parent")
+    void outdentNote_shouldMoveToGrandparent() {
+        Note root = creator.createNote("Root", "");
+        Note parent = creator.createChildNote(root.getId(), "Parent");
+        Note child = creator.createChildNote(parent.getId(), "Child");
 
-    Note outdented = moveUseCase.outdentNote(child.getId());
+        Note outdented = moveUseCase.outdentNote(child.getId());
 
-    String container = ((AttributeValue.StringValue)
-        outdented.getAttribute("$Container").orElseThrow()).value();
-    assertEquals(root.getId().toString(), container);
-  }
+        String container = ((AttributeValue.StringValue)
+                outdented.getAttribute("$Container").orElseThrow()).value();
+        assertEquals(root.getId().toString(), container);
+    }
 
-  @Test
-  @DisplayName("moveNote() throws for missing note")
-  void moveNote_shouldThrowForMissing() {
-    Note parent = creator.createNote("Parent", "");
+    @Test
+    @DisplayName("moveNote() throws for missing note")
+    void moveNote_shouldThrowForMissing() {
+        Note parent = creator.createNote("Parent", "");
 
-    assertThrows(NoSuchElementException.class,
-        () -> moveUseCase.moveNote(UUID.randomUUID(), parent.getId()));
-  }
+        assertThrows(NoSuchElementException.class,
+                () -> moveUseCase.moveNote(UUID.randomUUID(),
+                        parent.getId()));
+    }
 }

--- a/src/test/java/com/embervault/application/MoveNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/MoveNoteUseCaseTest.java
@@ -1,0 +1,110 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.MoveNoteUseCase;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MoveNoteUseCaseTest {
+
+  private MoveNoteUseCase moveUseCase;
+  private CreateNoteUseCase creator;
+  private GetNoteQuery query;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryNoteRepository repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    moveUseCase = service;
+    creator = service;
+    query = service;
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements MoveNoteUseCase")
+  void noteServiceImpl_shouldImplementMoveNoteUseCase() {
+    assertTrue(moveUseCase instanceof MoveNoteUseCase);
+  }
+
+  @Test
+  @DisplayName("moveNote() changes container to new parent")
+  void moveNote_shouldChangeContainer() {
+    Note parent1 = creator.createNote("Parent1", "");
+    Note parent2 = creator.createNote("Parent2", "");
+    Note child = creator.createChildNote(parent1.getId(), "Child");
+
+    Note moved = moveUseCase.moveNote(child.getId(), parent2.getId());
+
+    String container = ((AttributeValue.StringValue)
+        moved.getAttribute("$Container").orElseThrow()).value();
+    assertEquals(parent2.getId().toString(), container);
+  }
+
+  @Test
+  @DisplayName("moveNoteToPosition() places note at correct position")
+  void moveNoteToPosition_shouldPlaceCorrectly() {
+    Note parent = creator.createNote("Parent", "");
+    creator.createChildNote(parent.getId(), "A");
+    creator.createChildNote(parent.getId(), "B");
+    Note parent2 = creator.createNote("Parent2", "");
+    Note child = creator.createChildNote(parent2.getId(), "C");
+
+    moveUseCase.moveNoteToPosition(child.getId(), parent.getId(), 1);
+
+    List<Note> children = query.getChildren(parent.getId());
+    assertEquals(3, children.size());
+    assertEquals("A", children.get(0).getTitle());
+    assertEquals("C", children.get(1).getTitle());
+    assertEquals("B", children.get(2).getTitle());
+  }
+
+  @Test
+  @DisplayName("indentNote() makes note a child of the note above")
+  void indentNote_shouldMoveUnderNoteAbove() {
+    Note parent = creator.createNote("Parent", "");
+    Note child1 = creator.createChildNote(parent.getId(), "Child1");
+    Note child2 = creator.createChildNote(parent.getId(), "Child2");
+
+    Note indented = moveUseCase.indentNote(child2.getId());
+
+    String container = ((AttributeValue.StringValue)
+        indented.getAttribute("$Container").orElseThrow()).value();
+    assertEquals(child1.getId().toString(), container);
+  }
+
+  @Test
+  @DisplayName("outdentNote() moves note to be sibling of parent")
+  void outdentNote_shouldMoveToGrandparent() {
+    Note root = creator.createNote("Root", "");
+    Note parent = creator.createChildNote(root.getId(), "Parent");
+    Note child = creator.createChildNote(parent.getId(), "Child");
+
+    Note outdented = moveUseCase.outdentNote(child.getId());
+
+    String container = ((AttributeValue.StringValue)
+        outdented.getAttribute("$Container").orElseThrow()).value();
+    assertEquals(root.getId().toString(), container);
+  }
+
+  @Test
+  @DisplayName("moveNote() throws for missing note")
+  void moveNote_shouldThrowForMissing() {
+    Note parent = creator.createNote("Parent", "");
+
+    assertThrows(NoSuchElementException.class,
+        () -> moveUseCase.moveNote(UUID.randomUUID(), parent.getId()));
+  }
+}

--- a/src/test/java/com/embervault/application/RenameNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/RenameNoteUseCaseTest.java
@@ -17,46 +17,46 @@ import org.junit.jupiter.api.Test;
 
 class RenameNoteUseCaseTest {
 
-  private RenameNoteUseCase renameUseCase;
-  private CreateNoteUseCase creator;
+    private RenameNoteUseCase renameUseCase;
+    private CreateNoteUseCase creator;
 
-  @BeforeEach
-  void setUp() {
-    InMemoryNoteRepository repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    renameUseCase = service;
-    creator = service;
-  }
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        renameUseCase = service;
+        creator = service;
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements RenameNoteUseCase")
-  void noteServiceImpl_shouldImplementRenameNoteUseCase() {
-    assertTrue(renameUseCase instanceof RenameNoteUseCase);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements RenameNoteUseCase")
+    void noteServiceImpl_shouldImplementRenameNoteUseCase() {
+        assertTrue(renameUseCase instanceof RenameNoteUseCase);
+    }
 
-  @Test
-  @DisplayName("renameNote() updates the note title")
-  void renameNote_shouldUpdateTitle() {
-    Note note = creator.createNote("Old Title", "Content");
+    @Test
+    @DisplayName("renameNote() updates the note title")
+    void renameNote_shouldUpdateTitle() {
+        Note note = creator.createNote("Old Title", "Content");
 
-    Note renamed = renameUseCase.renameNote(note.getId(), "New Title");
+        Note renamed = renameUseCase.renameNote(note.getId(), "New Title");
 
-    assertEquals("New Title", renamed.getTitle());
-  }
+        assertEquals("New Title", renamed.getTitle());
+    }
 
-  @Test
-  @DisplayName("renameNote() throws for missing note")
-  void renameNote_shouldThrowForMissing() {
-    assertThrows(NoSuchElementException.class,
-        () -> renameUseCase.renameNote(UUID.randomUUID(), "Title"));
-  }
+    @Test
+    @DisplayName("renameNote() throws for missing note")
+    void renameNote_shouldThrowForMissing() {
+        assertThrows(NoSuchElementException.class,
+                () -> renameUseCase.renameNote(UUID.randomUUID(), "Title"));
+    }
 
-  @Test
-  @DisplayName("renameNote() rejects blank title")
-  void renameNote_shouldRejectBlankTitle() {
-    Note note = creator.createNote("Title", "Content");
+    @Test
+    @DisplayName("renameNote() rejects blank title")
+    void renameNote_shouldRejectBlankTitle() {
+        Note note = creator.createNote("Title", "Content");
 
-    assertThrows(IllegalArgumentException.class,
-        () -> renameUseCase.renameNote(note.getId(), "   "));
-  }
+        assertThrows(IllegalArgumentException.class,
+                () -> renameUseCase.renameNote(note.getId(), "   "));
+    }
 }

--- a/src/test/java/com/embervault/application/RenameNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/RenameNoteUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.RenameNoteUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RenameNoteUseCaseTest {
+
+  private RenameNoteUseCase renameUseCase;
+  private CreateNoteUseCase creator;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryNoteRepository repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    renameUseCase = service;
+    creator = service;
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements RenameNoteUseCase")
+  void noteServiceImpl_shouldImplementRenameNoteUseCase() {
+    assertTrue(renameUseCase instanceof RenameNoteUseCase);
+  }
+
+  @Test
+  @DisplayName("renameNote() updates the note title")
+  void renameNote_shouldUpdateTitle() {
+    Note note = creator.createNote("Old Title", "Content");
+
+    Note renamed = renameUseCase.renameNote(note.getId(), "New Title");
+
+    assertEquals("New Title", renamed.getTitle());
+  }
+
+  @Test
+  @DisplayName("renameNote() throws for missing note")
+  void renameNote_shouldThrowForMissing() {
+    assertThrows(NoSuchElementException.class,
+        () -> renameUseCase.renameNote(UUID.randomUUID(), "Title"));
+  }
+
+  @Test
+  @DisplayName("renameNote() rejects blank title")
+  void renameNote_shouldRejectBlankTitle() {
+    Note note = creator.createNote("Title", "Content");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> renameUseCase.renameNote(note.getId(), "   "));
+  }
+}

--- a/src/test/java/com/embervault/application/SearchNotesQueryTest.java
+++ b/src/test/java/com/embervault/application/SearchNotesQueryTest.java
@@ -15,41 +15,41 @@ import org.junit.jupiter.api.Test;
 
 class SearchNotesQueryTest {
 
-  private SearchNotesQuery searchQuery;
-  private CreateNoteUseCase creator;
+    private SearchNotesQuery searchQuery;
+    private CreateNoteUseCase creator;
 
-  @BeforeEach
-  void setUp() {
-    InMemoryNoteRepository repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    searchQuery = service;
-    creator = service;
-  }
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        searchQuery = service;
+        creator = service;
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements SearchNotesQuery")
-  void noteServiceImpl_shouldImplementSearchNotesQuery() {
-    assertTrue(searchQuery instanceof SearchNotesQuery);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements SearchNotesQuery")
+    void noteServiceImpl_shouldImplementSearchNotesQuery() {
+        assertTrue(searchQuery instanceof SearchNotesQuery);
+    }
 
-  @Test
-  @DisplayName("searchNotes() finds notes by title")
-  void searchNotes_shouldFindByTitle() {
-    creator.createNote("Alpha", "content");
-    creator.createNote("Beta", "content");
+    @Test
+    @DisplayName("searchNotes() finds notes by title")
+    void searchNotes_shouldFindByTitle() {
+        creator.createNote("Alpha", "content");
+        creator.createNote("Beta", "content");
 
-    List<Note> results = searchQuery.searchNotes("Alpha");
+        List<Note> results = searchQuery.searchNotes("Alpha");
 
-    assertEquals(1, results.size());
-    assertEquals("Alpha", results.get(0).getTitle());
-  }
+        assertEquals(1, results.size());
+        assertEquals("Alpha", results.get(0).getTitle());
+    }
 
-  @Test
-  @DisplayName("searchNotes() returns empty for blank query")
-  void searchNotes_shouldReturnEmptyForBlank() {
-    creator.createNote("Note", "content");
+    @Test
+    @DisplayName("searchNotes() returns empty for blank query")
+    void searchNotes_shouldReturnEmptyForBlank() {
+        creator.createNote("Note", "content");
 
-    assertTrue(searchQuery.searchNotes("").isEmpty());
-    assertTrue(searchQuery.searchNotes(null).isEmpty());
-  }
+        assertTrue(searchQuery.searchNotes("").isEmpty());
+        assertTrue(searchQuery.searchNotes(null).isEmpty());
+    }
 }

--- a/src/test/java/com/embervault/application/SearchNotesQueryTest.java
+++ b/src/test/java/com/embervault/application/SearchNotesQueryTest.java
@@ -1,0 +1,55 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.SearchNotesQuery;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SearchNotesQueryTest {
+
+  private SearchNotesQuery searchQuery;
+  private CreateNoteUseCase creator;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryNoteRepository repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    searchQuery = service;
+    creator = service;
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements SearchNotesQuery")
+  void noteServiceImpl_shouldImplementSearchNotesQuery() {
+    assertTrue(searchQuery instanceof SearchNotesQuery);
+  }
+
+  @Test
+  @DisplayName("searchNotes() finds notes by title")
+  void searchNotes_shouldFindByTitle() {
+    creator.createNote("Alpha", "content");
+    creator.createNote("Beta", "content");
+
+    List<Note> results = searchQuery.searchNotes("Alpha");
+
+    assertEquals(1, results.size());
+    assertEquals("Alpha", results.get(0).getTitle());
+  }
+
+  @Test
+  @DisplayName("searchNotes() returns empty for blank query")
+  void searchNotes_shouldReturnEmptyForBlank() {
+    creator.createNote("Note", "content");
+
+    assertTrue(searchQuery.searchNotes("").isEmpty());
+    assertTrue(searchQuery.searchNotes(null).isEmpty());
+  }
+}

--- a/src/test/java/com/embervault/application/UpdateNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/UpdateNoteUseCaseTest.java
@@ -17,40 +17,40 @@ import org.junit.jupiter.api.Test;
 
 class UpdateNoteUseCaseTest {
 
-  private UpdateNoteUseCase updateUseCase;
-  private CreateNoteUseCase creator;
+    private UpdateNoteUseCase updateUseCase;
+    private CreateNoteUseCase creator;
 
-  @BeforeEach
-  void setUp() {
-    InMemoryNoteRepository repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    updateUseCase = service;
-    creator = service;
-  }
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        updateUseCase = service;
+        creator = service;
+    }
 
-  @Test
-  @DisplayName("NoteServiceImpl implements UpdateNoteUseCase")
-  void noteServiceImpl_shouldImplementUpdateNoteUseCase() {
-    assertTrue(updateUseCase instanceof UpdateNoteUseCase);
-  }
+    @Test
+    @DisplayName("NoteServiceImpl implements UpdateNoteUseCase")
+    void noteServiceImpl_shouldImplementUpdateNoteUseCase() {
+        assertTrue(updateUseCase instanceof UpdateNoteUseCase);
+    }
 
-  @Test
-  @DisplayName("updateNote() updates title and content")
-  void updateNote_shouldModifyNote() {
-    Note created = creator.createNote("Old", "Old");
+    @Test
+    @DisplayName("updateNote() updates title and content")
+    void updateNote_shouldModifyNote() {
+        Note created = creator.createNote("Old", "Old");
 
-    Note updated = updateUseCase.updateNote(
-        created.getId(), "New", "New");
+        Note updated = updateUseCase.updateNote(
+                created.getId(), "New", "New");
 
-    assertEquals("New", updated.getTitle());
-    assertEquals("New", updated.getContent());
-  }
+        assertEquals("New", updated.getTitle());
+        assertEquals("New", updated.getContent());
+    }
 
-  @Test
-  @DisplayName("updateNote() throws for missing note")
-  void updateNote_shouldThrowForMissing() {
-    assertThrows(NoSuchElementException.class,
-        () -> updateUseCase.updateNote(
-            UUID.randomUUID(), "T", "C"));
-  }
+    @Test
+    @DisplayName("updateNote() throws for missing note")
+    void updateNote_shouldThrowForMissing() {
+        assertThrows(NoSuchElementException.class,
+                () -> updateUseCase.updateNote(
+                        UUID.randomUUID(), "T", "C"));
+    }
 }

--- a/src/test/java/com/embervault/application/UpdateNoteUseCaseTest.java
+++ b/src/test/java/com/embervault/application/UpdateNoteUseCaseTest.java
@@ -1,0 +1,56 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.UpdateNoteUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UpdateNoteUseCaseTest {
+
+  private UpdateNoteUseCase updateUseCase;
+  private CreateNoteUseCase creator;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryNoteRepository repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    updateUseCase = service;
+    creator = service;
+  }
+
+  @Test
+  @DisplayName("NoteServiceImpl implements UpdateNoteUseCase")
+  void noteServiceImpl_shouldImplementUpdateNoteUseCase() {
+    assertTrue(updateUseCase instanceof UpdateNoteUseCase);
+  }
+
+  @Test
+  @DisplayName("updateNote() updates title and content")
+  void updateNote_shouldModifyNote() {
+    Note created = creator.createNote("Old", "Old");
+
+    Note updated = updateUseCase.updateNote(
+        created.getId(), "New", "New");
+
+    assertEquals("New", updated.getTitle());
+    assertEquals("New", updated.getContent());
+  }
+
+  @Test
+  @DisplayName("updateNote() throws for missing note")
+  void updateNote_shouldThrowForMissing() {
+    assertThrows(NoSuchElementException.class,
+        () -> updateUseCase.updateNote(
+            UUID.randomUUID(), "T", "C"));
+  }
+}


### PR DESCRIPTION
## Summary
- Extract 8 focused use case interfaces from the monolithic `NoteService` (~17 methods): `CreateNoteUseCase`, `GetNoteQuery`, `DeleteNoteUseCase`, `RenameNoteUseCase`, `MoveNoteUseCase`, `UpdateNoteUseCase`, `SearchNotesQuery`, `GetOutlineNavigationQuery`
- Refactor `NoteService` to extend all new interfaces, eliminating duplicate method declarations while maintaining full backward compatibility
- `NoteServiceImpl` continues to implement `NoteService` (which now inherits all use case interfaces), so existing consumers require zero changes
- Each interface has its own dedicated test class verifying the contract through `NoteServiceImpl`

## Test plan
- [ ] All 8 new use case test classes pass (`CreateNoteUseCaseTest`, `GetNoteQueryTest`, `DeleteNoteUseCaseTest`, `RenameNoteUseCaseTest`, `MoveNoteUseCaseTest`, `UpdateNoteUseCaseTest`, `SearchNotesQueryTest`, `GetOutlineNavigationQueryTest`)
- [ ] All existing `NoteServiceImplTest` and `NoteServiceEdgeCaseTest` tests pass unchanged
- [ ] ArchUnit tests pass (new interfaces are in `application.port.in` and are interfaces)
- [ ] Checkstyle passes
- [ ] JaCoCo coverage thresholds met
- [ ] Full `./mvnw verify` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>