### PR TITLE
Use ViewType enum in ViewRefreshedEvent

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ViewRefreshedEvent.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ViewRefreshedEvent.java
@@ -1,12 +1,14 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import com.embervault.ViewType;
+
 /**
  * Event published when a view is refreshed.
  *
  * <p>Allows other components to react to view refresh events without
  * direct coupling to the view that was refreshed.</p>
  *
- * @param viewTypeName the display name of the refreshed view type
+ * @param viewType the type of the refreshed view
  */
-public record ViewRefreshedEvent(String viewTypeName) {
+public record ViewRefreshedEvent(ViewType viewType) {
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTypedEventsTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/EventBusTypedEventsTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.embervault.ViewType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,15 +38,15 @@ class EventBusTypedEventsTest {
     }
 
     @Test
-    @DisplayName("ViewRefreshedEvent carries view type name through EventBus")
+    @DisplayName("ViewRefreshedEvent carries view type through EventBus")
     void viewRefreshedEvent_carriesViewType() {
-        List<String> refreshedViews = new ArrayList<>();
+        List<ViewType> refreshedViews = new ArrayList<>();
         eventBus.subscribe(ViewRefreshedEvent.class,
-                e -> refreshedViews.add(e.viewTypeName()));
+                e -> refreshedViews.add(e.viewType()));
 
-        eventBus.publish(new ViewRefreshedEvent("Map"));
+        eventBus.publish(new ViewRefreshedEvent(ViewType.MAP));
 
-        assertEquals(List.of("Map"), refreshedViews);
+        assertEquals(List.of(ViewType.MAP), refreshedViews);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace `String viewTypeName` with `ViewType viewType` in `ViewRefreshedEvent` record
- The existing `ViewType` enum provides type safety and prevents typos vs raw strings
- Found during /simplify code quality review of PRs #241, #242, #243

## Test plan
- [x] `EventBusTypedEventsTest` updated to use `ViewType.MAP` instead of `"Map"`
- [x] `mvn verify` passes (tests, checkstyle, JaCoCo, ArchUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)