### PR TITLE
Add arrow key navigation for Outline view selection (#257)

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -109,6 +109,9 @@ public class OutlineViewController {
     }
 
     void handleTreeKeyFilter(KeyEvent event) {
+        if (event.getCode().isArrowKey()) {
+            return; // preserve TreeView navigation
+        }
         if (event.getCode() == KeyCode.ENTER
                 && !isAnyoneEditing()) {
             TreeItem<NoteDisplayItem> selected =
@@ -184,14 +187,10 @@ public class OutlineViewController {
     }
 
     private void createChildUnderSelected() {
-        TreeItem<NoteDisplayItem> selected = outlineTreeView.getSelectionModel()
-                .getSelectedItem();
-        UUID parentId;
-        if (selected != null && selected.getValue() != null) {
-            parentId = selected.getValue().getId();
-        } else {
-            parentId = viewModel.getBaseNoteId();
-        }
+        TreeItem<NoteDisplayItem> selected =
+                outlineTreeView.getSelectionModel().getSelectedItem();
+        UUID parentId = (selected != null && selected.getValue() != null)
+                ? selected.getValue().getId() : viewModel.getBaseNoteId();
         if (parentId != null) {
             viewModel.createChildNote(parentId, "Untitled");
         }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -603,4 +603,76 @@ class OutlineViewModelTest {
         NoteDisplayItem item = viewModel.getRootItems().get(0);
         assertEquals("", item.getBadge());
     }
+
+    // --- Sequential selection tests (arrow key navigation) ---
+
+    @Test
+    @DisplayName("sequential selectNote() calls update selectedNoteId correctly")
+    void selectNote_sequential_shouldUpdateSelectedNoteId() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child1 = noteService.createChildNote(parent.getId(), "Child1");
+        Note child2 = noteService.createChildNote(parent.getId(), "Child2");
+        Note child3 = noteService.createChildNote(parent.getId(), "Child3");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        // Simulate arrow-down navigation through items
+        viewModel.selectNote(child1.getId());
+        assertEquals(child1.getId(), viewModel.selectedNoteIdProperty().get());
+
+        viewModel.selectNote(child2.getId());
+        assertEquals(child2.getId(), viewModel.selectedNoteIdProperty().get());
+
+        viewModel.selectNote(child3.getId());
+        assertEquals(child3.getId(), viewModel.selectedNoteIdProperty().get());
+
+        // Simulate arrow-up navigation back
+        viewModel.selectNote(child2.getId());
+        assertEquals(child2.getId(), viewModel.selectedNoteIdProperty().get());
+
+        viewModel.selectNote(child1.getId());
+        assertEquals(child1.getId(), viewModel.selectedNoteIdProperty().get());
+    }
+
+    @Test
+    @DisplayName("selectNote() fires property change for each sequential selection")
+    void selectNote_sequential_shouldFirePropertyChange() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child1 = noteService.createChildNote(parent.getId(), "Child1");
+        Note child2 = noteService.createChildNote(parent.getId(), "Child2");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        java.util.List<UUID> observedIds = new java.util.ArrayList<>();
+        viewModel.selectedNoteIdProperty().addListener(
+                (obs, oldVal, newVal) -> observedIds.add(newVal));
+
+        viewModel.selectNote(child1.getId());
+        viewModel.selectNote(child2.getId());
+        viewModel.selectNote(child1.getId());
+
+        assertEquals(3, observedIds.size());
+        assertEquals(child1.getId(), observedIds.get(0));
+        assertEquals(child2.getId(), observedIds.get(1));
+        assertEquals(child1.getId(), observedIds.get(2));
+    }
+
+    @Test
+    @DisplayName("selectNote() with same id twice does not fire duplicate change")
+    void selectNote_sameIdTwice_shouldNotFireDuplicateChange() {
+        Note parent = noteService.createNote("Parent", "");
+        Note child1 = noteService.createChildNote(parent.getId(), "Child1");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        java.util.List<UUID> observedIds = new java.util.ArrayList<>();
+        viewModel.selectedNoteIdProperty().addListener(
+                (obs, oldVal, newVal) -> observedIds.add(newVal));
+
+        viewModel.selectNote(child1.getId());
+        viewModel.selectNote(child1.getId());
+
+        // JavaFX property only fires when value actually changes
+        assertEquals(1, observedIds.size());
+    }
 }


### PR DESCRIPTION
## Summary
- Added explicit arrow key pass-through guard in `OutlineViewController.handleTreeKeyFilter()` to ensure TreeView's built-in Up/Down/Left/Right navigation is never accidentally consumed by the event filter
- Added ViewModel-level tests verifying sequential `selectNote()` calls correctly update `selectedNoteIdProperty` (simulating arrow key navigation patterns)
- Added test verifying property change notifications fire for each sequential selection change
- Added test verifying duplicate same-id selections do not fire spurious change events

## Investigation findings
- Arrow keys were already working: the event filter only consumed ENTER and TAB events
- The TreeView selection listener already propagated selection changes to `viewModel.selectNote()`
- The explicit guard prevents future regressions if new key handlers are added to the filter

## Test plan
- [x] Sequential selection tests pass (`OutlineViewModelTest`)
- [x] Property change notification test passes
- [x] Duplicate selection suppression test passes
- [x] Full `mvn verify` passes (checkstyle, JaCoCo, ArchUnit)
- [ ] Manual verification: arrow keys navigate items in Outline view and update text pane

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)