### PR TITLE
Enhance search with attribute filters (#263)

### DIFF
--- a/src/main/java/com/embervault/application/FilteredSearchService.java
+++ b/src/main/java/com/embervault/application/FilteredSearchService.java
@@ -1,0 +1,141 @@
+package com.embervault.application;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import com.embervault.application.port.in.FilteredSearchQuery;
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Note;
+import com.embervault.domain.SearchFilter;
+import com.embervault.domain.TbxColor;
+
+/**
+ * Application service for searching notes with attribute filters.
+ *
+ * <p>Implements the {@link FilteredSearchQuery} inbound port, applying
+ * text, attribute, and relationship filters with AND logic.</p>
+ */
+public final class FilteredSearchService implements FilteredSearchQuery {
+
+    private final NoteRepository repository;
+
+    /**
+     * Constructs a FilteredSearchService backed by the given repository.
+     *
+     * @param repository the note repository
+     */
+    public FilteredSearchService(NoteRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<Note> searchNotesFiltered(SearchFilter filter) {
+        if (filter == null || filter.isEmpty()) {
+            return List.of();
+        }
+        List<Note> candidates = repository.findAll();
+        candidates = applyTextFilter(candidates, filter.textQuery());
+        candidates = applyAttributeFilters(candidates,
+                filter.attributeFilters());
+        candidates = applyRelationshipFilters(candidates,
+                filter.relationshipFilters());
+        return new ArrayList<>(candidates);
+    }
+
+    private List<Note> applyTextFilter(List<Note> candidates,
+            String textQuery) {
+        if (textQuery.isBlank()) {
+            return candidates;
+        }
+        String lowerQuery = textQuery.toLowerCase(Locale.ROOT);
+        List<Note> titleMatches = new ArrayList<>();
+        List<Note> textOnly = new ArrayList<>();
+        for (Note note : candidates) {
+            boolean titleMatch = note.getTitle()
+                    .toLowerCase(Locale.ROOT).contains(lowerQuery);
+            boolean textMatch = note.getContent()
+                    .toLowerCase(Locale.ROOT).contains(lowerQuery);
+            if (titleMatch) {
+                titleMatches.add(note);
+            } else if (textMatch) {
+                textOnly.add(note);
+            }
+        }
+        List<Note> result = new ArrayList<>(
+                titleMatches.size() + textOnly.size());
+        result.addAll(titleMatches);
+        result.addAll(textOnly);
+        return result;
+    }
+
+    private List<Note> applyAttributeFilters(List<Note> candidates,
+            Map<String, String> filters) {
+        List<Note> result = candidates;
+        for (Map.Entry<String, String> entry : filters.entrySet()) {
+            String attrName = entry.getKey();
+            String expected = entry.getValue();
+            result = result.stream()
+                    .filter(n -> matchesAttribute(
+                            n, attrName, expected))
+                    .toList();
+        }
+        return result;
+    }
+
+    private List<Note> applyRelationshipFilters(List<Note> candidates,
+            List<String> filters) {
+        List<Note> result = candidates;
+        for (String rel : filters) {
+            if ("children".equals(rel)) {
+                Collection<UUID> ids = result.stream()
+                        .map(Note::getId).toList();
+                Set<UUID> withChildren =
+                        repository.findNoteIdsWithChildren(ids);
+                result = result.stream()
+                        .filter(n -> withChildren.contains(
+                                n.getId()))
+                        .toList();
+            }
+        }
+        return result;
+    }
+
+    private boolean matchesAttribute(Note note, String attrName,
+            String expected) {
+        Optional<AttributeValue> valueOpt =
+                note.getAttribute(attrName);
+        if (valueOpt.isEmpty()) {
+            return false;
+        }
+        AttributeValue value = valueOpt.get();
+        String expectedLower = expected.toLowerCase(Locale.ROOT);
+        return switch (value) {
+            case AttributeValue.StringValue sv ->
+                    sv.value().toLowerCase(Locale.ROOT)
+                            .equals(expectedLower);
+            case AttributeValue.BooleanValue bv ->
+                    String.valueOf(bv.value()).equals(expectedLower);
+            case AttributeValue.ColorValue cv ->
+                    matchesColor(cv.value(), expected);
+            case AttributeValue.NumberValue nv ->
+                    String.valueOf(nv.value()).equals(expected);
+            default -> false;
+        };
+    }
+
+    private boolean matchesColor(TbxColor color, String expected) {
+        String expectedLower = expected.toLowerCase(Locale.ROOT);
+        if (color.getName().isPresent()
+                && color.getName().get().equals(expectedLower)) {
+            return true;
+        }
+        return color.toHex().equalsIgnoreCase(expected);
+    }
+}

--- a/src/main/java/com/embervault/application/port/in/FilteredSearchQuery.java
+++ b/src/main/java/com/embervault/application/port/in/FilteredSearchQuery.java
@@ -1,0 +1,25 @@
+package com.embervault.application.port.in;
+
+import java.util.List;
+
+import com.embervault.domain.Note;
+import com.embervault.domain.SearchFilter;
+
+/**
+ * Query interface for searching notes with attribute filters.
+ */
+public interface FilteredSearchQuery {
+
+    /**
+     * Searches notes using a parsed {@link SearchFilter} that may include
+     * text terms, attribute filters, and relationship filters.
+     *
+     * <p>All filter criteria are combined with AND logic: a note must
+     * match the text query, all attribute filters, and all relationship
+     * filters to be included in results.</p>
+     *
+     * @param filter the parsed search filter
+     * @return matching notes
+     */
+    List<Note> searchNotesFiltered(SearchFilter filter);
+}

--- a/src/main/java/com/embervault/domain/SearchFilter.java
+++ b/src/main/java/com/embervault/domain/SearchFilter.java
@@ -1,0 +1,45 @@
+package com.embervault.domain;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A parsed search query containing text terms and attribute filters.
+ *
+ * <p>Represents the decomposition of a search string like
+ * {@code "meeting color:red has:children"} into its constituent parts:
+ * a plain text query, attribute key-value filters, and relationship
+ * filters.</p>
+ *
+ * @param textQuery           the plain text search terms
+ * @param attributeFilters    attribute name to expected value mappings
+ * @param relationshipFilters relationship checks (e.g., "children")
+ */
+public record SearchFilter(
+    String textQuery,
+    Map<String, String> attributeFilters,
+    List<String> relationshipFilters) {
+
+  /**
+   * Constructs a SearchFilter with defensive copies of collections.
+   */
+  public SearchFilter {
+    textQuery = textQuery == null ? "" : textQuery;
+    attributeFilters = attributeFilters == null
+        ? Map.of() : Map.copyOf(attributeFilters);
+    relationshipFilters = relationshipFilters == null
+        ? List.of() : List.copyOf(relationshipFilters);
+  }
+
+  /**
+   * Returns true if this filter has no text query, attribute filters,
+   * or relationship filters.
+   *
+   * @return true if empty
+   */
+  public boolean isEmpty() {
+    return textQuery.isBlank()
+        && attributeFilters.isEmpty()
+        && relationshipFilters.isEmpty();
+  }
+}

--- a/src/main/java/com/embervault/domain/SearchFilter.java
+++ b/src/main/java/com/embervault/domain/SearchFilter.java
@@ -16,30 +16,30 @@ import java.util.Map;
  * @param relationshipFilters relationship checks (e.g., "children")
  */
 public record SearchFilter(
-    String textQuery,
-    Map<String, String> attributeFilters,
-    List<String> relationshipFilters) {
+        String textQuery,
+        Map<String, String> attributeFilters,
+        List<String> relationshipFilters) {
 
-  /**
-   * Constructs a SearchFilter with defensive copies of collections.
-   */
-  public SearchFilter {
-    textQuery = textQuery == null ? "" : textQuery;
-    attributeFilters = attributeFilters == null
-        ? Map.of() : Map.copyOf(attributeFilters);
-    relationshipFilters = relationshipFilters == null
-        ? List.of() : List.copyOf(relationshipFilters);
-  }
+    /**
+     * Constructs a SearchFilter with defensive copies of collections.
+     */
+    public SearchFilter {
+        textQuery = textQuery == null ? "" : textQuery;
+        attributeFilters = attributeFilters == null
+                ? Map.of() : Map.copyOf(attributeFilters);
+        relationshipFilters = relationshipFilters == null
+                ? List.of() : List.copyOf(relationshipFilters);
+    }
 
-  /**
-   * Returns true if this filter has no text query, attribute filters,
-   * or relationship filters.
-   *
-   * @return true if empty
-   */
-  public boolean isEmpty() {
-    return textQuery.isBlank()
-        && attributeFilters.isEmpty()
-        && relationshipFilters.isEmpty();
-  }
+    /**
+     * Returns true if this filter has no text query, attribute filters,
+     * or relationship filters.
+     *
+     * @return true if empty
+     */
+    public boolean isEmpty() {
+        return textQuery.isBlank()
+                && attributeFilters.isEmpty()
+                && relationshipFilters.isEmpty();
+    }
 }

--- a/src/main/java/com/embervault/domain/SearchQueryParser.java
+++ b/src/main/java/com/embervault/domain/SearchQueryParser.java
@@ -21,61 +21,62 @@ import java.util.Map;
  */
 public final class SearchQueryParser {
 
-  private static final Map<String, String> FILTER_KEY_MAP = Map.ofEntries(
-      Map.entry("color", Attributes.COLOR),
-      Map.entry("badge", Attributes.BADGE),
-      Map.entry("checked", Attributes.CHECKED),
-      Map.entry("name", Attributes.NAME),
-      Map.entry("shape", Attributes.SHAPE),
-      Map.entry("text", Attributes.TEXT),
-      Map.entry("url", Attributes.URL),
-      Map.entry("prototype", Attributes.PROTOTYPE)
-  );
+    private static final Map<String, String> FILTER_KEY_MAP = Map.ofEntries(
+            Map.entry("color", Attributes.COLOR),
+            Map.entry("badge", Attributes.BADGE),
+            Map.entry("checked", Attributes.CHECKED),
+            Map.entry("name", Attributes.NAME),
+            Map.entry("shape", Attributes.SHAPE),
+            Map.entry("text", Attributes.TEXT),
+            Map.entry("url", Attributes.URL),
+            Map.entry("prototype", Attributes.PROTOTYPE)
+    );
 
-  private SearchQueryParser() {
-    // utility class
-  }
-
-  /**
-   * Parses a search query string into a {@link SearchFilter}.
-   *
-   * @param input the raw search string (may be null)
-   * @return the parsed filter
-   */
-  public static SearchFilter parse(String input) {
-    if (input == null || input.isBlank()) {
-      return new SearchFilter("", Map.of(), List.of());
+    private SearchQueryParser() {
+        // utility class
     }
 
-    String[] tokens = input.trim().split("\\s+");
-    List<String> textParts = new ArrayList<>();
-    Map<String, String> attributeFilters = new HashMap<>();
-    List<String> relationshipFilters = new ArrayList<>();
-
-    for (String token : tokens) {
-      int colonIndex = token.indexOf(':');
-      if (colonIndex > 0 && colonIndex < token.length() - 1) {
-        String key = token.substring(0, colonIndex)
-            .toLowerCase(Locale.ROOT);
-        String value = token.substring(colonIndex + 1);
-
-        if ("has".equals(key)) {
-          relationshipFilters.add(value.toLowerCase(Locale.ROOT));
-        } else {
-          String attrName = FILTER_KEY_MAP.get(key);
-          if (attrName != null) {
-            attributeFilters.put(attrName, value);
-          } else {
-            textParts.add(token);
-          }
+    /**
+     * Parses a search query string into a {@link SearchFilter}.
+     *
+     * @param input the raw search string (may be null)
+     * @return the parsed filter
+     */
+    public static SearchFilter parse(String input) {
+        if (input == null || input.isBlank()) {
+            return new SearchFilter("", Map.of(), List.of());
         }
-      } else {
-        textParts.add(token);
-      }
-    }
 
-    String textQuery = String.join(" ", textParts);
-    return new SearchFilter(textQuery, attributeFilters,
-        relationshipFilters);
-  }
+        String[] tokens = input.trim().split("\\s+");
+        List<String> textParts = new ArrayList<>();
+        Map<String, String> attributeFilters = new HashMap<>();
+        List<String> relationshipFilters = new ArrayList<>();
+
+        for (String token : tokens) {
+            int colonIndex = token.indexOf(':');
+            if (colonIndex > 0 && colonIndex < token.length() - 1) {
+                String key = token.substring(0, colonIndex)
+                        .toLowerCase(Locale.ROOT);
+                String value = token.substring(colonIndex + 1);
+
+                if ("has".equals(key)) {
+                    relationshipFilters.add(
+                            value.toLowerCase(Locale.ROOT));
+                } else {
+                    String attrName = FILTER_KEY_MAP.get(key);
+                    if (attrName != null) {
+                        attributeFilters.put(attrName, value);
+                    } else {
+                        textParts.add(token);
+                    }
+                }
+            } else {
+                textParts.add(token);
+            }
+        }
+
+        String textQuery = String.join(" ", textParts);
+        return new SearchFilter(textQuery, attributeFilters,
+                relationshipFilters);
+    }
 }

--- a/src/main/java/com/embervault/domain/SearchQueryParser.java
+++ b/src/main/java/com/embervault/domain/SearchQueryParser.java
@@ -1,0 +1,81 @@
+package com.embervault.domain;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Parses a search query string into a {@link SearchFilter}.
+ *
+ * <p>Supports three kinds of tokens:</p>
+ * <ul>
+ *   <li><b>Attribute filters</b>: {@code color:red}, {@code badge:star},
+ *       {@code checked:true} — mapped to Tinderbox attribute names</li>
+ *   <li><b>Relationship filters</b>: {@code has:children} — checks
+ *       structural relationships</li>
+ *   <li><b>Text terms</b>: everything else is treated as plain-text
+ *       search</li>
+ * </ul>
+ */
+public final class SearchQueryParser {
+
+  private static final Map<String, String> FILTER_KEY_MAP = Map.ofEntries(
+      Map.entry("color", Attributes.COLOR),
+      Map.entry("badge", Attributes.BADGE),
+      Map.entry("checked", Attributes.CHECKED),
+      Map.entry("name", Attributes.NAME),
+      Map.entry("shape", Attributes.SHAPE),
+      Map.entry("text", Attributes.TEXT),
+      Map.entry("url", Attributes.URL),
+      Map.entry("prototype", Attributes.PROTOTYPE)
+  );
+
+  private SearchQueryParser() {
+    // utility class
+  }
+
+  /**
+   * Parses a search query string into a {@link SearchFilter}.
+   *
+   * @param input the raw search string (may be null)
+   * @return the parsed filter
+   */
+  public static SearchFilter parse(String input) {
+    if (input == null || input.isBlank()) {
+      return new SearchFilter("", Map.of(), List.of());
+    }
+
+    String[] tokens = input.trim().split("\\s+");
+    List<String> textParts = new ArrayList<>();
+    Map<String, String> attributeFilters = new HashMap<>();
+    List<String> relationshipFilters = new ArrayList<>();
+
+    for (String token : tokens) {
+      int colonIndex = token.indexOf(':');
+      if (colonIndex > 0 && colonIndex < token.length() - 1) {
+        String key = token.substring(0, colonIndex)
+            .toLowerCase(Locale.ROOT);
+        String value = token.substring(colonIndex + 1);
+
+        if ("has".equals(key)) {
+          relationshipFilters.add(value.toLowerCase(Locale.ROOT));
+        } else {
+          String attrName = FILTER_KEY_MAP.get(key);
+          if (attrName != null) {
+            attributeFilters.put(attrName, value);
+          } else {
+            textParts.add(token);
+          }
+        }
+      } else {
+        textParts.add(token);
+      }
+    }
+
+    String textQuery = String.join(" ", textParts);
+    return new SearchFilter(textQuery, attributeFilters,
+        relationshipFilters);
+  }
+}

--- a/src/test/java/com/embervault/application/FilteredSearchTest.java
+++ b/src/test/java/com/embervault/application/FilteredSearchTest.java
@@ -1,0 +1,170 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+import com.embervault.domain.SearchFilter;
+import com.embervault.domain.TbxColor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FilteredSearchTest {
+
+    private NoteServiceImpl noteService;
+    private FilteredSearchService searchService;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        searchService = new FilteredSearchService(repository);
+    }
+
+    @Test
+    @DisplayName("empty filter returns empty results")
+    void emptyFilter_shouldReturnEmpty() {
+        noteService.createNote("Alpha", "content");
+
+        SearchFilter filter = new SearchFilter("", Map.of(), List.of());
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("text-only filter matches like basic search")
+    void textOnlyFilter_shouldMatchLikeBasicSearch() {
+        noteService.createNote("Meeting notes", "agenda");
+        noteService.createNote("Unrelated", "stuff");
+
+        SearchFilter filter = new SearchFilter(
+                "meeting", Map.of(), List.of());
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertEquals(1, results.size());
+        assertEquals("Meeting notes", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("color filter matches notes with matching color")
+    void colorFilter_shouldMatchColorAttribute() {
+        Note red = noteService.createNote("Red note", "");
+        red.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+        repository.save(red);
+
+        Note blue = noteService.createNote("Blue note", "");
+        blue.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("blue")));
+        repository.save(blue);
+
+        SearchFilter filter = new SearchFilter(
+                "", Map.of(Attributes.COLOR, "red"), List.of());
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertEquals(1, results.size());
+        assertEquals("Red note", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("badge filter matches notes with matching badge")
+    void badgeFilter_shouldMatchBadgeAttribute() {
+        Note starred = noteService.createNote("Starred", "");
+        starred.setAttribute(Attributes.BADGE,
+                new AttributeValue.StringValue("star"));
+        repository.save(starred);
+
+        noteService.createNote("Plain", "");
+
+        SearchFilter filter = new SearchFilter(
+                "", Map.of(Attributes.BADGE, "star"), List.of());
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertEquals(1, results.size());
+        assertEquals("Starred", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("checked filter matches notes with checked=true")
+    void checkedFilter_shouldMatchCheckedAttribute() {
+        Note checked = noteService.createNote("Done", "");
+        checked.setAttribute(Attributes.CHECKED,
+                new AttributeValue.BooleanValue(true));
+        repository.save(checked);
+
+        Note unchecked = noteService.createNote("Todo", "");
+        unchecked.setAttribute(Attributes.CHECKED,
+                new AttributeValue.BooleanValue(false));
+        repository.save(unchecked);
+
+        SearchFilter filter = new SearchFilter(
+                "", Map.of(Attributes.CHECKED, "true"), List.of());
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertEquals(1, results.size());
+        assertEquals("Done", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("text and attribute filter both applied (AND logic)")
+    void textAndAttributeFilter_shouldApplyBoth() {
+        Note match = noteService.createNote("Meeting agenda", "");
+        match.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+        repository.save(match);
+
+        noteService.createNote("Meeting notes", "");
+
+        Note colorOnly = noteService.createNote("Unrelated", "");
+        colorOnly.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+        repository.save(colorOnly);
+
+        SearchFilter filter = new SearchFilter(
+                "meeting", Map.of(Attributes.COLOR, "red"), List.of());
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertEquals(1, results.size());
+        assertEquals("Meeting agenda", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("has:children filter matches notes with children")
+    void hasChildrenFilter_shouldMatchParentNotes() {
+        Note parent = noteService.createNote("Parent", "");
+        noteService.createChildNote(parent.getId(), "Child");
+
+        noteService.createNote("Leaf", "");
+
+        SearchFilter filter = new SearchFilter(
+                "", Map.of(), List.of("children"));
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertEquals(1, results.size());
+        assertEquals("Parent", results.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("string attribute filter uses case-insensitive match")
+    void stringFilter_shouldBeCaseInsensitive() {
+        Note note = noteService.createNote("Test", "");
+        note.setAttribute(Attributes.BADGE,
+                new AttributeValue.StringValue("Star"));
+        repository.save(note);
+
+        SearchFilter filter = new SearchFilter(
+                "", Map.of(Attributes.BADGE, "star"), List.of());
+        List<Note> results = searchService.searchNotesFiltered(filter);
+
+        assertEquals(1, results.size());
+    }
+}

--- a/src/test/java/com/embervault/domain/SearchFilterTest.java
+++ b/src/test/java/com/embervault/domain/SearchFilterTest.java
@@ -11,53 +11,55 @@ import org.junit.jupiter.api.Test;
 
 class SearchFilterTest {
 
-  @Test
-  @DisplayName("SearchFilter with text only has empty filters")
-  void textOnly_shouldHaveEmptyFilters() {
-    SearchFilter filter = new SearchFilter("meeting", Map.of(), List.of());
+    @Test
+    @DisplayName("SearchFilter with text only has empty filters")
+    void textOnly_shouldHaveEmptyFilters() {
+        SearchFilter filter = new SearchFilter(
+                "meeting", Map.of(), List.of());
 
-    assertEquals("meeting", filter.textQuery());
-    assertTrue(filter.attributeFilters().isEmpty());
-    assertTrue(filter.relationshipFilters().isEmpty());
-  }
+        assertEquals("meeting", filter.textQuery());
+        assertTrue(filter.attributeFilters().isEmpty());
+        assertTrue(filter.relationshipFilters().isEmpty());
+    }
 
-  @Test
-  @DisplayName("SearchFilter with attribute filters retains them")
-  void withAttributeFilters_shouldRetainThem() {
-    Map<String, String> attrs = Map.of("$Color", "red");
-    SearchFilter filter = new SearchFilter("", attrs, List.of());
+    @Test
+    @DisplayName("SearchFilter with attribute filters retains them")
+    void withAttributeFilters_shouldRetainThem() {
+        Map<String, String> attrs = Map.of("$Color", "red");
+        SearchFilter filter = new SearchFilter("", attrs, List.of());
 
-    assertEquals("red", filter.attributeFilters().get("$Color"));
-    assertTrue(filter.textQuery().isEmpty());
-  }
+        assertEquals("red", filter.attributeFilters().get("$Color"));
+        assertTrue(filter.textQuery().isEmpty());
+    }
 
-  @Test
-  @DisplayName("SearchFilter with relationship filter retains it")
-  void withRelationshipFilter_shouldRetainIt() {
-    SearchFilter filter = new SearchFilter(
-        "", Map.of(), List.of("children"));
+    @Test
+    @DisplayName("SearchFilter with relationship filter retains it")
+    void withRelationshipFilter_shouldRetainIt() {
+        SearchFilter filter = new SearchFilter(
+                "", Map.of(), List.of("children"));
 
-    assertEquals(1, filter.relationshipFilters().size());
-    assertEquals("children", filter.relationshipFilters().get(0));
-  }
+        assertEquals(1, filter.relationshipFilters().size());
+        assertEquals("children", filter.relationshipFilters().get(0));
+    }
 
-  @Test
-  @DisplayName("SearchFilter is empty when all parts are empty")
-  void isEmpty_shouldReturnTrueWhenAllEmpty() {
-    SearchFilter filter = new SearchFilter("", Map.of(), List.of());
+    @Test
+    @DisplayName("SearchFilter is empty when all parts are empty")
+    void isEmpty_shouldReturnTrueWhenAllEmpty() {
+        SearchFilter filter = new SearchFilter("", Map.of(), List.of());
 
-    assertTrue(filter.isEmpty());
-  }
+        assertTrue(filter.isEmpty());
+    }
 
-  @Test
-  @DisplayName("SearchFilter maps are unmodifiable")
-  void maps_shouldBeUnmodifiable() {
-    Map<String, String> attrs = new java.util.HashMap<>();
-    attrs.put("$Color", "red");
-    SearchFilter filter = new SearchFilter("text", attrs, List.of());
+    @Test
+    @DisplayName("SearchFilter maps are unmodifiable")
+    void maps_shouldBeUnmodifiable() {
+        Map<String, String> attrs = new java.util.HashMap<>();
+        attrs.put("$Color", "red");
+        SearchFilter filter = new SearchFilter(
+                "text", attrs, List.of());
 
-    // Modifying original should not affect the filter
-    attrs.put("$Badge", "star");
-    assertEquals(1, filter.attributeFilters().size());
-  }
+        // Modifying original should not affect the filter
+        attrs.put("$Badge", "star");
+        assertEquals(1, filter.attributeFilters().size());
+    }
 }

--- a/src/test/java/com/embervault/domain/SearchFilterTest.java
+++ b/src/test/java/com/embervault/domain/SearchFilterTest.java
@@ -1,0 +1,63 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SearchFilterTest {
+
+  @Test
+  @DisplayName("SearchFilter with text only has empty filters")
+  void textOnly_shouldHaveEmptyFilters() {
+    SearchFilter filter = new SearchFilter("meeting", Map.of(), List.of());
+
+    assertEquals("meeting", filter.textQuery());
+    assertTrue(filter.attributeFilters().isEmpty());
+    assertTrue(filter.relationshipFilters().isEmpty());
+  }
+
+  @Test
+  @DisplayName("SearchFilter with attribute filters retains them")
+  void withAttributeFilters_shouldRetainThem() {
+    Map<String, String> attrs = Map.of("$Color", "red");
+    SearchFilter filter = new SearchFilter("", attrs, List.of());
+
+    assertEquals("red", filter.attributeFilters().get("$Color"));
+    assertTrue(filter.textQuery().isEmpty());
+  }
+
+  @Test
+  @DisplayName("SearchFilter with relationship filter retains it")
+  void withRelationshipFilter_shouldRetainIt() {
+    SearchFilter filter = new SearchFilter(
+        "", Map.of(), List.of("children"));
+
+    assertEquals(1, filter.relationshipFilters().size());
+    assertEquals("children", filter.relationshipFilters().get(0));
+  }
+
+  @Test
+  @DisplayName("SearchFilter is empty when all parts are empty")
+  void isEmpty_shouldReturnTrueWhenAllEmpty() {
+    SearchFilter filter = new SearchFilter("", Map.of(), List.of());
+
+    assertTrue(filter.isEmpty());
+  }
+
+  @Test
+  @DisplayName("SearchFilter maps are unmodifiable")
+  void maps_shouldBeUnmodifiable() {
+    Map<String, String> attrs = new java.util.HashMap<>();
+    attrs.put("$Color", "red");
+    SearchFilter filter = new SearchFilter("text", attrs, List.of());
+
+    // Modifying original should not affect the filter
+    attrs.put("$Badge", "star");
+    assertEquals(1, filter.attributeFilters().size());
+  }
+}

--- a/src/test/java/com/embervault/domain/SearchQueryParserTest.java
+++ b/src/test/java/com/embervault/domain/SearchQueryParserTest.java
@@ -1,0 +1,117 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SearchQueryParserTest {
+
+  @Test
+  @DisplayName("parse plain text returns text-only filter")
+  void parsePlainText_shouldReturnTextOnlyFilter() {
+    SearchFilter filter = SearchQueryParser.parse("meeting notes");
+
+    assertEquals("meeting notes", filter.textQuery());
+    assertTrue(filter.attributeFilters().isEmpty());
+    assertTrue(filter.relationshipFilters().isEmpty());
+  }
+
+  @Test
+  @DisplayName("parse null returns empty filter")
+  void parseNull_shouldReturnEmptyFilter() {
+    SearchFilter filter = SearchQueryParser.parse(null);
+
+    assertTrue(filter.isEmpty());
+  }
+
+  @Test
+  @DisplayName("parse blank returns empty filter")
+  void parseBlank_shouldReturnEmptyFilter() {
+    SearchFilter filter = SearchQueryParser.parse("   ");
+
+    assertTrue(filter.isEmpty());
+  }
+
+  @Test
+  @DisplayName("parse color:red returns attribute filter for $Color")
+  void parseColorFilter_shouldReturnAttributeFilter() {
+    SearchFilter filter = SearchQueryParser.parse("color:red");
+
+    assertTrue(filter.textQuery().isEmpty());
+    assertEquals("red", filter.attributeFilters().get(Attributes.COLOR));
+  }
+
+  @Test
+  @DisplayName("parse badge:star returns attribute filter for $Badge")
+  void parseBadgeFilter_shouldReturnAttributeFilter() {
+    SearchFilter filter = SearchQueryParser.parse("badge:star");
+
+    assertEquals("star", filter.attributeFilters().get(Attributes.BADGE));
+  }
+
+  @Test
+  @DisplayName("parse checked:true returns attribute filter for $Checked")
+  void parseCheckedFilter_shouldReturnAttributeFilter() {
+    SearchFilter filter = SearchQueryParser.parse("checked:true");
+
+    assertEquals("true",
+        filter.attributeFilters().get(Attributes.CHECKED));
+  }
+
+  @Test
+  @DisplayName("parse mixed text and filters separates them")
+  void parseMixedInput_shouldSeparateTextAndFilters() {
+    SearchFilter filter = SearchQueryParser.parse(
+        "meeting color:red important");
+
+    assertEquals("meeting important", filter.textQuery());
+    assertEquals("red", filter.attributeFilters().get(Attributes.COLOR));
+  }
+
+  @Test
+  @DisplayName("parse has:children returns relationship filter")
+  void parseHasChildren_shouldReturnRelationshipFilter() {
+    SearchFilter filter = SearchQueryParser.parse("has:children");
+
+    assertTrue(filter.textQuery().isEmpty());
+    assertEquals(1, filter.relationshipFilters().size());
+    assertEquals("children", filter.relationshipFilters().get(0));
+  }
+
+  @Test
+  @DisplayName("parse is case-insensitive for filter keys")
+  void parseFilterKeys_shouldBeCaseInsensitive() {
+    SearchFilter filter = SearchQueryParser.parse("Color:blue");
+
+    assertEquals("blue", filter.attributeFilters().get(Attributes.COLOR));
+  }
+
+  @Test
+  @DisplayName("parse name:foo returns attribute filter for $Name")
+  void parseNameFilter_shouldReturnAttributeFilter() {
+    SearchFilter filter = SearchQueryParser.parse("name:foo");
+
+    assertEquals("foo", filter.attributeFilters().get(Attributes.NAME));
+  }
+
+  @Test
+  @DisplayName("parse multiple filters retains all")
+  void parseMultipleFilters_shouldRetainAll() {
+    SearchFilter filter = SearchQueryParser.parse(
+        "color:red badge:star");
+
+    assertEquals("red", filter.attributeFilters().get(Attributes.COLOR));
+    assertEquals("star", filter.attributeFilters().get(Attributes.BADGE));
+  }
+
+  @Test
+  @DisplayName("parse shape:circle returns attribute filter for $Shape")
+  void parseShapeFilter_shouldReturnAttributeFilter() {
+    SearchFilter filter = SearchQueryParser.parse("shape:circle");
+
+    assertEquals("circle",
+        filter.attributeFilters().get(Attributes.SHAPE));
+  }
+}

--- a/src/test/java/com/embervault/domain/SearchQueryParserTest.java
+++ b/src/test/java/com/embervault/domain/SearchQueryParserTest.java
@@ -8,110 +8,118 @@ import org.junit.jupiter.api.Test;
 
 class SearchQueryParserTest {
 
-  @Test
-  @DisplayName("parse plain text returns text-only filter")
-  void parsePlainText_shouldReturnTextOnlyFilter() {
-    SearchFilter filter = SearchQueryParser.parse("meeting notes");
+    @Test
+    @DisplayName("parse plain text returns text-only filter")
+    void parsePlainText_shouldReturnTextOnlyFilter() {
+        SearchFilter filter = SearchQueryParser.parse("meeting notes");
 
-    assertEquals("meeting notes", filter.textQuery());
-    assertTrue(filter.attributeFilters().isEmpty());
-    assertTrue(filter.relationshipFilters().isEmpty());
-  }
+        assertEquals("meeting notes", filter.textQuery());
+        assertTrue(filter.attributeFilters().isEmpty());
+        assertTrue(filter.relationshipFilters().isEmpty());
+    }
 
-  @Test
-  @DisplayName("parse null returns empty filter")
-  void parseNull_shouldReturnEmptyFilter() {
-    SearchFilter filter = SearchQueryParser.parse(null);
+    @Test
+    @DisplayName("parse null returns empty filter")
+    void parseNull_shouldReturnEmptyFilter() {
+        SearchFilter filter = SearchQueryParser.parse(null);
 
-    assertTrue(filter.isEmpty());
-  }
+        assertTrue(filter.isEmpty());
+    }
 
-  @Test
-  @DisplayName("parse blank returns empty filter")
-  void parseBlank_shouldReturnEmptyFilter() {
-    SearchFilter filter = SearchQueryParser.parse("   ");
+    @Test
+    @DisplayName("parse blank returns empty filter")
+    void parseBlank_shouldReturnEmptyFilter() {
+        SearchFilter filter = SearchQueryParser.parse("   ");
 
-    assertTrue(filter.isEmpty());
-  }
+        assertTrue(filter.isEmpty());
+    }
 
-  @Test
-  @DisplayName("parse color:red returns attribute filter for $Color")
-  void parseColorFilter_shouldReturnAttributeFilter() {
-    SearchFilter filter = SearchQueryParser.parse("color:red");
+    @Test
+    @DisplayName("parse color:red returns attribute filter for $Color")
+    void parseColorFilter_shouldReturnAttributeFilter() {
+        SearchFilter filter = SearchQueryParser.parse("color:red");
 
-    assertTrue(filter.textQuery().isEmpty());
-    assertEquals("red", filter.attributeFilters().get(Attributes.COLOR));
-  }
+        assertTrue(filter.textQuery().isEmpty());
+        assertEquals("red",
+                filter.attributeFilters().get(Attributes.COLOR));
+    }
 
-  @Test
-  @DisplayName("parse badge:star returns attribute filter for $Badge")
-  void parseBadgeFilter_shouldReturnAttributeFilter() {
-    SearchFilter filter = SearchQueryParser.parse("badge:star");
+    @Test
+    @DisplayName("parse badge:star returns attribute filter for $Badge")
+    void parseBadgeFilter_shouldReturnAttributeFilter() {
+        SearchFilter filter = SearchQueryParser.parse("badge:star");
 
-    assertEquals("star", filter.attributeFilters().get(Attributes.BADGE));
-  }
+        assertEquals("star",
+                filter.attributeFilters().get(Attributes.BADGE));
+    }
 
-  @Test
-  @DisplayName("parse checked:true returns attribute filter for $Checked")
-  void parseCheckedFilter_shouldReturnAttributeFilter() {
-    SearchFilter filter = SearchQueryParser.parse("checked:true");
+    @Test
+    @DisplayName("parse checked:true returns attribute filter")
+    void parseCheckedFilter_shouldReturnAttributeFilter() {
+        SearchFilter filter = SearchQueryParser.parse("checked:true");
 
-    assertEquals("true",
-        filter.attributeFilters().get(Attributes.CHECKED));
-  }
+        assertEquals("true",
+                filter.attributeFilters().get(Attributes.CHECKED));
+    }
 
-  @Test
-  @DisplayName("parse mixed text and filters separates them")
-  void parseMixedInput_shouldSeparateTextAndFilters() {
-    SearchFilter filter = SearchQueryParser.parse(
-        "meeting color:red important");
+    @Test
+    @DisplayName("parse mixed text and filters separates them")
+    void parseMixedInput_shouldSeparateTextAndFilters() {
+        SearchFilter filter = SearchQueryParser.parse(
+                "meeting color:red important");
 
-    assertEquals("meeting important", filter.textQuery());
-    assertEquals("red", filter.attributeFilters().get(Attributes.COLOR));
-  }
+        assertEquals("meeting important", filter.textQuery());
+        assertEquals("red",
+                filter.attributeFilters().get(Attributes.COLOR));
+    }
 
-  @Test
-  @DisplayName("parse has:children returns relationship filter")
-  void parseHasChildren_shouldReturnRelationshipFilter() {
-    SearchFilter filter = SearchQueryParser.parse("has:children");
+    @Test
+    @DisplayName("parse has:children returns relationship filter")
+    void parseHasChildren_shouldReturnRelationshipFilter() {
+        SearchFilter filter = SearchQueryParser.parse("has:children");
 
-    assertTrue(filter.textQuery().isEmpty());
-    assertEquals(1, filter.relationshipFilters().size());
-    assertEquals("children", filter.relationshipFilters().get(0));
-  }
+        assertTrue(filter.textQuery().isEmpty());
+        assertEquals(1, filter.relationshipFilters().size());
+        assertEquals("children",
+                filter.relationshipFilters().get(0));
+    }
 
-  @Test
-  @DisplayName("parse is case-insensitive for filter keys")
-  void parseFilterKeys_shouldBeCaseInsensitive() {
-    SearchFilter filter = SearchQueryParser.parse("Color:blue");
+    @Test
+    @DisplayName("parse is case-insensitive for filter keys")
+    void parseFilterKeys_shouldBeCaseInsensitive() {
+        SearchFilter filter = SearchQueryParser.parse("Color:blue");
 
-    assertEquals("blue", filter.attributeFilters().get(Attributes.COLOR));
-  }
+        assertEquals("blue",
+                filter.attributeFilters().get(Attributes.COLOR));
+    }
 
-  @Test
-  @DisplayName("parse name:foo returns attribute filter for $Name")
-  void parseNameFilter_shouldReturnAttributeFilter() {
-    SearchFilter filter = SearchQueryParser.parse("name:foo");
+    @Test
+    @DisplayName("parse name:foo returns attribute filter for $Name")
+    void parseNameFilter_shouldReturnAttributeFilter() {
+        SearchFilter filter = SearchQueryParser.parse("name:foo");
 
-    assertEquals("foo", filter.attributeFilters().get(Attributes.NAME));
-  }
+        assertEquals("foo",
+                filter.attributeFilters().get(Attributes.NAME));
+    }
 
-  @Test
-  @DisplayName("parse multiple filters retains all")
-  void parseMultipleFilters_shouldRetainAll() {
-    SearchFilter filter = SearchQueryParser.parse(
-        "color:red badge:star");
+    @Test
+    @DisplayName("parse multiple filters retains all")
+    void parseMultipleFilters_shouldRetainAll() {
+        SearchFilter filter = SearchQueryParser.parse(
+                "color:red badge:star");
 
-    assertEquals("red", filter.attributeFilters().get(Attributes.COLOR));
-    assertEquals("star", filter.attributeFilters().get(Attributes.BADGE));
-  }
+        assertEquals("red",
+                filter.attributeFilters().get(Attributes.COLOR));
+        assertEquals("star",
+                filter.attributeFilters().get(Attributes.BADGE));
+    }
 
-  @Test
-  @DisplayName("parse shape:circle returns attribute filter for $Shape")
-  void parseShapeFilter_shouldReturnAttributeFilter() {
-    SearchFilter filter = SearchQueryParser.parse("shape:circle");
+    @Test
+    @DisplayName("parse shape:circle returns attribute filter")
+    void parseShapeFilter_shouldReturnAttributeFilter() {
+        SearchFilter filter = SearchQueryParser.parse("shape:circle");
 
-    assertEquals("circle",
-        filter.attributeFilters().get(Attributes.SHAPE));
-  }
+        assertEquals("circle",
+                filter.attributeFilters().get(Attributes.SHAPE));
+    }
 }


### PR DESCRIPTION
## Summary
- Add `SearchFilter` domain value object representing parsed search queries with text terms, attribute filters, and relationship filters
- Add `SearchQueryParser` that parses search strings like `meeting color:red has:children` into structured `SearchFilter` objects
- Add `FilteredSearchQuery` inbound port and `FilteredSearchService` application service supporting attribute matching (`color:red`, `badge:star`, `checked:true`) and relationship checks (`has:children`) with AND logic
- Supports case-insensitive matching for string/boolean attributes and color name matching for `ColorValue` attributes

## Test plan
- [ ] `SearchFilterTest` — value object construction, emptiness check, defensive copies
- [ ] `SearchQueryParserTest` — plain text, null/blank, color/badge/checked/name/shape filters, has:children, mixed text+filters, case-insensitivity, multiple filters
- [ ] `FilteredSearchTest` — empty filter, text-only, color filter, badge filter, checked filter, AND logic (text+attribute), has:children, case-insensitive string match
- [ ] Full `mvn verify` passes (tests, checkstyle, JaCoCo, ArchUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>