### PR TITLE
Add undo/redo command history (#262)

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -66,6 +66,7 @@ public class App extends Application {
                 setup.paneDeps().noteService(),
                 setup.paneDeps().noteService(),
                 setup.appState(), setup.eventBus());
+        outlineViewModel.setCommandHistory(commandHistory);
         outlineViewModel.setBaseNoteId(project.getRootNote().getId());
         var paneHolder = new ViewPaneContext[1];
         Parent outlineView = loadView("OutlineView.fxml", c -> {

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -132,7 +132,7 @@ public class App extends Application {
                 sharedServices, windowManager,
                 outlineViewModel.selectedNoteIdProperty(),
                 setup.appState(), stage,
-                searchViewModel::toggleVisible,
+                searchViewModel::toggleVisible, null,
                 newRootId -> {
                     outlineViewModel.setBaseNoteId(newRootId);
                     outlineViewModel.loadNotes();

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -56,7 +56,7 @@ public class App extends Application {
         CommandHistory commandHistory = new CommandHistory();
         SelectedNoteViewModel selectedNoteVm = setup.selectedNoteVm();
 
-        // Single Outline view
+        // Outline view (declared before commandHistory callback)
         OutlineViewModel outlineViewModel = new OutlineViewModel(
                 setup.rootNoteTitle(),
                 setup.paneDeps().noteService(),
@@ -67,6 +67,11 @@ public class App extends Application {
                 setup.paneDeps().noteService(),
                 setup.appState(), setup.eventBus());
         outlineViewModel.setCommandHistory(commandHistory);
+        commandHistory.setOnChanged(() -> {
+            outlineViewModel.loadNotes();
+            selectedNoteVm.setSelectedNoteId(
+                    selectedNoteVm.selectedNoteIdProperty().get());
+        });
         outlineViewModel.setBaseNoteId(project.getRootNote().getId());
         var paneHolder = new ViewPaneContext[1];
         Parent outlineView = loadView("OutlineView.fxml", c -> {

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -13,6 +13,7 @@ import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.adapter.in.ui.viewmodel.ShortcutRegistry;
+import com.embervault.application.CommandHistory;
 import com.embervault.application.port.in.StampService;
 import com.embervault.domain.Attributes;
 import com.embervault.domain.Project;
@@ -52,6 +53,7 @@ public class App extends Application {
                 sharedServices, windowManager);
         WindowSetupResult setup = WindowBuilder.build(setupCtx);
         new AppStateEventBridge(setup.eventBus(), setup.appState());
+        CommandHistory commandHistory = new CommandHistory();
         SelectedNoteViewModel selectedNoteVm = setup.selectedNoteVm();
 
         // Single Outline view
@@ -135,7 +137,7 @@ public class App extends Application {
                 sharedServices, windowManager,
                 outlineViewModel.selectedNoteIdProperty(),
                 setup.appState(), stage,
-                searchViewModel::toggleVisible, null,
+                searchViewModel::toggleVisible, commandHistory,
                 newRootId -> {
                     outlineViewModel.setBaseNoteId(newRootId);
                     outlineViewModel.loadNotes();

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -215,8 +215,20 @@ final class MenuBarFactory {
                         KeyCombination.SHIFT_DOWN));
         if (ctx.commandHistory() != null) {
             var history = ctx.commandHistory();
-            undoItem.setOnAction(e -> history.undo());
-            redoItem.setOnAction(e -> history.redo());
+            undoItem.setOnAction(e -> {
+                try {
+                    history.undo();
+                } catch (Exception ex) {
+                    LOG.warn("Undo failed", ex);
+                }
+            });
+            redoItem.setOnAction(e -> {
+                try {
+                    history.redo();
+                } catch (Exception ex) {
+                    LOG.warn("Redo failed", ex);
+                }
+            });
         }
 
         MenuItem findItem = new MenuItem("Find");

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -218,10 +218,12 @@ final class MenuBarFactory {
             undoItem.setOnAction(e -> {
                 history.undo();
                 ctx.appState().notifyDataChanged();
+                ctx.windowManager().notifyAllWindows();
             });
             redoItem.setOnAction(e -> {
                 history.redo();
                 ctx.appState().notifyDataChanged();
+                ctx.windowManager().notifyAllWindows();
             });
         }
         undoItem.setDisable(true);

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -135,8 +135,6 @@ final class MenuBarFactory {
                         KeyCombination.SHIFT_DOWN));
         if (ctx.commandHistory() != null) {
             var history = ctx.commandHistory();
-            undoItem.setDisable(!history.canUndo());
-            redoItem.setDisable(!history.canRedo());
             undoItem.setOnAction(e -> {
                 history.undo();
                 ctx.appState().notifyDataChanged();
@@ -145,10 +143,9 @@ final class MenuBarFactory {
                 history.redo();
                 ctx.appState().notifyDataChanged();
             });
-        } else {
-            undoItem.setDisable(true);
-            redoItem.setDisable(true);
         }
+        undoItem.setDisable(true);
+        redoItem.setDisable(true);
 
         MenuItem findItem = new MenuItem("Find");
         findItem.setAccelerator(
@@ -162,6 +159,13 @@ final class MenuBarFactory {
         Menu menu = new Menu("Edit");
         menu.getItems().addAll(undoItem, redoItem,
                 new SeparatorMenuItem(), findItem);
+        if (ctx.commandHistory() != null) {
+            var history = ctx.commandHistory();
+            menu.setOnShowing(e -> {
+                undoItem.setDisable(!history.canUndo());
+                redoItem.setDisable(!history.canRedo());
+            });
+        }
         return menu;
     }
 

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -215,20 +215,8 @@ final class MenuBarFactory {
                         KeyCombination.SHIFT_DOWN));
         if (ctx.commandHistory() != null) {
             var history = ctx.commandHistory();
-            undoItem.setOnAction(e -> {
-                if (history.canUndo()) {
-                    history.undo();
-                    ctx.appState().notifyDataChanged();
-                    ctx.windowManager().notifyAllWindows();
-                }
-            });
-            redoItem.setOnAction(e -> {
-                if (history.canRedo()) {
-                    history.redo();
-                    ctx.appState().notifyDataChanged();
-                    ctx.windowManager().notifyAllWindows();
-                }
-            });
+            undoItem.setOnAction(e -> history.undo());
+            redoItem.setOnAction(e -> history.redo());
         }
 
         MenuItem findItem = new MenuItem("Find");

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -216,18 +216,20 @@ final class MenuBarFactory {
         if (ctx.commandHistory() != null) {
             var history = ctx.commandHistory();
             undoItem.setOnAction(e -> {
-                history.undo();
-                ctx.appState().notifyDataChanged();
-                ctx.windowManager().notifyAllWindows();
+                if (history.canUndo()) {
+                    history.undo();
+                    ctx.appState().notifyDataChanged();
+                    ctx.windowManager().notifyAllWindows();
+                }
             });
             redoItem.setOnAction(e -> {
-                history.redo();
-                ctx.appState().notifyDataChanged();
-                ctx.windowManager().notifyAllWindows();
+                if (history.canRedo()) {
+                    history.redo();
+                    ctx.appState().notifyDataChanged();
+                    ctx.windowManager().notifyAllWindows();
+                }
             });
         }
-        undoItem.setDisable(true);
-        redoItem.setDisable(true);
 
         MenuItem findItem = new MenuItem("Find");
         findItem.setAccelerator(
@@ -241,13 +243,6 @@ final class MenuBarFactory {
         Menu menu = new Menu("Edit");
         menu.getItems().addAll(undoItem, redoItem,
                 new SeparatorMenuItem(), findItem);
-        if (ctx.commandHistory() != null) {
-            var history = ctx.commandHistory();
-            menu.setOnShowing(e -> {
-                undoItem.setDisable(!history.canUndo());
-                redoItem.setDisable(!history.canRedo());
-            });
-        }
         return menu;
     }
 

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -124,6 +124,32 @@ final class MenuBarFactory {
     }
 
     private static Menu buildEditMenu(WindowContext ctx) {
+        MenuItem undoItem = new MenuItem("Undo");
+        undoItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.Z,
+                        KeyCombination.SHORTCUT_DOWN));
+        MenuItem redoItem = new MenuItem("Redo");
+        redoItem.setAccelerator(
+                new KeyCodeCombination(KeyCode.Z,
+                        KeyCombination.SHORTCUT_DOWN,
+                        KeyCombination.SHIFT_DOWN));
+        if (ctx.commandHistory() != null) {
+            var history = ctx.commandHistory();
+            undoItem.setDisable(!history.canUndo());
+            redoItem.setDisable(!history.canRedo());
+            undoItem.setOnAction(e -> {
+                history.undo();
+                ctx.appState().notifyDataChanged();
+            });
+            redoItem.setOnAction(e -> {
+                history.redo();
+                ctx.appState().notifyDataChanged();
+            });
+        } else {
+            undoItem.setDisable(true);
+            redoItem.setDisable(true);
+        }
+
         MenuItem findItem = new MenuItem("Find");
         findItem.setAccelerator(
                 new KeyCodeCombination(KeyCode.F,
@@ -134,7 +160,8 @@ final class MenuBarFactory {
             }
         });
         Menu menu = new Menu("Edit");
-        menu.getItems().add(findItem);
+        menu.getItems().addAll(undoItem, redoItem,
+                new SeparatorMenuItem(), findItem);
         return menu;
     }
 

--- a/src/main/java/com/embervault/WindowContext.java
+++ b/src/main/java/com/embervault/WindowContext.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import com.embervault.adapter.in.ui.viewmodel.AppState;
+import com.embervault.application.CommandHistory;
 import javafx.beans.property.ObjectProperty;
 import javafx.stage.Stage;
 
@@ -17,9 +18,11 @@ import javafx.stage.Stage;
  * @param sharedServices shared singleton services
  * @param windowManager  the application window manager
  * @param selectedNoteId this window's selected note id property
- * @param appState       the shared application state for data-change notification
+ * @param appState       the shared application state for
+ *                       data-change notification
  * @param ownerStage     this window's stage (for modal dialogs)
  * @param onFind         callback for Edit &gt; Find, or null
+ * @param commandHistory the undo/redo command history, or null
  * @param onBaseNoteChanged callback when loaded project changes
  *                          root note, or null
  */
@@ -30,5 +33,6 @@ public record WindowContext(
         AppState appState,
         Stage ownerStage,
         Runnable onFind,
+        CommandHistory commandHistory,
         Consumer<UUID> onBaseNoteChanged) {
 }

--- a/src/main/java/com/embervault/WindowFactory.java
+++ b/src/main/java/com/embervault/WindowFactory.java
@@ -105,7 +105,7 @@ public final class WindowFactory {
         WindowContext winCtx = new WindowContext(
                 services, windowManager,
                 mapVm.selectedNoteIdProperty(),
-                setup.appState(), newStage, null,
+                setup.appState(), newStage, null, null,
                 newRootId -> {
                     mapVm.setBaseNoteId(newRootId);
                     mapVm.loadNotes();

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -47,6 +47,7 @@ public final class OutlineViewModel {
     private final StringProperty rootNoteTitle;
     private final AppState appState;
     private final EventBus eventBus;
+    private com.embervault.application.CommandHistory commandHistory;
 
     /**
      * Constructs an OutlineViewModel that derives its tab title from
@@ -100,6 +101,16 @@ public final class OutlineViewModel {
                 updateTabTitle(newVal);
             }
         });
+    }
+
+    /**
+     * Sets an optional command history for undo/redo support.
+     *
+     * @param history the command history, or null to disable
+     */
+    public void setCommandHistory(
+            com.embervault.application.CommandHistory history) {
+        this.commandHistory = history;
     }
 
     /** Returns the tab title property. */
@@ -240,7 +251,14 @@ public final class OutlineViewModel {
         if (newTitle == null || newTitle.isBlank()) {
             return false;
         }
-        renameNoteUseCase.renameNote(noteId, newTitle);
+        if (commandHistory != null) {
+            commandHistory.execute(
+                    new com.embervault.application.RenameNoteCommand(
+                            renameNoteUseCase, getNoteQuery,
+                            noteId, newTitle));
+        } else {
+            renameNoteUseCase.renameNote(noteId, newTitle);
+        }
         for (int i = 0; i < rootItems.size(); i++) {
             NoteDisplayItem item = rootItems.get(i);
             if (item.getId().equals(noteId)) {

--- a/src/main/java/com/embervault/application/CommandHistory.java
+++ b/src/main/java/com/embervault/application/CommandHistory.java
@@ -12,7 +12,8 @@ import com.embervault.application.port.in.Command;
  * redo stack is cleared. Undoing pops from the undo stack and pushes onto
  * redo; redoing does the reverse.</p>
  */
-public class CommandHistory {
+public class CommandHistory implements
+        com.embervault.application.port.in.UndoRedoUseCase {
 
     private final Deque<Command> undoStack = new ArrayDeque<>();
     private final Deque<Command> redoStack = new ArrayDeque<>();

--- a/src/main/java/com/embervault/application/CommandHistory.java
+++ b/src/main/java/com/embervault/application/CommandHistory.java
@@ -27,4 +27,50 @@ public class CommandHistory {
         undoStack.push(command);
         redoStack.clear();
     }
+
+    /**
+     * Undoes the most recently executed command.
+     *
+     * <p>If the undo stack is empty, this method does nothing.</p>
+     */
+    public void undo() {
+        if (undoStack.isEmpty()) {
+            return;
+        }
+        Command command = undoStack.pop();
+        command.undo();
+        redoStack.push(command);
+    }
+
+    /**
+     * Re-applies the most recently undone command.
+     *
+     * <p>If the redo stack is empty, this method does nothing.</p>
+     */
+    public void redo() {
+        if (redoStack.isEmpty()) {
+            return;
+        }
+        Command command = redoStack.pop();
+        command.execute();
+        undoStack.push(command);
+    }
+
+    /**
+     * Returns whether there are commands that can be undone.
+     *
+     * @return true if the undo stack is not empty
+     */
+    public boolean canUndo() {
+        return !undoStack.isEmpty();
+    }
+
+    /**
+     * Returns whether there are commands that can be redone.
+     *
+     * @return true if the redo stack is not empty
+     */
+    public boolean canRedo() {
+        return !redoStack.isEmpty();
+    }
 }

--- a/src/main/java/com/embervault/application/CommandHistory.java
+++ b/src/main/java/com/embervault/application/CommandHistory.java
@@ -1,0 +1,30 @@
+package com.embervault.application;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import com.embervault.application.port.in.Command;
+
+/**
+ * Maintains undo and redo stacks for reversible commands.
+ *
+ * <p>When a command is executed, it is pushed onto the undo stack and the
+ * redo stack is cleared. Undoing pops from the undo stack and pushes onto
+ * redo; redoing does the reverse.</p>
+ */
+public class CommandHistory {
+
+    private final Deque<Command> undoStack = new ArrayDeque<>();
+    private final Deque<Command> redoStack = new ArrayDeque<>();
+
+    /**
+     * Executes the given command and records it for undo.
+     *
+     * @param command the command to execute
+     */
+    public void execute(Command command) {
+        command.execute();
+        undoStack.push(command);
+        redoStack.clear();
+    }
+}

--- a/src/main/java/com/embervault/application/CommandHistory.java
+++ b/src/main/java/com/embervault/application/CommandHistory.java
@@ -17,6 +17,16 @@ public class CommandHistory implements
 
     private final Deque<Command> undoStack = new ArrayDeque<>();
     private final Deque<Command> redoStack = new ArrayDeque<>();
+    private Runnable onChanged;
+
+    /**
+     * Sets a callback invoked after any execute, undo, or redo.
+     *
+     * @param callback the callback, or null to clear
+     */
+    public void setOnChanged(Runnable callback) {
+        this.onChanged = callback;
+    }
 
     /**
      * Executes the given command and records it for undo.
@@ -27,6 +37,7 @@ public class CommandHistory implements
         command.execute();
         undoStack.push(command);
         redoStack.clear();
+        fireChanged();
     }
 
     /**
@@ -41,6 +52,7 @@ public class CommandHistory implements
         Command command = undoStack.pop();
         command.undo();
         redoStack.push(command);
+        fireChanged();
     }
 
     /**
@@ -55,6 +67,13 @@ public class CommandHistory implements
         Command command = redoStack.pop();
         command.execute();
         undoStack.push(command);
+        fireChanged();
+    }
+
+    private void fireChanged() {
+        if (onChanged != null) {
+            onChanged.run();
+        }
     }
 
     /**

--- a/src/main/java/com/embervault/application/MoveNoteCommand.java
+++ b/src/main/java/com/embervault/application/MoveNoteCommand.java
@@ -1,0 +1,62 @@
+package com.embervault.application;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.Command;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.MoveNoteUseCase;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+
+/**
+ * Command that moves a note to a new parent, capturing the previous
+ * parent for undo.
+ */
+public final class MoveNoteCommand implements Command {
+
+    private final MoveNoteUseCase moveUseCase;
+    private final GetNoteQuery getNoteQuery;
+    private final UUID noteId;
+    private final UUID newParentId;
+    private UUID previousParentId;
+
+    /**
+     * Creates a move command.
+     *
+     * @param moveUseCase  the use case for moving notes
+     * @param getNoteQuery the query for reading the current parent
+     * @param noteId       the note to move
+     * @param newParentId  the target parent
+     */
+    public MoveNoteCommand(MoveNoteUseCase moveUseCase,
+            GetNoteQuery getNoteQuery, UUID noteId, UUID newParentId) {
+        this.moveUseCase = Objects.requireNonNull(moveUseCase);
+        this.getNoteQuery = Objects.requireNonNull(getNoteQuery);
+        this.noteId = Objects.requireNonNull(noteId);
+        this.newParentId = Objects.requireNonNull(newParentId);
+    }
+
+    @Override
+    public void execute() {
+        Note note = getNoteQuery.getNote(noteId).orElseThrow();
+        note.getAttribute(Attributes.CONTAINER)
+                .map(v -> ((AttributeValue.StringValue) v).value())
+                .map(UUID::fromString)
+                .ifPresent(id -> previousParentId = id);
+        moveUseCase.moveNote(noteId, newParentId);
+    }
+
+    @Override
+    public void undo() {
+        if (previousParentId != null) {
+            moveUseCase.moveNote(noteId, previousParentId);
+        }
+    }
+
+    @Override
+    public String description() {
+        return "Move note";
+    }
+}

--- a/src/main/java/com/embervault/application/RenameNoteCommand.java
+++ b/src/main/java/com/embervault/application/RenameNoteCommand.java
@@ -44,7 +44,10 @@ public final class RenameNoteCommand implements Command {
 
     @Override
     public void undo() {
-        renameUseCase.renameNote(noteId, previousTitle);
+        String restoreTitle = (previousTitle == null
+                || previousTitle.isBlank())
+                ? "Untitled" : previousTitle;
+        renameUseCase.renameNote(noteId, restoreTitle);
     }
 
     @Override

--- a/src/main/java/com/embervault/application/RenameNoteCommand.java
+++ b/src/main/java/com/embervault/application/RenameNoteCommand.java
@@ -1,0 +1,54 @@
+package com.embervault.application;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.Command;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.RenameNoteUseCase;
+
+/**
+ * Command that renames a note, capturing the previous title for undo.
+ */
+public final class RenameNoteCommand implements Command {
+
+    private final RenameNoteUseCase renameUseCase;
+    private final GetNoteQuery getNoteQuery;
+    private final UUID noteId;
+    private final String newTitle;
+    private String previousTitle;
+
+    /**
+     * Creates a rename command.
+     *
+     * @param renameUseCase the use case for renaming
+     * @param getNoteQuery  the query for reading the current title
+     * @param noteId        the note to rename
+     * @param newTitle      the new title
+     */
+    public RenameNoteCommand(RenameNoteUseCase renameUseCase,
+            GetNoteQuery getNoteQuery, UUID noteId, String newTitle) {
+        this.renameUseCase = Objects.requireNonNull(renameUseCase);
+        this.getNoteQuery = Objects.requireNonNull(getNoteQuery);
+        this.noteId = Objects.requireNonNull(noteId);
+        this.newTitle = Objects.requireNonNull(newTitle);
+    }
+
+    @Override
+    public void execute() {
+        previousTitle = getNoteQuery.getNote(noteId)
+                .orElseThrow()
+                .getTitle();
+        renameUseCase.renameNote(noteId, newTitle);
+    }
+
+    @Override
+    public void undo() {
+        renameUseCase.renameNote(noteId, previousTitle);
+    }
+
+    @Override
+    public String description() {
+        return "Rename note to '" + newTitle + "'";
+    }
+}

--- a/src/main/java/com/embervault/application/UpdateNoteTextCommand.java
+++ b/src/main/java/com/embervault/application/UpdateNoteTextCommand.java
@@ -1,0 +1,55 @@
+package com.embervault.application;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.Command;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.UpdateNoteTextUseCase;
+
+/**
+ * Command that updates a note's text content, capturing the previous
+ * text for undo.
+ */
+public final class UpdateNoteTextCommand implements Command {
+
+    private final UpdateNoteTextUseCase updateTextUseCase;
+    private final GetNoteQuery getNoteQuery;
+    private final UUID noteId;
+    private final String newText;
+    private String previousText;
+
+    /**
+     * Creates an update-text command.
+     *
+     * @param updateTextUseCase the use case for updating text
+     * @param getNoteQuery      the query for reading the current text
+     * @param noteId            the note to update
+     * @param newText           the new text content
+     */
+    public UpdateNoteTextCommand(UpdateNoteTextUseCase updateTextUseCase,
+            GetNoteQuery getNoteQuery, UUID noteId, String newText) {
+        this.updateTextUseCase = Objects.requireNonNull(updateTextUseCase);
+        this.getNoteQuery = Objects.requireNonNull(getNoteQuery);
+        this.noteId = Objects.requireNonNull(noteId);
+        this.newText = Objects.requireNonNull(newText);
+    }
+
+    @Override
+    public void execute() {
+        previousText = getNoteQuery.getNote(noteId)
+                .orElseThrow()
+                .getText();
+        updateTextUseCase.updateNoteText(noteId, newText);
+    }
+
+    @Override
+    public void undo() {
+        updateTextUseCase.updateNoteText(noteId, previousText);
+    }
+
+    @Override
+    public String description() {
+        return "Update note text";
+    }
+}

--- a/src/main/java/com/embervault/application/port/in/Command.java
+++ b/src/main/java/com/embervault/application/port/in/Command.java
@@ -1,0 +1,27 @@
+package com.embervault.application.port.in;
+
+/**
+ * A reversible command that can be executed and undone.
+ *
+ * <p>Commands capture the before-state needed to reverse their effect.
+ * They are used by {@link UndoRedoUseCase} to provide undo/redo support.</p>
+ */
+public interface Command {
+
+    /**
+     * Executes this command.
+     */
+    void execute();
+
+    /**
+     * Reverses the effect of this command.
+     */
+    void undo();
+
+    /**
+     * Returns a human-readable description of this command.
+     *
+     * @return the description
+     */
+    String description();
+}

--- a/src/main/java/com/embervault/application/port/in/UndoRedoUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/UndoRedoUseCase.java
@@ -1,0 +1,41 @@
+package com.embervault.application.port.in;
+
+/**
+ * Use case for undoing and redoing commands.
+ *
+ * <p>Provides undo/redo capability backed by a command history stack.
+ * ViewModels use this to expose undo/redo actions to the UI.</p>
+ */
+public interface UndoRedoUseCase {
+
+    /**
+     * Executes a command and records it for potential undo.
+     *
+     * @param command the command to execute
+     */
+    void execute(Command command);
+
+    /**
+     * Undoes the most recently executed command.
+     */
+    void undo();
+
+    /**
+     * Re-applies the most recently undone command.
+     */
+    void redo();
+
+    /**
+     * Returns whether there are commands that can be undone.
+     *
+     * @return true if undo is available
+     */
+    boolean canUndo();
+
+    /**
+     * Returns whether there are commands that can be redone.
+     *
+     * @return true if redo is available
+     */
+    boolean canRedo();
+}

--- a/src/test/java/com/embervault/application/CommandHistoryIntegrationTest.java
+++ b/src/test/java/com/embervault/application/CommandHistoryIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommandHistoryIntegrationTest {
+
+    private NoteServiceImpl service;
+    private CommandHistory history;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        service = new NoteServiceImpl(repository);
+        history = new CommandHistory();
+    }
+
+    @Test
+    @DisplayName("rename via history then undo restores original title")
+    void renameViaHistory_thenUndo_shouldRestoreTitle() {
+        Note note = service.createNote("Alpha", "content");
+        RenameNoteCommand cmd = new RenameNoteCommand(
+                service, service, note.getId(), "Beta");
+
+        history.execute(cmd);
+        assertEquals("Beta",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+
+        history.undo();
+        assertEquals("Alpha",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+
+        history.redo();
+        assertEquals("Beta",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("multiple commands undo in reverse order")
+    void multipleCommands_undoInReverseOrder() {
+        Note note = service.createNote("First", "content");
+
+        history.execute(new RenameNoteCommand(
+                service, service, note.getId(), "Second"));
+        history.execute(new RenameNoteCommand(
+                service, service, note.getId(), "Third"));
+
+        assertEquals("Third",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+
+        history.undo();
+        assertEquals("Second",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+
+        history.undo();
+        assertEquals("First",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("new execute after undo clears redo stack")
+    void newExecuteAfterUndo_clearsRedoStack() {
+        Note note = service.createNote("Original", "content");
+
+        history.execute(new RenameNoteCommand(
+                service, service, note.getId(), "Changed"));
+        history.undo();
+        assertTrue(history.canRedo());
+
+        history.execute(new RenameNoteCommand(
+                service, service, note.getId(), "Different"));
+        assertFalse(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("text update via history then undo restores original text")
+    void textUpdateViaHistory_thenUndo_shouldRestoreText() {
+        Note note = service.createNote("Title", "original");
+        UpdateNoteTextCommand cmd = new UpdateNoteTextCommand(
+                service, service, note.getId(), "updated");
+
+        history.execute(cmd);
+        assertEquals("updated",
+                service.getNote(note.getId()).orElseThrow().getText());
+
+        history.undo();
+        assertEquals("original",
+                service.getNote(note.getId()).orElseThrow().getText());
+    }
+}

--- a/src/test/java/com/embervault/application/CommandHistoryTest.java
+++ b/src/test/java/com/embervault/application/CommandHistoryTest.java
@@ -1,0 +1,37 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.embervault.application.port.in.Command;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommandHistoryTest {
+
+    @Test
+    @DisplayName("execute() calls command's execute method")
+    void execute_shouldCallCommandExecute() {
+        CommandHistory history = new CommandHistory();
+        int[] counter = {0};
+        Command command = new Command() {
+            @Override
+            public void execute() {
+                counter[0]++;
+            }
+
+            @Override
+            public void undo() {
+                counter[0]--;
+            }
+
+            @Override
+            public String description() {
+                return "test";
+            }
+        };
+
+        history.execute(command);
+
+        assertEquals(1, counter[0]);
+    }
+}

--- a/src/test/java/com/embervault/application/CommandHistoryTest.java
+++ b/src/test/java/com/embervault/application/CommandHistoryTest.java
@@ -1,19 +1,25 @@
 package com.embervault.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.embervault.application.port.in.Command;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class CommandHistoryTest {
 
-    @Test
-    @DisplayName("execute() calls command's execute method")
-    void execute_shouldCallCommandExecute() {
-        CommandHistory history = new CommandHistory();
-        int[] counter = {0};
-        Command command = new Command() {
+    private CommandHistory history;
+
+    @BeforeEach
+    void setUp() {
+        history = new CommandHistory();
+    }
+
+    private Command counterCommand(int[] counter) {
+        return new Command() {
             @Override
             public void execute() {
                 counter[0]++;
@@ -26,12 +32,112 @@ class CommandHistoryTest {
 
             @Override
             public String description() {
-                return "test";
+                return "increment";
             }
         };
+    }
 
-        history.execute(command);
+    @Test
+    @DisplayName("execute() calls command's execute method")
+    void execute_shouldCallCommandExecute() {
+        int[] counter = {0};
+        history.execute(counterCommand(counter));
+        assertEquals(1, counter[0]);
+    }
+
+    @Test
+    @DisplayName("undo() reverses the last executed command")
+    void undo_shouldReverseLastCommand() {
+        int[] counter = {0};
+        history.execute(counterCommand(counter));
+
+        history.undo();
+
+        assertEquals(0, counter[0]);
+    }
+
+    @Test
+    @DisplayName("undo() on empty history does nothing")
+    void undo_onEmptyHistory_shouldDoNothing() {
+        history.undo(); // should not throw
+    }
+
+    @Test
+    @DisplayName("canUndo() returns false when history is empty")
+    void canUndo_shouldReturnFalseWhenEmpty() {
+        assertFalse(history.canUndo());
+    }
+
+    @Test
+    @DisplayName("canUndo() returns true after execute")
+    void canUndo_shouldReturnTrueAfterExecute() {
+        int[] counter = {0};
+        history.execute(counterCommand(counter));
+        assertTrue(history.canUndo());
+    }
+
+    @Test
+    @DisplayName("redo() re-applies the last undone command")
+    void redo_shouldReapplyLastUndoneCommand() {
+        int[] counter = {0};
+        history.execute(counterCommand(counter));
+        history.undo();
+
+        history.redo();
 
         assertEquals(1, counter[0]);
+    }
+
+    @Test
+    @DisplayName("redo() on empty redo stack does nothing")
+    void redo_onEmptyRedoStack_shouldDoNothing() {
+        history.redo(); // should not throw
+    }
+
+    @Test
+    @DisplayName("canRedo() returns false when redo stack is empty")
+    void canRedo_shouldReturnFalseWhenEmpty() {
+        assertFalse(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("canRedo() returns true after undo")
+    void canRedo_shouldReturnTrueAfterUndo() {
+        int[] counter = {0};
+        history.execute(counterCommand(counter));
+        history.undo();
+        assertTrue(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("execute() clears redo stack")
+    void execute_shouldClearRedoStack() {
+        int[] counter = {0};
+        history.execute(counterCommand(counter));
+        history.undo();
+        assertTrue(history.canRedo());
+
+        history.execute(counterCommand(counter));
+
+        assertFalse(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("multiple undo/redo operations maintain correct state")
+    void multipleUndoRedo_shouldMaintainCorrectState() {
+        int[] counter = {0};
+        history.execute(counterCommand(counter));
+        history.execute(counterCommand(counter));
+        history.execute(counterCommand(counter));
+        assertEquals(3, counter[0]);
+
+        history.undo();
+        assertEquals(2, counter[0]);
+
+        history.undo();
+        assertEquals(1, counter[0]);
+
+        history.redo();
+        assertEquals(2, counter[0]);
     }
 }

--- a/src/test/java/com/embervault/application/CommandHistoryTest.java
+++ b/src/test/java/com/embervault/application/CommandHistoryTest.java
@@ -2,9 +2,11 @@ package com.embervault.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.embervault.application.port.in.Command;
+import com.embervault.application.port.in.UndoRedoUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,12 @@ class CommandHistoryTest {
                 return "increment";
             }
         };
+    }
+
+    @Test
+    @DisplayName("CommandHistory implements UndoRedoUseCase")
+    void commandHistory_shouldImplementUndoRedoUseCase() {
+        assertInstanceOf(UndoRedoUseCase.class, history);
     }
 
     @Test

--- a/src/test/java/com/embervault/application/MoveNoteCommandTest.java
+++ b/src/test/java/com/embervault/application/MoveNoteCommandTest.java
@@ -1,0 +1,74 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.MoveNoteUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MoveNoteCommandTest {
+
+    private NoteServiceImpl service;
+    private MoveNoteUseCase moveUseCase;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        service = new NoteServiceImpl(repository);
+        moveUseCase = service;
+    }
+
+    @Test
+    @DisplayName("execute() moves note to new parent")
+    void execute_shouldMoveNoteToNewParent() {
+        Note parent1 = service.createNote("Parent1", "");
+        Note parent2 = service.createNote("Parent2", "");
+        Note child = service.createChildNote(parent1.getId(), "Child");
+
+        MoveNoteCommand command = new MoveNoteCommand(
+                moveUseCase, service, child.getId(), parent2.getId());
+        command.execute();
+
+        List<Note> parent2Children = service.getChildren(parent2.getId());
+        assertEquals(1, parent2Children.size());
+        assertEquals("Child", parent2Children.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("undo() restores note to original parent")
+    void undo_shouldRestoreNoteToOriginalParent() {
+        Note parent1 = service.createNote("Parent1", "");
+        Note parent2 = service.createNote("Parent2", "");
+        Note child = service.createChildNote(parent1.getId(), "Child");
+
+        MoveNoteCommand command = new MoveNoteCommand(
+                moveUseCase, service, child.getId(), parent2.getId());
+        command.execute();
+        command.undo();
+
+        List<Note> parent1Children = service.getChildren(parent1.getId());
+        assertEquals(1, parent1Children.size());
+        assertEquals("Child", parent1Children.get(0).getTitle());
+
+        List<Note> parent2Children = service.getChildren(parent2.getId());
+        assertEquals(0, parent2Children.size());
+    }
+
+    @Test
+    @DisplayName("description() returns meaningful text")
+    void description_shouldReturnMeaningfulText() {
+        Note parent1 = service.createNote("Parent1", "");
+        Note parent2 = service.createNote("Parent2", "");
+        Note child = service.createChildNote(parent1.getId(), "Child");
+
+        MoveNoteCommand command = new MoveNoteCommand(
+                moveUseCase, service, child.getId(), parent2.getId());
+
+        assertEquals("Move note", command.description());
+    }
+}

--- a/src/test/java/com/embervault/application/RenameNoteCommandTest.java
+++ b/src/test/java/com/embervault/application/RenameNoteCommandTest.java
@@ -1,0 +1,60 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.RenameNoteUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RenameNoteCommandTest {
+
+    private NoteServiceImpl service;
+    private RenameNoteUseCase renameUseCase;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        service = new NoteServiceImpl(repository);
+        renameUseCase = service;
+    }
+
+    @Test
+    @DisplayName("execute() renames the note via RenameNoteUseCase")
+    void execute_shouldRenameNote() {
+        Note note = service.createNote("Original", "content");
+        RenameNoteCommand command = new RenameNoteCommand(
+                renameUseCase, service, note.getId(), "Renamed");
+
+        command.execute();
+
+        assertEquals("Renamed",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("undo() restores the original title")
+    void undo_shouldRestoreOriginalTitle() {
+        Note note = service.createNote("Original", "content");
+        RenameNoteCommand command = new RenameNoteCommand(
+                renameUseCase, service, note.getId(), "Renamed");
+        command.execute();
+
+        command.undo();
+
+        assertEquals("Original",
+                service.getNote(note.getId()).orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("description() returns meaningful text")
+    void description_shouldReturnMeaningfulText() {
+        Note note = service.createNote("Original", "content");
+        RenameNoteCommand command = new RenameNoteCommand(
+                renameUseCase, service, note.getId(), "Renamed");
+
+        assertEquals("Rename note to 'Renamed'", command.description());
+    }
+}

--- a/src/test/java/com/embervault/application/UpdateNoteTextCommandTest.java
+++ b/src/test/java/com/embervault/application/UpdateNoteTextCommandTest.java
@@ -1,0 +1,60 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.UpdateNoteTextUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UpdateNoteTextCommandTest {
+
+    private NoteServiceImpl service;
+    private UpdateNoteTextUseCase updateTextUseCase;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryNoteRepository repository = new InMemoryNoteRepository();
+        service = new NoteServiceImpl(repository);
+        updateTextUseCase = service;
+    }
+
+    @Test
+    @DisplayName("execute() updates the note text")
+    void execute_shouldUpdateNoteText() {
+        Note note = service.createNote("Title", "original text");
+        UpdateNoteTextCommand command = new UpdateNoteTextCommand(
+                updateTextUseCase, service, note.getId(), "new text");
+
+        command.execute();
+
+        assertEquals("new text",
+                service.getNote(note.getId()).orElseThrow().getText());
+    }
+
+    @Test
+    @DisplayName("undo() restores the original text")
+    void undo_shouldRestoreOriginalText() {
+        Note note = service.createNote("Title", "original text");
+        UpdateNoteTextCommand command = new UpdateNoteTextCommand(
+                updateTextUseCase, service, note.getId(), "new text");
+        command.execute();
+
+        command.undo();
+
+        assertEquals("original text",
+                service.getNote(note.getId()).orElseThrow().getText());
+    }
+
+    @Test
+    @DisplayName("description() returns meaningful text")
+    void description_shouldReturnMeaningfulText() {
+        Note note = service.createNote("Title", "original text");
+        UpdateNoteTextCommand command = new UpdateNoteTextCommand(
+                updateTextUseCase, service, note.getId(), "new text");
+
+        assertEquals("Update note text", command.description());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Command` interface (execute/undo/description) as an inbound port for reversible operations
- Add `CommandHistory` class implementing `UndoRedoUseCase` with undo/redo stacks
- Add `RenameNoteCommand`, `MoveNoteCommand`, and `UpdateNoteTextCommand` as concrete commands that capture before-state for reversal
- All commands use narrow use-case interfaces (e.g., `RenameNoteUseCase`, `GetNoteQuery`) per hexagonal architecture

## Test plan
- [ ] `CommandHistoryTest` — verifies execute/undo/redo/canUndo/canRedo stack behavior
- [ ] `RenameNoteCommandTest` — verifies rename execute, undo restores title, description text
- [ ] `MoveNoteCommandTest` — verifies move execute, undo restores original parent
- [ ] `UpdateNoteTextCommandTest` — verifies text update execute, undo restores original text
- [ ] `CommandHistoryIntegrationTest` — end-to-end: multi-command undo ordering, redo clearing, rename+text via history
- [ ] Full `mvn verify` passes (checkstyle, JaCoCo, ArchUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>