### PR TITLE
Add global keyboard shortcut registry with command palette (#265)

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -8,9 +8,11 @@ import com.embervault.adapter.in.ui.view.OutlineViewController;
 import com.embervault.adapter.in.ui.view.SearchViewController;
 import com.embervault.adapter.in.ui.view.TextPaneViewController;
 import com.embervault.adapter.in.ui.viewmodel.AppStateEventBridge;
+import com.embervault.adapter.in.ui.viewmodel.CommandPaletteViewModel;
 import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
+import com.embervault.adapter.in.ui.viewmodel.ShortcutRegistry;
 import com.embervault.application.port.in.StampService;
 import com.embervault.domain.Attributes;
 import com.embervault.domain.Project;
@@ -21,6 +23,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.SplitPane;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
@@ -143,7 +146,22 @@ public class App extends Application {
         root.setTop(topArea);
         root.setCenter(mainSplitPane);
 
-        Scene scene = new Scene(root, 1024, 768);
+        // Shortcut registry and command palette
+        ShortcutRegistry shortcutRegistry = new ShortcutRegistry();
+        CommandPaletteViewModel commandPaletteVm =
+                new CommandPaletteViewModel(shortcutRegistry);
+        CommandPaletteOverlay overlay =
+                new CommandPaletteOverlay(commandPaletteVm);
+
+        StackPane layeredRoot =
+                new StackPane(root, overlay.getNode());
+
+        registerShortcuts(shortcutRegistry, commandPaletteVm,
+                winCtx, searchViewModel, outlineViewModel,
+                setup, project);
+
+        Scene scene = new Scene(layeredRoot, 1024, 768);
+        ShortcutInstaller.install(scene, shortcutRegistry);
         stage.setTitle("EmberVault - " + project.getName());
         stage.setScene(scene);
         stage.show();
@@ -174,6 +192,53 @@ public class App extends Application {
             stampService.createStamp("Badge:" + b,
                     Attributes.BADGE + "=" + b);
         }
+    }
+
+    private void registerShortcuts(
+            ShortcutRegistry registry,
+            CommandPaletteViewModel commandPaletteVm,
+            WindowContext winCtx,
+            SearchViewModel searchViewModel,
+            OutlineViewModel outlineViewModel,
+            WindowSetupResult setup,
+            Project project) {
+        registry.register("Shortcut+K", "Command Palette",
+                "Open the command palette",
+                commandPaletteVm::show);
+        registry.register("Shortcut+F", "Find",
+                "Toggle the search panel",
+                searchViewModel::toggleVisible);
+        registry.register("Shortcut+N", "New Note",
+                "Create a new child note", () -> {
+                    UUID parentId =
+                            winCtx.selectedNoteId().get();
+                    if (parentId != null) {
+                        sharedServices.noteService()
+                                .createChildNote(parentId,
+                                        "Untitled");
+                        setup.appState().notifyDataChanged();
+                    }
+                });
+        registry.register("Shortcut+Shift+N", "New Window",
+                "Open a new window", () -> {
+                    try {
+                        WindowFactory.openNewWindow(
+                                sharedServices, windowManager);
+                    } catch (java.io.IOException ex) {
+                        LOG.error("Failed to open new window", ex);
+                    }
+                });
+        registry.register("Shortcut+D", "Delete Note",
+                "Delete the selected note", () -> {
+                    UUID noteId =
+                            winCtx.selectedNoteId().get();
+                    if (noteId != null && !noteId.equals(
+                            project.getRootNote().getId())) {
+                        sharedServices.noteService()
+                                .deleteNote(noteId);
+                        setup.appState().notifyDataChanged();
+                    }
+                });
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -204,10 +204,10 @@ public class App extends Application {
             Project project) {
         registry.register("Shortcut+K", "Command Palette",
                 "Open the command palette",
-                commandPaletteVm::show);
+                commandPaletteVm::show, true);
         registry.register("Shortcut+F", "Find",
                 "Toggle the search panel",
-                searchViewModel::toggleVisible);
+                searchViewModel::toggleVisible, true);
         registry.register("Shortcut+N", "New Note",
                 "Create a new child note", () -> {
                     UUID parentId =

--- a/src/main/java/com/embervault/CommandPaletteOverlay.java
+++ b/src/main/java/com/embervault/CommandPaletteOverlay.java
@@ -1,0 +1,143 @@
+package com.embervault;
+
+import com.embervault.adapter.in.ui.viewmodel.CommandPaletteViewModel;
+import com.embervault.adapter.in.ui.viewmodel.ShortcutAction;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+
+/**
+ * Overlay UI for the command palette.
+ *
+ * <p>A centered popup with a search field and a list of matching
+ * shortcut actions. Bound to a {@link CommandPaletteViewModel}.</p>
+ */
+final class CommandPaletteOverlay {
+
+    private static final double PALETTE_WIDTH = 400;
+    private static final double PALETTE_MAX_HEIGHT = 300;
+
+    private final StackPane root;
+
+    CommandPaletteOverlay(CommandPaletteViewModel viewModel) {
+        TextField searchField = new TextField();
+        searchField.setPromptText("Type a command...");
+        searchField.textProperty()
+                .bindBidirectional(viewModel.queryProperty());
+
+        ListView<ShortcutAction> listView = new ListView<>();
+        listView.setItems(viewModel.getFilteredActions());
+        listView.setMaxHeight(PALETTE_MAX_HEIGHT);
+        listView.setCellFactory(lv -> new ShortcutCell());
+
+        VBox palette = new VBox(4, searchField, listView);
+        palette.setPadding(new Insets(8));
+        palette.setMaxWidth(PALETTE_WIDTH);
+        palette.setMaxHeight(PALETTE_MAX_HEIGHT + 50);
+        palette.setStyle(
+                "-fx-background-color: -fx-background;"
+                + " -fx-border-color: -fx-accent;"
+                + " -fx-border-radius: 4;"
+                + " -fx-background-radius: 4;"
+                + " -fx-effect: dropshadow(gaussian, "
+                + "rgba(0,0,0,0.3), 10, 0, 0, 4);");
+
+        root = new StackPane(palette);
+        root.setAlignment(Pos.TOP_CENTER);
+        root.setPadding(new Insets(80, 0, 0, 0));
+        root.setPickOnBounds(false);
+        root.visibleProperty().bind(viewModel.visibleProperty());
+        root.managedProperty().bind(viewModel.visibleProperty());
+
+        // Focus search field when shown
+        viewModel.visibleProperty().addListener((obs, was, is) -> {
+            if (is) {
+                searchField.requestFocus();
+            }
+        });
+
+        // Escape hides the palette
+        searchField.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ESCAPE) {
+                viewModel.hide();
+                event.consume();
+            } else if (event.getCode() == KeyCode.ENTER) {
+                if (!listView.getItems().isEmpty()) {
+                    ShortcutAction selected =
+                            listView.getSelectionModel()
+                                    .getSelectedItem();
+                    if (selected == null) {
+                        selected = listView.getItems().get(0);
+                    }
+                    viewModel.executeSelected(selected);
+                }
+                event.consume();
+            } else if (event.getCode() == KeyCode.DOWN) {
+                listView.requestFocus();
+                listView.getSelectionModel().selectFirst();
+                event.consume();
+            }
+        });
+
+        listView.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ESCAPE) {
+                viewModel.hide();
+                event.consume();
+            } else if (event.getCode() == KeyCode.ENTER) {
+                ShortcutAction selected =
+                        listView.getSelectionModel()
+                                .getSelectedItem();
+                if (selected != null) {
+                    viewModel.executeSelected(selected);
+                }
+                event.consume();
+            }
+        });
+
+        // Click on backdrop hides palette
+        root.setOnMouseClicked(event -> {
+            if (event.getTarget() == root) {
+                viewModel.hide();
+            }
+        });
+    }
+
+    Node getNode() {
+        return root;
+    }
+
+    private static final class ShortcutCell
+            extends ListCell<ShortcutAction> {
+        @Override
+        protected void updateItem(ShortcutAction item,
+                boolean empty) {
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                Label nameLabel = new Label(item.name());
+                nameLabel.setStyle("-fx-font-weight: bold;");
+                Label keyLabel =
+                        new Label(item.keyCombination());
+                keyLabel.setStyle(
+                        "-fx-text-fill: -fx-mid-text-color;");
+                HBox row = new HBox(nameLabel);
+                HBox.setHgrow(nameLabel, Priority.ALWAYS);
+                nameLabel.setMaxWidth(Double.MAX_VALUE);
+                row.getChildren().add(keyLabel);
+                row.setSpacing(8);
+                setGraphic(row);
+            }
+        }
+    }
+}

--- a/src/main/java/com/embervault/CommandPaletteOverlay.java
+++ b/src/main/java/com/embervault/CommandPaletteOverlay.java
@@ -54,14 +54,16 @@ final class CommandPaletteOverlay {
         root = new StackPane(palette);
         root.setAlignment(Pos.TOP_CENTER);
         root.setPadding(new Insets(80, 0, 0, 0));
-        root.setPickOnBounds(false);
         root.visibleProperty().bind(viewModel.visibleProperty());
         root.managedProperty().bind(viewModel.visibleProperty());
 
         // Focus search field when shown
         viewModel.visibleProperty().addListener((obs, was, is) -> {
             if (is) {
+                root.setPickOnBounds(true);
                 searchField.requestFocus();
+            } else {
+                root.setPickOnBounds(false);
             }
         });
 

--- a/src/main/java/com/embervault/ShortcutInstaller.java
+++ b/src/main/java/com/embervault/ShortcutInstaller.java
@@ -2,7 +2,9 @@ package com.embervault;
 
 import com.embervault.adapter.in.ui.viewmodel.ShortcutAction;
 import com.embervault.adapter.in.ui.viewmodel.ShortcutRegistry;
+import javafx.scene.Node;
 import javafx.scene.Scene;
+import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import org.slf4j.Logger;
@@ -31,7 +33,11 @@ final class ShortcutInstaller {
      */
     static void install(Scene scene, ShortcutRegistry registry) {
         scene.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            boolean editing = isTextEditing(scene);
             for (ShortcutAction action : registry.getAll()) {
+                if (editing && !action.global()) {
+                    continue;
+                }
                 try {
                     KeyCombination combo =
                             KeyCombination.valueOf(
@@ -47,5 +53,10 @@ final class ShortcutInstaller {
                 }
             }
         });
+    }
+
+    private static boolean isTextEditing(Scene scene) {
+        Node focus = scene.getFocusOwner();
+        return focus instanceof TextInputControl;
     }
 }

--- a/src/main/java/com/embervault/ShortcutInstaller.java
+++ b/src/main/java/com/embervault/ShortcutInstaller.java
@@ -1,0 +1,51 @@
+package com.embervault;
+
+import com.embervault.adapter.in.ui.viewmodel.ShortcutAction;
+import com.embervault.adapter.in.ui.viewmodel.ShortcutRegistry;
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Installs {@link ShortcutRegistry} actions as scene-level key event filters.
+ *
+ * <p>Translates the registry's string-based key combinations into JavaFX
+ * {@link KeyCombination} objects and adds a single event filter to the
+ * scene that dispatches matching key events to the registered actions.</p>
+ */
+final class ShortcutInstaller {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ShortcutInstaller.class);
+
+    private ShortcutInstaller() { }
+
+    /**
+     * Installs a key event filter on the given scene that routes key
+     * presses to matching actions in the registry.
+     *
+     * @param scene    the scene to install the filter on
+     * @param registry the shortcut registry to consult
+     */
+    static void install(Scene scene, ShortcutRegistry registry) {
+        scene.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            for (ShortcutAction action : registry.getAll()) {
+                try {
+                    KeyCombination combo =
+                            KeyCombination.valueOf(
+                                    action.keyCombination());
+                    if (combo.match(event)) {
+                        action.action().run();
+                        event.consume();
+                        return;
+                    }
+                } catch (IllegalArgumentException e) {
+                    LOG.warn("Invalid key combination: {}",
+                            action.keyCombination(), e);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModel.java
@@ -16,61 +16,61 @@ import javafx.collections.ObservableList;
  * from the {@link ShortcutRegistry}, and a visibility flag for
  * toggling the palette open/closed.</p>
  */
-class CommandPaletteViewModel {
+public class CommandPaletteViewModel {
 
-  private final ShortcutRegistry registry;
-  private final BooleanProperty visible =
-      new SimpleBooleanProperty(false);
-  private final StringProperty query =
-      new SimpleStringProperty("");
-  private final ObservableList<ShortcutAction> filteredActions =
-      FXCollections.observableArrayList();
+    private final ShortcutRegistry registry;
+    private final BooleanProperty visible =
+            new SimpleBooleanProperty(false);
+    private final StringProperty query =
+            new SimpleStringProperty("");
+    private final ObservableList<ShortcutAction> filteredActions =
+            FXCollections.observableArrayList();
 
-  CommandPaletteViewModel(ShortcutRegistry registry) {
-    this.registry = registry;
-    query.addListener((obs, oldVal, newVal) -> updateFilter());
-  }
+    public CommandPaletteViewModel(ShortcutRegistry registry) {
+        this.registry = registry;
+        query.addListener((obs, oldVal, newVal) -> updateFilter());
+    }
 
-  BooleanProperty visibleProperty() {
-    return visible;
-  }
+    public BooleanProperty visibleProperty() {
+        return visible;
+    }
 
-  StringProperty queryProperty() {
-    return query;
-  }
+    public StringProperty queryProperty() {
+        return query;
+    }
 
-  ObservableList<ShortcutAction> getFilteredActions() {
-    return filteredActions;
-  }
+    public ObservableList<ShortcutAction> getFilteredActions() {
+        return filteredActions;
+    }
 
-  /**
-   * Shows the command palette with all shortcuts visible.
-   */
-  void show() {
-    visible.set(true);
-    updateFilter();
-  }
+    /**
+     * Shows the command palette with all shortcuts visible.
+     */
+    public void show() {
+        visible.set(true);
+        updateFilter();
+    }
 
-  /**
-   * Hides the command palette and resets the query.
-   */
-  void hide() {
-    visible.set(false);
-    query.set("");
-  }
+    /**
+     * Hides the command palette and resets the query.
+     */
+    public void hide() {
+        visible.set(false);
+        query.set("");
+    }
 
-  /**
-   * Executes the given action and hides the palette.
-   *
-   * @param action the shortcut action to execute
-   */
-  void executeSelected(ShortcutAction action) {
-    action.action().run();
-    hide();
-  }
+    /**
+     * Executes the given action and hides the palette.
+     *
+     * @param action the shortcut action to execute
+     */
+    public void executeSelected(ShortcutAction action) {
+        action.action().run();
+        hide();
+    }
 
-  private void updateFilter() {
-    List<ShortcutAction> results = registry.search(query.get());
-    filteredActions.setAll(results);
-  }
+    private void updateFilter() {
+        List<ShortcutAction> results = registry.search(query.get());
+        filteredActions.setAll(results);
+    }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModel.java
@@ -1,0 +1,76 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.List;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * ViewModel for the command palette overlay.
+ *
+ * <p>Exposes a query property that filters registered shortcuts
+ * from the {@link ShortcutRegistry}, and a visibility flag for
+ * toggling the palette open/closed.</p>
+ */
+class CommandPaletteViewModel {
+
+  private final ShortcutRegistry registry;
+  private final BooleanProperty visible =
+      new SimpleBooleanProperty(false);
+  private final StringProperty query =
+      new SimpleStringProperty("");
+  private final ObservableList<ShortcutAction> filteredActions =
+      FXCollections.observableArrayList();
+
+  CommandPaletteViewModel(ShortcutRegistry registry) {
+    this.registry = registry;
+    query.addListener((obs, oldVal, newVal) -> updateFilter());
+  }
+
+  BooleanProperty visibleProperty() {
+    return visible;
+  }
+
+  StringProperty queryProperty() {
+    return query;
+  }
+
+  ObservableList<ShortcutAction> getFilteredActions() {
+    return filteredActions;
+  }
+
+  /**
+   * Shows the command palette with all shortcuts visible.
+   */
+  void show() {
+    visible.set(true);
+    updateFilter();
+  }
+
+  /**
+   * Hides the command palette and resets the query.
+   */
+  void hide() {
+    visible.set(false);
+    query.set("");
+  }
+
+  /**
+   * Executes the given action and hides the palette.
+   *
+   * @param action the shortcut action to execute
+   */
+  void executeSelected(ShortcutAction action) {
+    action.action().run();
+    hide();
+  }
+
+  private void updateFilter() {
+    List<ShortcutAction> results = registry.search(query.get());
+    filteredActions.setAll(results);
+  }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutAction.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutAction.java
@@ -1,0 +1,17 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+/**
+ * A named action bound to a keyboard shortcut.
+ *
+ * @param keyCombination string representation of the key combination
+ *                       (e.g. "Shortcut+N", "Shortcut+Shift+N")
+ * @param name           human-readable name for display
+ * @param description    longer description for tooltips or command palette
+ * @param action         the runnable to execute when the shortcut is triggered
+ */
+record ShortcutAction(
+    String keyCombination,
+    String name,
+    String description,
+    Runnable action) {
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutAction.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutAction.java
@@ -7,11 +7,16 @@ package com.embervault.adapter.in.ui.viewmodel;
  *                       (e.g. "Shortcut+N", "Shortcut+Shift+N")
  * @param name           human-readable name for display
  * @param description    longer description for tooltips or command palette
- * @param action         the runnable to execute when the shortcut is triggered
+ * @param action         the runnable to execute when the shortcut
+ *                       is triggered
+ * @param global         if true, this shortcut fires even when a text
+ *                       input control has focus; if false, it is
+ *                       suppressed during text editing
  */
 public record ShortcutAction(
         String keyCombination,
         String name,
         String description,
-        Runnable action) {
+        Runnable action,
+        boolean global) {
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutAction.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutAction.java
@@ -9,9 +9,9 @@ package com.embervault.adapter.in.ui.viewmodel;
  * @param description    longer description for tooltips or command palette
  * @param action         the runnable to execute when the shortcut is triggered
  */
-record ShortcutAction(
-    String keyCombination,
-    String name,
-    String description,
-    Runnable action) {
+public record ShortcutAction(
+        String keyCombination,
+        String name,
+        String description,
+        Runnable action) {
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
@@ -1,0 +1,42 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Central registry of keyboard shortcut actions.
+ *
+ * <p>Maps string-based key combination descriptions to named actions.
+ * Uses strings rather than {@code javafx.scene.input.KeyCombination}
+ * to comply with ADR-0013 (ViewModels must not reference scene-graph classes).</p>
+ */
+class ShortcutRegistry {
+
+  private final Map<String, ShortcutAction> shortcuts =
+      new LinkedHashMap<>();
+
+  /**
+   * Registers a shortcut action.
+   *
+   * @param keyCombination string key combination (e.g. "Shortcut+N")
+   * @param name           human-readable name
+   * @param description    longer description
+   * @param action         runnable to execute
+   */
+  void register(String keyCombination, String name,
+      String description, Runnable action) {
+    shortcuts.put(keyCombination,
+        new ShortcutAction(keyCombination, name, description, action));
+  }
+
+  /**
+   * Looks up a shortcut action by its key combination string.
+   *
+   * @param keyCombination the key combination to look up
+   * @return the action if registered, or empty
+   */
+  Optional<ShortcutAction> lookup(String keyCombination) {
+    return Optional.ofNullable(shortcuts.get(keyCombination));
+  }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
@@ -1,6 +1,8 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,5 +40,14 @@ class ShortcutRegistry {
    */
   Optional<ShortcutAction> lookup(String keyCombination) {
     return Optional.ofNullable(shortcuts.get(keyCombination));
+  }
+
+  /**
+   * Returns all registered shortcut actions in insertion order.
+   *
+   * @return unmodifiable list of all actions
+   */
+  List<ShortcutAction> getAll() {
+    return List.copyOf(shortcuts.values());
   }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
@@ -13,74 +13,77 @@ import java.util.Optional;
  * Uses strings rather than {@code javafx.scene.input.KeyCombination}
  * to comply with ADR-0013 (ViewModels must not reference scene-graph classes).</p>
  */
-class ShortcutRegistry {
+public class ShortcutRegistry {
 
-  private final Map<String, ShortcutAction> shortcuts =
-      new LinkedHashMap<>();
+    private final Map<String, ShortcutAction> shortcuts =
+            new LinkedHashMap<>();
 
-  /**
-   * Registers a shortcut action.
-   *
-   * @param keyCombination string key combination (e.g. "Shortcut+N")
-   * @param name           human-readable name
-   * @param description    longer description
-   * @param action         runnable to execute
-   */
-  void register(String keyCombination, String name,
-      String description, Runnable action) {
-    shortcuts.put(keyCombination,
-        new ShortcutAction(keyCombination, name, description, action));
-  }
-
-  /**
-   * Looks up a shortcut action by its key combination string.
-   *
-   * @param keyCombination the key combination to look up
-   * @return the action if registered, or empty
-   */
-  Optional<ShortcutAction> lookup(String keyCombination) {
-    return Optional.ofNullable(shortcuts.get(keyCombination));
-  }
-
-  /**
-   * Removes a shortcut registration.
-   *
-   * @param keyCombination the key combination to unregister
-   */
-  void unregister(String keyCombination) {
-    shortcuts.remove(keyCombination);
-  }
-
-  /**
-   * Returns all registered shortcut actions in insertion order.
-   *
-   * @return unmodifiable list of all actions
-   */
-  List<ShortcutAction> getAll() {
-    return List.copyOf(shortcuts.values());
-  }
-
-  /**
-   * Searches registered shortcuts by name or description substring
-   * (case-insensitive). An empty query returns all shortcuts.
-   *
-   * @param query the search query
-   * @return matching actions in insertion order
-   */
-  List<ShortcutAction> search(String query) {
-    if (query == null || query.isEmpty()) {
-      return getAll();
+    /**
+     * Registers a shortcut action.
+     *
+     * @param keyCombination string key combination (e.g. "Shortcut+N")
+     * @param name           human-readable name
+     * @param description    longer description
+     * @param action         runnable to execute
+     */
+    public void register(String keyCombination, String name,
+            String description, Runnable action) {
+        shortcuts.put(keyCombination,
+                new ShortcutAction(keyCombination, name,
+                        description, action));
     }
-    String lowerQuery = query.toLowerCase();
-    List<ShortcutAction> results = new ArrayList<>();
-    for (ShortcutAction action : shortcuts.values()) {
-      if (action.name().toLowerCase().contains(lowerQuery)
-          || action.description().toLowerCase().contains(lowerQuery)
-          || action.keyCombination().toLowerCase()
-              .contains(lowerQuery)) {
-        results.add(action);
-      }
+
+    /**
+     * Looks up a shortcut action by its key combination string.
+     *
+     * @param keyCombination the key combination to look up
+     * @return the action if registered, or empty
+     */
+    public Optional<ShortcutAction> lookup(String keyCombination) {
+        return Optional.ofNullable(shortcuts.get(keyCombination));
     }
-    return results;
-  }
+
+    /**
+     * Removes a shortcut registration.
+     *
+     * @param keyCombination the key combination to unregister
+     */
+    public void unregister(String keyCombination) {
+        shortcuts.remove(keyCombination);
+    }
+
+    /**
+     * Returns all registered shortcut actions in insertion order.
+     *
+     * @return unmodifiable list of all actions
+     */
+    public List<ShortcutAction> getAll() {
+        return List.copyOf(shortcuts.values());
+    }
+
+    /**
+     * Searches registered shortcuts by name, description, or key
+     * combination substring (case-insensitive). An empty query
+     * returns all shortcuts.
+     *
+     * @param query the search query
+     * @return matching actions in insertion order
+     */
+    public List<ShortcutAction> search(String query) {
+        if (query == null || query.isEmpty()) {
+            return getAll();
+        }
+        String lowerQuery = query.toLowerCase();
+        List<ShortcutAction> results = new ArrayList<>();
+        for (ShortcutAction action : shortcuts.values()) {
+            if (action.name().toLowerCase().contains(lowerQuery)
+                    || action.description().toLowerCase()
+                            .contains(lowerQuery)
+                    || action.keyCombination().toLowerCase()
+                            .contains(lowerQuery)) {
+                results.add(action);
+            }
+        }
+        return results;
+    }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
@@ -28,9 +28,24 @@ public class ShortcutRegistry {
      */
     public void register(String keyCombination, String name,
             String description, Runnable action) {
+        register(keyCombination, name, description, action, false);
+    }
+
+    /**
+     * Registers a shortcut action with explicit global flag.
+     *
+     * @param keyCombination string key combination
+     * @param name           human-readable name
+     * @param description    longer description
+     * @param action         runnable to execute
+     * @param global         true if this shortcut should fire even
+     *                       when a text input has focus
+     */
+    public void register(String keyCombination, String name,
+            String description, Runnable action, boolean global) {
         shortcuts.put(keyCombination,
                 new ShortcutAction(keyCombination, name,
-                        description, action));
+                        description, action, global));
     }
 
     /**

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
@@ -43,6 +43,15 @@ class ShortcutRegistry {
   }
 
   /**
+   * Removes a shortcut registration.
+   *
+   * @param keyCombination the key combination to unregister
+   */
+  void unregister(String keyCombination) {
+    shortcuts.remove(keyCombination);
+  }
+
+  /**
    * Returns all registered shortcut actions in insertion order.
    *
    * @return unmodifiable list of all actions
@@ -66,7 +75,9 @@ class ShortcutRegistry {
     List<ShortcutAction> results = new ArrayList<>();
     for (ShortcutAction action : shortcuts.values()) {
       if (action.name().toLowerCase().contains(lowerQuery)
-          || action.description().toLowerCase().contains(lowerQuery)) {
+          || action.description().toLowerCase().contains(lowerQuery)
+          || action.keyCombination().toLowerCase()
+              .contains(lowerQuery)) {
         results.add(action);
       }
     }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistry.java
@@ -50,4 +50,26 @@ class ShortcutRegistry {
   List<ShortcutAction> getAll() {
     return List.copyOf(shortcuts.values());
   }
+
+  /**
+   * Searches registered shortcuts by name or description substring
+   * (case-insensitive). An empty query returns all shortcuts.
+   *
+   * @param query the search query
+   * @return matching actions in insertion order
+   */
+  List<ShortcutAction> search(String query) {
+    if (query == null || query.isEmpty()) {
+      return getAll();
+    }
+    String lowerQuery = query.toLowerCase();
+    List<ShortcutAction> results = new ArrayList<>();
+    for (ShortcutAction action : shortcuts.values()) {
+      if (action.name().toLowerCase().contains(lowerQuery)
+          || action.description().toLowerCase().contains(lowerQuery)) {
+        results.add(action);
+      }
+    }
+    return results;
+  }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModelTest.java
@@ -10,71 +10,71 @@ import org.junit.jupiter.api.Test;
 
 class CommandPaletteViewModelTest {
 
-  private ShortcutRegistry registry;
-  private CommandPaletteViewModel viewModel;
+    private ShortcutRegistry registry;
+    private CommandPaletteViewModel viewModel;
 
-  @BeforeEach
-  void setUp() {
-    registry = new ShortcutRegistry();
-    registry.register("Shortcut+N", "New Note",
-        "Create a new note", () -> { });
-    registry.register("Shortcut+F", "Find",
-        "Open search", () -> { });
-    registry.register("Shortcut+S", "Save",
-        "Save project", () -> { });
-    viewModel = new CommandPaletteViewModel(registry);
-  }
+    @BeforeEach
+    void setUp() {
+        registry = new ShortcutRegistry();
+        registry.register("Shortcut+N", "New Note",
+                "Create a new note", () -> { });
+        registry.register("Shortcut+F", "Find",
+                "Open search", () -> { });
+        registry.register("Shortcut+S", "Save",
+                "Save project", () -> { });
+        viewModel = new CommandPaletteViewModel(registry);
+    }
 
-  @Test
-  @DisplayName("initially not visible")
-  void shouldBeHiddenInitially() {
-    assertFalse(viewModel.visibleProperty().get());
-  }
+    @Test
+    @DisplayName("initially not visible")
+    void shouldBeHiddenInitially() {
+        assertFalse(viewModel.visibleProperty().get());
+    }
 
-  @Test
-  @DisplayName("show makes palette visible and lists all shortcuts")
-  void show_shouldMakeVisibleAndListAll() {
-    viewModel.show();
+    @Test
+    @DisplayName("show makes palette visible and lists all shortcuts")
+    void show_shouldMakeVisibleAndListAll() {
+        viewModel.show();
 
-    assertTrue(viewModel.visibleProperty().get());
-    assertEquals(3, viewModel.getFilteredActions().size());
-  }
+        assertTrue(viewModel.visibleProperty().get());
+        assertEquals(3, viewModel.getFilteredActions().size());
+    }
 
-  @Test
-  @DisplayName("hide clears visibility and query")
-  void hide_shouldClearVisibilityAndQuery() {
-    viewModel.show();
-    viewModel.queryProperty().set("note");
-    viewModel.hide();
+    @Test
+    @DisplayName("hide clears visibility and query")
+    void hide_shouldClearVisibilityAndQuery() {
+        viewModel.show();
+        viewModel.queryProperty().set("note");
+        viewModel.hide();
 
-    assertFalse(viewModel.visibleProperty().get());
-    assertEquals("", viewModel.queryProperty().get());
-  }
+        assertFalse(viewModel.visibleProperty().get());
+        assertEquals("", viewModel.queryProperty().get());
+    }
 
-  @Test
-  @DisplayName("query filters the action list")
-  void query_shouldFilterActions() {
-    viewModel.show();
-    viewModel.queryProperty().set("note");
+    @Test
+    @DisplayName("query filters the action list")
+    void query_shouldFilterActions() {
+        viewModel.show();
+        viewModel.queryProperty().set("note");
 
-    assertEquals(1, viewModel.getFilteredActions().size());
-    assertEquals("New Note",
-        viewModel.getFilteredActions().get(0).name());
-  }
+        assertEquals(1, viewModel.getFilteredActions().size());
+        assertEquals("New Note",
+                viewModel.getFilteredActions().get(0).name());
+    }
 
-  @Test
-  @DisplayName("execute runs the selected action and hides palette")
-  void execute_shouldRunActionAndHide() {
-    boolean[] executed = {false};
-    registry.register("Shortcut+T", "Test Action",
-        "Test", () -> executed[0] = true);
-    viewModel.show();
-    viewModel.queryProperty().set("test");
+    @Test
+    @DisplayName("execute runs the selected action and hides palette")
+    void execute_shouldRunActionAndHide() {
+        boolean[] executed = {false};
+        registry.register("Shortcut+T", "Test Action",
+                "Test", () -> executed[0] = true);
+        viewModel.show();
+        viewModel.queryProperty().set("test");
 
-    viewModel.executeSelected(
-        viewModel.getFilteredActions().get(0));
+        viewModel.executeSelected(
+                viewModel.getFilteredActions().get(0));
 
-    assertTrue(executed[0]);
-    assertFalse(viewModel.visibleProperty().get());
-  }
+        assertTrue(executed[0]);
+        assertFalse(viewModel.visibleProperty().get());
+    }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/CommandPaletteViewModelTest.java
@@ -1,0 +1,80 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommandPaletteViewModelTest {
+
+  private ShortcutRegistry registry;
+  private CommandPaletteViewModel viewModel;
+
+  @BeforeEach
+  void setUp() {
+    registry = new ShortcutRegistry();
+    registry.register("Shortcut+N", "New Note",
+        "Create a new note", () -> { });
+    registry.register("Shortcut+F", "Find",
+        "Open search", () -> { });
+    registry.register("Shortcut+S", "Save",
+        "Save project", () -> { });
+    viewModel = new CommandPaletteViewModel(registry);
+  }
+
+  @Test
+  @DisplayName("initially not visible")
+  void shouldBeHiddenInitially() {
+    assertFalse(viewModel.visibleProperty().get());
+  }
+
+  @Test
+  @DisplayName("show makes palette visible and lists all shortcuts")
+  void show_shouldMakeVisibleAndListAll() {
+    viewModel.show();
+
+    assertTrue(viewModel.visibleProperty().get());
+    assertEquals(3, viewModel.getFilteredActions().size());
+  }
+
+  @Test
+  @DisplayName("hide clears visibility and query")
+  void hide_shouldClearVisibilityAndQuery() {
+    viewModel.show();
+    viewModel.queryProperty().set("note");
+    viewModel.hide();
+
+    assertFalse(viewModel.visibleProperty().get());
+    assertEquals("", viewModel.queryProperty().get());
+  }
+
+  @Test
+  @DisplayName("query filters the action list")
+  void query_shouldFilterActions() {
+    viewModel.show();
+    viewModel.queryProperty().set("note");
+
+    assertEquals(1, viewModel.getFilteredActions().size());
+    assertEquals("New Note",
+        viewModel.getFilteredActions().get(0).name());
+  }
+
+  @Test
+  @DisplayName("execute runs the selected action and hides palette")
+  void execute_shouldRunActionAndHide() {
+    boolean[] executed = {false};
+    registry.register("Shortcut+T", "Test Action",
+        "Test", () -> executed[0] = true);
+    viewModel.show();
+    viewModel.queryProperty().set("test");
+
+    viewModel.executeSelected(
+        viewModel.getFilteredActions().get(0));
+
+    assertTrue(executed[0]);
+    assertFalse(viewModel.visibleProperty().get());
+  }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
@@ -58,4 +58,46 @@ class ShortcutRegistryTest {
 
     assertTrue(result.isEmpty());
   }
+
+  @Test
+  @DisplayName("search filters shortcuts by name substring (case-insensitive)")
+  void search_shouldFilterByNameCaseInsensitive() {
+    registry.register("Shortcut+N", "New Note",
+        "Create a new note", () -> { });
+    registry.register("Shortcut+F", "Find",
+        "Open search", () -> { });
+    registry.register("Shortcut+Shift+N", "New Child Note",
+        "Create child note", () -> { });
+
+    List<ShortcutAction> results = registry.search("new");
+
+    assertEquals(2, results.size());
+    assertEquals("New Note", results.get(0).name());
+    assertEquals("New Child Note", results.get(1).name());
+  }
+
+  @Test
+  @DisplayName("search also matches description substring")
+  void search_shouldMatchDescription() {
+    registry.register("Shortcut+F", "Find",
+        "Open search panel", () -> { });
+
+    List<ShortcutAction> results = registry.search("search");
+
+    assertEquals(1, results.size());
+    assertEquals("Find", results.get(0).name());
+  }
+
+  @Test
+  @DisplayName("search with empty query returns all shortcuts")
+  void search_shouldReturnAllForEmptyQuery() {
+    registry.register("Shortcut+N", "New Note",
+        "Create note", () -> { });
+    registry.register("Shortcut+F", "Find",
+        "Open search", () -> { });
+
+    List<ShortcutAction> results = registry.search("");
+
+    assertEquals(2, results.size());
+  }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
@@ -12,127 +12,129 @@ import org.junit.jupiter.api.Test;
 
 class ShortcutRegistryTest {
 
-  private ShortcutRegistry registry;
+    private ShortcutRegistry registry;
 
-  @BeforeEach
-  void setUp() {
-    registry = new ShortcutRegistry();
-  }
+    @BeforeEach
+    void setUp() {
+        registry = new ShortcutRegistry();
+    }
 
-  @Test
-  @DisplayName("register and retrieve a shortcut action by key combination")
-  void register_shouldAllowRetrievalByKeyCombination() {
-    Runnable action = () -> { };
-    registry.register("Shortcut+N", "New Note",
-        "Create a new note", action);
+    @Test
+    @DisplayName("register and retrieve a shortcut action by key combination")
+    void register_shouldAllowRetrievalByKeyCombination() {
+        Runnable action = () -> { };
+        registry.register("Shortcut+N", "New Note",
+                "Create a new note", action);
 
-    Optional<ShortcutAction> result =
-        registry.lookup("Shortcut+N");
+        Optional<ShortcutAction> result =
+                registry.lookup("Shortcut+N");
 
-    assertTrue(result.isPresent());
-    assertEquals("New Note", result.get().name());
-    assertEquals("Create a new note", result.get().description());
-    assertEquals(action, result.get().action());
-  }
+        assertTrue(result.isPresent());
+        assertEquals("New Note", result.get().name());
+        assertEquals("Create a new note",
+                result.get().description());
+        assertEquals(action, result.get().action());
+    }
 
-  @Test
-  @DisplayName("getAll returns all registered shortcuts in insertion order")
-  void getAll_shouldReturnAllRegisteredShortcuts() {
-    registry.register("Shortcut+N", "New Note",
-        "Create a new note", () -> { });
-    registry.register("Shortcut+F", "Find",
-        "Open search", () -> { });
+    @Test
+    @DisplayName("getAll returns all registered shortcuts in insertion order")
+    void getAll_shouldReturnAllRegisteredShortcuts() {
+        registry.register("Shortcut+N", "New Note",
+                "Create a new note", () -> { });
+        registry.register("Shortcut+F", "Find",
+                "Open search", () -> { });
 
-    List<ShortcutAction> all = registry.getAll();
+        List<ShortcutAction> all = registry.getAll();
 
-    assertEquals(2, all.size());
-    assertEquals("New Note", all.get(0).name());
-    assertEquals("Find", all.get(1).name());
-  }
+        assertEquals(2, all.size());
+        assertEquals("New Note", all.get(0).name());
+        assertEquals("Find", all.get(1).name());
+    }
 
-  @Test
-  @DisplayName("lookup returns empty for unregistered key combination")
-  void lookup_shouldReturnEmptyForUnregisteredKey() {
-    Optional<ShortcutAction> result =
-        registry.lookup("Shortcut+Z");
+    @Test
+    @DisplayName("lookup returns empty for unregistered key combination")
+    void lookup_shouldReturnEmptyForUnregisteredKey() {
+        Optional<ShortcutAction> result =
+                registry.lookup("Shortcut+Z");
 
-    assertTrue(result.isEmpty());
-  }
+        assertTrue(result.isEmpty());
+    }
 
-  @Test
-  @DisplayName("search filters shortcuts by name substring (case-insensitive)")
-  void search_shouldFilterByNameCaseInsensitive() {
-    registry.register("Shortcut+N", "New Note",
-        "Create a new note", () -> { });
-    registry.register("Shortcut+F", "Find",
-        "Open search", () -> { });
-    registry.register("Shortcut+Shift+N", "New Child Note",
-        "Create child note", () -> { });
+    @Test
+    @DisplayName("search filters shortcuts by name substring (case-insensitive)")
+    void search_shouldFilterByNameCaseInsensitive() {
+        registry.register("Shortcut+N", "New Note",
+                "Create a new note", () -> { });
+        registry.register("Shortcut+F", "Find",
+                "Open search", () -> { });
+        registry.register("Shortcut+Shift+N", "New Child Note",
+                "Create child note", () -> { });
 
-    List<ShortcutAction> results = registry.search("new");
+        List<ShortcutAction> results = registry.search("new");
 
-    assertEquals(2, results.size());
-    assertEquals("New Note", results.get(0).name());
-    assertEquals("New Child Note", results.get(1).name());
-  }
+        assertEquals(2, results.size());
+        assertEquals("New Note", results.get(0).name());
+        assertEquals("New Child Note", results.get(1).name());
+    }
 
-  @Test
-  @DisplayName("search also matches description substring")
-  void search_shouldMatchDescription() {
-    registry.register("Shortcut+F", "Find",
-        "Open search panel", () -> { });
+    @Test
+    @DisplayName("search also matches description substring")
+    void search_shouldMatchDescription() {
+        registry.register("Shortcut+F", "Find",
+                "Open search panel", () -> { });
 
-    List<ShortcutAction> results = registry.search("search");
+        List<ShortcutAction> results = registry.search("search");
 
-    assertEquals(1, results.size());
-    assertEquals("Find", results.get(0).name());
-  }
+        assertEquals(1, results.size());
+        assertEquals("Find", results.get(0).name());
+    }
 
-  @Test
-  @DisplayName("search with empty query returns all shortcuts")
-  void search_shouldReturnAllForEmptyQuery() {
-    registry.register("Shortcut+N", "New Note",
-        "Create note", () -> { });
-    registry.register("Shortcut+F", "Find",
-        "Open search", () -> { });
+    @Test
+    @DisplayName("search with empty query returns all shortcuts")
+    void search_shouldReturnAllForEmptyQuery() {
+        registry.register("Shortcut+N", "New Note",
+                "Create note", () -> { });
+        registry.register("Shortcut+F", "Find",
+                "Open search", () -> { });
 
-    List<ShortcutAction> results = registry.search("");
+        List<ShortcutAction> results = registry.search("");
 
-    assertEquals(2, results.size());
-  }
+        assertEquals(2, results.size());
+    }
 
-  @Test
-  @DisplayName("registering duplicate key replaces previous action")
-  void register_shouldReplaceDuplicateKey() {
-    registry.register("Shortcut+N", "Old Action",
-        "Old description", () -> { });
-    registry.register("Shortcut+N", "New Action",
-        "New description", () -> { });
+    @Test
+    @DisplayName("registering duplicate key replaces previous action")
+    void register_shouldReplaceDuplicateKey() {
+        registry.register("Shortcut+N", "Old Action",
+                "Old description", () -> { });
+        registry.register("Shortcut+N", "New Action",
+                "New description", () -> { });
 
-    assertEquals(1, registry.getAll().size());
-    assertEquals("New Action",
-        registry.lookup("Shortcut+N").get().name());
-  }
+        assertEquals(1, registry.getAll().size());
+        assertEquals("New Action",
+                registry.lookup("Shortcut+N").get().name());
+    }
 
-  @Test
-  @DisplayName("unregister removes a shortcut by key combination")
-  void unregister_shouldRemoveShortcut() {
-    registry.register("Shortcut+N", "New Note",
-        "Create note", () -> { });
-    registry.unregister("Shortcut+N");
+    @Test
+    @DisplayName("unregister removes a shortcut by key combination")
+    void unregister_shouldRemoveShortcut() {
+        registry.register("Shortcut+N", "New Note",
+                "Create note", () -> { });
+        registry.unregister("Shortcut+N");
 
-    assertTrue(registry.lookup("Shortcut+N").isEmpty());
-    assertEquals(0, registry.getAll().size());
-  }
+        assertTrue(registry.lookup("Shortcut+N").isEmpty());
+        assertEquals(0, registry.getAll().size());
+    }
 
-  @Test
-  @DisplayName("search also matches key combination string")
-  void search_shouldMatchKeyCombination() {
-    registry.register("Shortcut+N", "New Note",
-        "Create note", () -> { });
+    @Test
+    @DisplayName("search also matches key combination string")
+    void search_shouldMatchKeyCombination() {
+        registry.register("Shortcut+N", "New Note",
+                "Create note", () -> { });
 
-    List<ShortcutAction> results = registry.search("Shortcut+N");
+        List<ShortcutAction> results =
+                registry.search("Shortcut+N");
 
-    assertEquals(1, results.size());
-  }
+        assertEquals(1, results.size());
+    }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
@@ -3,6 +3,7 @@ package com.embervault.adapter.in.ui.viewmodel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,5 +33,29 @@ class ShortcutRegistryTest {
     assertEquals("New Note", result.get().name());
     assertEquals("Create a new note", result.get().description());
     assertEquals(action, result.get().action());
+  }
+
+  @Test
+  @DisplayName("getAll returns all registered shortcuts in insertion order")
+  void getAll_shouldReturnAllRegisteredShortcuts() {
+    registry.register("Shortcut+N", "New Note",
+        "Create a new note", () -> { });
+    registry.register("Shortcut+F", "Find",
+        "Open search", () -> { });
+
+    List<ShortcutAction> all = registry.getAll();
+
+    assertEquals(2, all.size());
+    assertEquals("New Note", all.get(0).name());
+    assertEquals("Find", all.get(1).name());
+  }
+
+  @Test
+  @DisplayName("lookup returns empty for unregistered key combination")
+  void lookup_shouldReturnEmptyForUnregisteredKey() {
+    Optional<ShortcutAction> result =
+        registry.lookup("Shortcut+Z");
+
+    assertTrue(result.isEmpty());
   }
 }

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
@@ -1,0 +1,36 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ShortcutRegistryTest {
+
+  private ShortcutRegistry registry;
+
+  @BeforeEach
+  void setUp() {
+    registry = new ShortcutRegistry();
+  }
+
+  @Test
+  @DisplayName("register and retrieve a shortcut action by key combination")
+  void register_shouldAllowRetrievalByKeyCombination() {
+    Runnable action = () -> { };
+    registry.register("Shortcut+N", "New Note",
+        "Create a new note", action);
+
+    Optional<ShortcutAction> result =
+        registry.lookup("Shortcut+N");
+
+    assertTrue(result.isPresent());
+    assertEquals("New Note", result.get().name());
+    assertEquals("Create a new note", result.get().description());
+    assertEquals(action, result.get().action());
+  }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/ShortcutRegistryTest.java
@@ -100,4 +100,39 @@ class ShortcutRegistryTest {
 
     assertEquals(2, results.size());
   }
+
+  @Test
+  @DisplayName("registering duplicate key replaces previous action")
+  void register_shouldReplaceDuplicateKey() {
+    registry.register("Shortcut+N", "Old Action",
+        "Old description", () -> { });
+    registry.register("Shortcut+N", "New Action",
+        "New description", () -> { });
+
+    assertEquals(1, registry.getAll().size());
+    assertEquals("New Action",
+        registry.lookup("Shortcut+N").get().name());
+  }
+
+  @Test
+  @DisplayName("unregister removes a shortcut by key combination")
+  void unregister_shouldRemoveShortcut() {
+    registry.register("Shortcut+N", "New Note",
+        "Create note", () -> { });
+    registry.unregister("Shortcut+N");
+
+    assertTrue(registry.lookup("Shortcut+N").isEmpty());
+    assertEquals(0, registry.getAll().size());
+  }
+
+  @Test
+  @DisplayName("search also matches key combination string")
+  void search_shouldMatchKeyCombination() {
+    registry.register("Shortcut+N", "New Note",
+        "Create note", () -> { });
+
+    List<ShortcutAction> results = registry.search("Shortcut+N");
+
+    assertEquals(1, results.size());
+  }
 }


### PR DESCRIPTION
## Summary
- Add `ShortcutRegistry` class (viewmodel layer) that maps string key combinations to named `ShortcutAction` records, with search/lookup/unregister support
- Add `CommandPaletteViewModel` with observable query filtering over registered shortcuts, visibility toggle, and action execution
- Add `CommandPaletteOverlay` UI with search field and ListView, opened via Cmd+K / Ctrl+K
- Add `ShortcutInstaller` to translate string key combos into JavaFX `KeyCombination` objects and install a single scene-level event filter
- Register existing shortcuts centrally in App.java: Cmd+K (palette), Cmd+F (find), Cmd+N (new note), Cmd+Shift+N (new window), Cmd+D (delete note)
- Uses string-based key representations in registry to comply with ADR-0013 (ViewModels must not reference javafx.scene classes)

## Test plan
- [ ] `ShortcutRegistryTest` — register, lookup, getAll, unregister, duplicate-key replacement, search by name/description/key combo
- [ ] `CommandPaletteViewModelTest` — visibility toggle, query filtering, execute-and-hide behavior
- [ ] All existing tests pass (`mvn verify` green)
- [ ] ArchUnit rules pass (no javafx.scene dependency in viewmodel layer)
- [ ] Checkstyle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>