### PR TITLE
Add multi-format export (JSON, Markdown, OPML) (#264)

### DIFF
--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -134,17 +134,23 @@ final class MenuBarFactory {
 
     private static void doExport(WindowContext ctx,
             ExportFormat format, String desc, String ext) {
+        String suffix = ext.replace("*", "");
         FileChooser chooser = new FileChooser();
         chooser.setTitle("Export as " + desc);
+        chooser.setInitialFileName("export" + suffix);
         chooser.getExtensionFilters().add(
                 new FileChooser.ExtensionFilter(desc, ext));
         File file = chooser.showSaveDialog(ctx.ownerStage());
         if (file != null) {
+            if (!file.getName().endsWith(suffix)) {
+                file = new File(file.getPath() + suffix);
+            }
             try {
                 createExportService(ctx)
                         .exportProject(format, file.toPath());
+                LOG.info("Exported {} to {}", desc, file);
             } catch (IOException ex) {
-                LOG.error("Export failed", ex);
+                LOG.error("Export to {} failed", file, ex);
             }
         }
     }
@@ -158,8 +164,9 @@ final class MenuBarFactory {
             try {
                 createExportService(ctx)
                         .exportProject(format, dir.toPath());
+                LOG.info("Exported Markdown to {}", dir);
             } catch (IOException ex) {
-                LOG.error("Export failed", ex);
+                LOG.error("Export to {} failed", dir, ex);
             }
         }
     }

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -8,8 +8,14 @@ import java.util.UUID;
 
 import com.embervault.adapter.in.ui.view.StampEditorViewController;
 import com.embervault.adapter.in.ui.viewmodel.StampEditorViewModel;
+import com.embervault.adapter.out.persistence.JsonExportAdapter;
+import com.embervault.adapter.out.persistence.MarkdownExportAdapter;
+import com.embervault.adapter.out.persistence.OpmlExportAdapter;
 import com.embervault.adapter.out.persistence.ProjectFileManager;
+import com.embervault.application.ExportServiceImpl;
+import com.embervault.application.port.in.ExportProjectUseCase;
 import com.embervault.application.port.in.StampService;
+import com.embervault.domain.ExportFormat;
 import com.embervault.domain.Stamp;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -22,6 +28,7 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,9 +107,75 @@ final class MenuBarFactory {
             }
         });
 
+        Menu exportMenu = buildExportMenu(ctx);
+
         Menu menu = new Menu("File");
-        menu.getItems().addAll(openItem, saveItem);
+        menu.getItems().addAll(openItem, saveItem,
+                new SeparatorMenuItem(), exportMenu);
         return menu;
+    }
+
+    private static Menu buildExportMenu(WindowContext ctx) {
+        MenuItem jsonItem = new MenuItem("JSON...");
+        jsonItem.setOnAction(e ->
+                doExport(ctx, ExportFormat.JSON, "JSON",
+                        "*.json"));
+        MenuItem mdItem = new MenuItem("Markdown...");
+        mdItem.setOnAction(e ->
+                doExportDir(ctx, ExportFormat.MARKDOWN));
+        MenuItem opmlItem = new MenuItem("OPML...");
+        opmlItem.setOnAction(e ->
+                doExport(ctx, ExportFormat.OPML, "OPML",
+                        "*.opml"));
+        Menu menu = new Menu("Export");
+        menu.getItems().addAll(jsonItem, mdItem, opmlItem);
+        return menu;
+    }
+
+    private static void doExport(WindowContext ctx,
+            ExportFormat format, String desc, String ext) {
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Export as " + desc);
+        chooser.getExtensionFilters().add(
+                new FileChooser.ExtensionFilter(desc, ext));
+        File file = chooser.showSaveDialog(ctx.ownerStage());
+        if (file != null) {
+            try {
+                createExportService(ctx)
+                        .exportProject(format, file.toPath());
+            } catch (IOException ex) {
+                LOG.error("Export failed", ex);
+            }
+        }
+    }
+
+    private static void doExportDir(WindowContext ctx,
+            ExportFormat format) {
+        DirectoryChooser chooser = new DirectoryChooser();
+        chooser.setTitle("Export as Markdown");
+        File dir = chooser.showDialog(ctx.ownerStage());
+        if (dir != null) {
+            try {
+                createExportService(ctx)
+                        .exportProject(format, dir.toPath());
+            } catch (IOException ex) {
+                LOG.error("Export failed", ex);
+            }
+        }
+    }
+
+    private static ExportProjectUseCase createExportService(
+            WindowContext ctx) {
+        SharedServices svc = ctx.sharedServices();
+        return new ExportServiceImpl(
+                svc.project(), svc.noteService(),
+                svc.linkService(), svc.stampService(),
+                Map.of(ExportFormat.JSON,
+                        new JsonExportAdapter(),
+                        ExportFormat.MARKDOWN,
+                        new MarkdownExportAdapter(),
+                        ExportFormat.OPML,
+                        new OpmlExportAdapter()));
     }
 
     private static Menu buildNoteMenu(WindowContext ctx) {

--- a/src/main/java/com/embervault/MenuBarFactory.java
+++ b/src/main/java/com/embervault/MenuBarFactory.java
@@ -137,7 +137,7 @@ final class MenuBarFactory {
         String suffix = ext.replace("*", "");
         FileChooser chooser = new FileChooser();
         chooser.setTitle("Export as " + desc);
-        chooser.setInitialFileName("export" + suffix);
+        chooser.setInitialFileName("export");
         chooser.getExtensionFilters().add(
                 new FileChooser.ExtensionFilter(desc, ext));
         File file = chooser.showSaveDialog(ctx.ownerStage());

--- a/src/main/java/com/embervault/adapter/out/persistence/JsonExportAdapter.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/JsonExportAdapter.java
@@ -1,0 +1,188 @@
+package com.embervault.adapter.out.persistence;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Link;
+import com.embervault.domain.Note;
+import com.embervault.domain.Stamp;
+
+/**
+ * Exports project data to a full-fidelity JSON file.
+ *
+ * <p>Produces a JSON document with top-level keys {@code "notes"},
+ * {@code "links"}, and {@code "stamps"}, preserving all typed
+ * attribute values for round-trip fidelity.</p>
+ */
+public final class JsonExportAdapter {
+
+    /**
+     * Exports notes, links, and stamps to a JSON file.
+     *
+     * @param notes   the notes to export
+     * @param links   the links to export
+     * @param stamps  the stamps to export
+     * @param output  the output file path
+     * @throws IOException if writing fails
+     */
+    public void export(List<Note> notes, List<Link> links,
+            List<Stamp> stamps, Path output) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"notes\": [\n");
+        for (int i = 0; i < notes.size(); i++) {
+            writeNote(sb, notes.get(i));
+            if (i < notes.size() - 1) {
+                sb.append(",");
+            }
+            sb.append("\n");
+        }
+        sb.append("  ],\n");
+
+        sb.append("  \"links\": [\n");
+        for (int i = 0; i < links.size(); i++) {
+            writeLink(sb, links.get(i));
+            if (i < links.size() - 1) {
+                sb.append(",");
+            }
+            sb.append("\n");
+        }
+        sb.append("  ],\n");
+
+        sb.append("  \"stamps\": [\n");
+        for (int i = 0; i < stamps.size(); i++) {
+            writeStamp(sb, stamps.get(i));
+            if (i < stamps.size() - 1) {
+                sb.append(",");
+            }
+            sb.append("\n");
+        }
+        sb.append("  ]\n");
+        sb.append("}");
+
+        Files.writeString(output, sb.toString(),
+                StandardCharsets.UTF_8);
+    }
+
+    private void writeNote(StringBuilder sb, Note note) {
+        sb.append("    {\n");
+        sb.append("      \"id\": ")
+                .append(jsonString(note.getId().toString()))
+                .append(",\n");
+
+        note.getPrototypeId().ifPresent(pid ->
+                sb.append("      \"prototypeId\": ")
+                        .append(jsonString(pid.toString()))
+                        .append(",\n"));
+
+        sb.append("      \"attributes\": {\n");
+        Map<String, AttributeValue> entries =
+                note.getAttributes().localEntries();
+        int count = 0;
+        for (Map.Entry<String, AttributeValue> entry
+                : entries.entrySet()) {
+            sb.append("        ")
+                    .append(jsonString(entry.getKey()))
+                    .append(": ")
+                    .append(formatValue(entry.getValue()));
+            count++;
+            if (count < entries.size()) {
+                sb.append(",");
+            }
+            sb.append("\n");
+        }
+        sb.append("      }\n");
+        sb.append("    }");
+    }
+
+    private void writeLink(StringBuilder sb, Link link) {
+        sb.append("    {\n");
+        sb.append("      \"id\": ")
+                .append(jsonString(link.id().toString()))
+                .append(",\n");
+        sb.append("      \"sourceId\": ")
+                .append(jsonString(link.sourceId().toString()))
+                .append(",\n");
+        sb.append("      \"destinationId\": ")
+                .append(jsonString(
+                        link.destinationId().toString()))
+                .append(",\n");
+        sb.append("      \"type\": ")
+                .append(jsonString(link.type()))
+                .append("\n");
+        sb.append("    }");
+    }
+
+    private void writeStamp(StringBuilder sb, Stamp stamp) {
+        sb.append("    {\n");
+        sb.append("      \"id\": ")
+                .append(jsonString(stamp.id().toString()))
+                .append(",\n");
+        sb.append("      \"name\": ")
+                .append(jsonString(stamp.name()))
+                .append(",\n");
+        sb.append("      \"action\": ")
+                .append(jsonString(stamp.action()))
+                .append("\n");
+        sb.append("    }");
+    }
+
+    private String formatValue(AttributeValue value) {
+        return switch (value) {
+            case AttributeValue.StringValue sv ->
+                    jsonString(sv.value());
+            case AttributeValue.NumberValue nv -> {
+                double d = nv.value();
+                yield d == Math.floor(d)
+                        && !Double.isInfinite(d)
+                        ? String.valueOf((long) d)
+                        : String.valueOf(d);
+            }
+            case AttributeValue.BooleanValue bv ->
+                    String.valueOf(bv.value());
+            case AttributeValue.ColorValue cv ->
+                    jsonString(cv.value().toHex());
+            case AttributeValue.DateValue dv ->
+                    jsonString(dv.value().toString());
+            case AttributeValue.IntervalValue iv ->
+                    jsonString(iv.value().toString());
+            case AttributeValue.FileValue fv ->
+                    jsonString(fv.path());
+            case AttributeValue.UrlValue uv ->
+                    jsonString(uv.url());
+            case AttributeValue.ListValue lv ->
+                    formatList(lv.values());
+            case AttributeValue.SetValue sv ->
+                    formatSet(sv.values());
+            case AttributeValue.ActionValue av ->
+                    jsonString(av.expression());
+        };
+    }
+
+    private String formatList(java.util.List<String> values) {
+        return values.stream()
+                .map(this::jsonString)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private String formatSet(java.util.Set<String> values) {
+        return new TreeSet<>(values).stream()
+                .map(this::jsonString)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private String jsonString(String value) {
+        return "\"" + value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t") + "\"";
+    }
+}

--- a/src/main/java/com/embervault/adapter/out/persistence/JsonExportAdapter.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/JsonExportAdapter.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import com.embervault.application.port.out.ExportPort;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Link;
 import com.embervault.domain.Note;
@@ -21,19 +22,12 @@ import com.embervault.domain.Stamp;
  * {@code "links"}, and {@code "stamps"}, preserving all typed
  * attribute values for round-trip fidelity.</p>
  */
-public final class JsonExportAdapter {
+public final class JsonExportAdapter implements ExportPort {
 
-    /**
-     * Exports notes, links, and stamps to a JSON file.
-     *
-     * @param notes   the notes to export
-     * @param links   the links to export
-     * @param stamps  the stamps to export
-     * @param output  the output file path
-     * @throws IOException if writing fails
-     */
+    @Override
     public void export(List<Note> notes, List<Link> links,
-            List<Stamp> stamps, Path output) throws IOException {
+            List<Stamp> stamps, String projectName,
+            Path output) throws IOException {
         StringBuilder sb = new StringBuilder();
         sb.append("{\n");
         sb.append("  \"notes\": [\n");

--- a/src/main/java/com/embervault/adapter/out/persistence/MarkdownExportAdapter.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/MarkdownExportAdapter.java
@@ -1,0 +1,48 @@
+package com.embervault.adapter.out.persistence;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.embervault.domain.Note;
+
+/**
+ * Exports notes as individual Markdown files with YAML frontmatter.
+ *
+ * <p>Each note becomes a separate {@code .md} file in the output
+ * directory, using the same serialization format as
+ * {@link NoteFileSerializer} for consistency with the project's
+ * native file format.</p>
+ */
+public final class MarkdownExportAdapter {
+
+    private final NoteFileSerializer serializer =
+            new NoteFileSerializer();
+
+    /**
+     * Exports the given notes to individual Markdown files.
+     *
+     * @param notes     the notes to export
+     * @param outputDir the output directory
+     * @throws IOException if writing fails
+     */
+    public void export(List<Note> notes, Path outputDir)
+            throws IOException {
+        Files.createDirectories(outputDir);
+        for (Note note : notes) {
+            String filename = sanitizeFilename(
+                    note.getTitle()) + ".md";
+            Path file = outputDir.resolve(filename);
+            String content = serializer.serialize(note);
+            Files.writeString(file, content,
+                    StandardCharsets.UTF_8);
+        }
+    }
+
+    private String sanitizeFilename(String name) {
+        // Replace characters not allowed in filenames
+        return name.replaceAll("[/\\\\:*?\"<>|]", "_");
+    }
+}

--- a/src/main/java/com/embervault/adapter/out/persistence/MarkdownExportAdapter.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/MarkdownExportAdapter.java
@@ -6,7 +6,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import com.embervault.application.port.out.ExportPort;
+import com.embervault.domain.Link;
 import com.embervault.domain.Note;
+import com.embervault.domain.Stamp;
 
 /**
  * Exports notes as individual Markdown files with YAML frontmatter.
@@ -16,25 +19,20 @@ import com.embervault.domain.Note;
  * {@link NoteFileSerializer} for consistency with the project's
  * native file format.</p>
  */
-public final class MarkdownExportAdapter {
+public final class MarkdownExportAdapter implements ExportPort {
 
     private final NoteFileSerializer serializer =
             new NoteFileSerializer();
 
-    /**
-     * Exports the given notes to individual Markdown files.
-     *
-     * @param notes     the notes to export
-     * @param outputDir the output directory
-     * @throws IOException if writing fails
-     */
-    public void export(List<Note> notes, Path outputDir)
-            throws IOException {
-        Files.createDirectories(outputDir);
+    @Override
+    public void export(List<Note> notes, List<Link> links,
+            List<Stamp> stamps, String projectName,
+            Path output) throws IOException {
+        Files.createDirectories(output);
         for (Note note : notes) {
             String filename = sanitizeFilename(
                     note.getTitle()) + ".md";
-            Path file = outputDir.resolve(filename);
+            Path file = output.resolve(filename);
             String content = serializer.serialize(note);
             Files.writeString(file, content,
                     StandardCharsets.UTF_8);

--- a/src/main/java/com/embervault/adapter/out/persistence/OpmlExportAdapter.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/OpmlExportAdapter.java
@@ -1,0 +1,80 @@
+package com.embervault.adapter.out.persistence;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.embervault.domain.Note;
+
+/**
+ * Exports notes to OPML (Outline Processor Markup Language) format.
+ *
+ * <p>Produces an OPML 2.0 document where each note becomes an
+ * {@code <outline>} element. The note title maps to the
+ * {@code text} attribute, and the note body maps to the
+ * {@code _note} attribute (a common OPML convention).</p>
+ */
+public final class OpmlExportAdapter {
+
+    /**
+     * Exports the given notes to an OPML file.
+     *
+     * @param notes       the notes to export
+     * @param projectName the project name for the title
+     * @param output      the output file path
+     * @throws IOException if writing fails
+     */
+    public void export(List<Note> notes, String projectName,
+            Path output) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<opml version=\"2.0\">\n");
+        sb.append("  <head>\n");
+        sb.append("    <title>")
+                .append(escapeXml(projectName))
+                .append("</title>\n");
+        sb.append("  </head>\n");
+        sb.append("  <body>\n");
+
+        for (Note note : notes) {
+            writeOutline(sb, note);
+        }
+
+        sb.append("  </body>\n");
+        sb.append("</opml>\n");
+
+        Files.writeString(output, sb.toString(),
+                StandardCharsets.UTF_8);
+    }
+
+    private void writeOutline(StringBuilder sb, Note note) {
+        sb.append("    <outline");
+        sb.append(" text=\"")
+                .append(escapeXml(note.getTitle()))
+                .append("\"");
+
+        String text = note.getText();
+        if (text != null && !text.isEmpty()) {
+            sb.append(" _note=\"")
+                    .append(escapeXml(text))
+                    .append("\"");
+        }
+
+        sb.append(" created=\"")
+                .append(note.getCreatedAt().toString())
+                .append("\"");
+
+        sb.append("/>\n");
+    }
+
+    private String escapeXml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/src/main/java/com/embervault/adapter/out/persistence/OpmlExportAdapter.java
+++ b/src/main/java/com/embervault/adapter/out/persistence/OpmlExportAdapter.java
@@ -6,7 +6,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import com.embervault.application.port.out.ExportPort;
+import com.embervault.domain.Link;
 import com.embervault.domain.Note;
+import com.embervault.domain.Stamp;
 
 /**
  * Exports notes to OPML (Outline Processor Markup Language) format.
@@ -16,20 +19,15 @@ import com.embervault.domain.Note;
  * {@code text} attribute, and the note body maps to the
  * {@code _note} attribute (a common OPML convention).</p>
  */
-public final class OpmlExportAdapter {
+public final class OpmlExportAdapter implements ExportPort {
 
-    /**
-     * Exports the given notes to an OPML file.
-     *
-     * @param notes       the notes to export
-     * @param projectName the project name for the title
-     * @param output      the output file path
-     * @throws IOException if writing fails
-     */
-    public void export(List<Note> notes, String projectName,
+    @Override
+    public void export(List<Note> notes, List<Link> links,
+            List<Stamp> stamps, String projectName,
             Path output) throws IOException {
         StringBuilder sb = new StringBuilder();
-        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         sb.append("<opml version=\"2.0\">\n");
         sb.append("  <head>\n");
         sb.append("    <title>")

--- a/src/main/java/com/embervault/application/ExportServiceImpl.java
+++ b/src/main/java/com/embervault/application/ExportServiceImpl.java
@@ -1,0 +1,88 @@
+package com.embervault.application;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import com.embervault.application.port.in.ExportProjectUseCase;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.LinkService;
+import com.embervault.application.port.in.StampService;
+import com.embervault.application.port.out.ExportPort;
+import com.embervault.domain.ExportFormat;
+import com.embervault.domain.Link;
+import com.embervault.domain.Note;
+import com.embervault.domain.Project;
+
+/**
+ * Application service implementing project export use cases.
+ *
+ * <p>Delegates to format-specific {@link ExportPort} implementations
+ * based on the requested {@link ExportFormat}.</p>
+ */
+public final class ExportServiceImpl
+        implements ExportProjectUseCase {
+
+    private final Project project;
+    private final GetNoteQuery noteQuery;
+    private final LinkService linkService;
+    private final StampService stampService;
+    private final Map<ExportFormat, ExportPort> exportPorts;
+
+    /**
+     * Creates an ExportServiceImpl.
+     *
+     * @param project      the project
+     * @param noteQuery    the note query service
+     * @param linkService  the link service
+     * @param stampService the stamp service
+     * @param exportPorts  map of format to export port
+     */
+    public ExportServiceImpl(Project project,
+            GetNoteQuery noteQuery,
+            LinkService linkService,
+            StampService stampService,
+            Map<ExportFormat, ExportPort> exportPorts) {
+        this.project = project;
+        this.noteQuery = noteQuery;
+        this.linkService = linkService;
+        this.stampService = stampService;
+        this.exportPorts = exportPorts;
+    }
+
+    @Override
+    public void exportProject(ExportFormat format, Path output)
+            throws IOException {
+        ExportPort port = exportPorts.get(format);
+        if (port == null) {
+            throw new IllegalArgumentException(
+                    "Unsupported export format: " + format);
+        }
+
+        List<Note> notes = noteQuery.getAllNotes();
+        List<Link> links = collectAllLinks(notes);
+
+        port.export(notes, links,
+                stampService.getAllStamps(),
+                project.getName(), output);
+    }
+
+    private List<Link> collectAllLinks(List<Note> notes) {
+        Set<UUID> seen = new HashSet<>();
+        List<Link> allLinks = new ArrayList<>();
+        for (Note note : notes) {
+            for (Link link
+                    : linkService.getLinksFrom(note.getId())) {
+                if (seen.add(link.id())) {
+                    allLinks.add(link);
+                }
+            }
+        }
+        return allLinks;
+    }
+}

--- a/src/main/java/com/embervault/application/port/in/ExportProjectUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/ExportProjectUseCase.java
@@ -1,0 +1,22 @@
+package com.embervault.application.port.in;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.embervault.domain.ExportFormat;
+
+/**
+ * Inbound port for exporting project data to various formats.
+ */
+public interface ExportProjectUseCase {
+
+    /**
+     * Exports the current project to the specified format.
+     *
+     * @param format the export format
+     * @param output the output path (file for JSON/OPML, directory for Markdown)
+     * @throws IOException if writing fails
+     */
+    void exportProject(ExportFormat format, Path output)
+            throws IOException;
+}

--- a/src/main/java/com/embervault/application/port/out/ExportPort.java
+++ b/src/main/java/com/embervault/application/port/out/ExportPort.java
@@ -1,0 +1,32 @@
+package com.embervault.application.port.out;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.embervault.domain.Link;
+import com.embervault.domain.Note;
+import com.embervault.domain.Stamp;
+
+/**
+ * Outbound port for exporting project data to a specific format.
+ *
+ * <p>Each export format (JSON, Markdown, OPML) provides its own
+ * implementation of this port.</p>
+ */
+public interface ExportPort {
+
+    /**
+     * Exports the given project data to the specified output path.
+     *
+     * @param notes       the notes to export
+     * @param links       the links to export
+     * @param stamps      the stamps to export
+     * @param projectName the project name
+     * @param output      the output path
+     * @throws IOException if writing fails
+     */
+    void export(List<Note> notes, List<Link> links,
+            List<Stamp> stamps, String projectName,
+            Path output) throws IOException;
+}

--- a/src/main/java/com/embervault/domain/ExportFormat.java
+++ b/src/main/java/com/embervault/domain/ExportFormat.java
@@ -1,0 +1,16 @@
+package com.embervault.domain;
+
+/**
+ * Supported export formats for project data.
+ */
+public enum ExportFormat {
+
+    /** Full-fidelity JSON with notes, links, and stamps. */
+    JSON,
+
+    /** Markdown archive with one .md file per note. */
+    MARKDOWN,
+
+    /** OPML 2.0 outline format. */
+    OPML
+}

--- a/src/test/java/com/embervault/adapter/out/persistence/JsonExportAdapterTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/JsonExportAdapterTest.java
@@ -40,7 +40,7 @@ class JsonExportAdapterTest {
         Path outputFile = tempDir.resolve("export.json");
 
         adapter.export(List.of(note), List.of(), List.of(),
-                outputFile);
+                "Test", outputFile);
 
         assertTrue(Files.exists(outputFile));
         String json = Files.readString(outputFile,
@@ -66,7 +66,7 @@ class JsonExportAdapterTest {
         Path outputFile = tempDir.resolve("export.json");
 
         adapter.export(List.of(note1, note2), List.of(link),
-                List.of(), outputFile);
+                List.of(), "Test", outputFile);
 
         String json = Files.readString(outputFile,
                 StandardCharsets.UTF_8);
@@ -89,7 +89,7 @@ class JsonExportAdapterTest {
         Path outputFile = tempDir.resolve("export.json");
 
         adapter.export(List.of(note), List.of(),
-                List.of(stamp), outputFile);
+                List.of(stamp), "Test", outputFile);
 
         String json = Files.readString(outputFile,
                 StandardCharsets.UTF_8);
@@ -115,7 +115,7 @@ class JsonExportAdapterTest {
         Path outputFile = tempDir.resolve("export.json");
 
         adapter.export(List.of(note), List.of(), List.of(),
-                outputFile);
+                "Test", outputFile);
 
         String json = Files.readString(outputFile,
                 StandardCharsets.UTF_8);
@@ -134,7 +134,7 @@ class JsonExportAdapterTest {
         Path outputFile = tempDir.resolve("export.json");
 
         adapter.export(List.of(note), List.of(), List.of(),
-                outputFile);
+                "Test", outputFile);
 
         String json = Files.readString(outputFile,
                 StandardCharsets.UTF_8);

--- a/src/test/java/com/embervault/adapter/out/persistence/JsonExportAdapterTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/JsonExportAdapterTest.java
@@ -1,0 +1,147 @@
+package com.embervault.adapter.out.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Link;
+import com.embervault.domain.Note;
+import com.embervault.domain.Stamp;
+import com.embervault.domain.TbxColor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link JsonExportAdapter}.
+ */
+class JsonExportAdapterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("exports single note to JSON with attributes")
+    void exportSingleNote() throws IOException {
+        UUID noteId = UUID.randomUUID();
+        Instant now = Instant.parse("2025-06-15T10:30:00Z");
+        Note note = new Note(noteId, "Test Note", "Note body",
+                now, now);
+
+        JsonExportAdapter adapter = new JsonExportAdapter();
+        Path outputFile = tempDir.resolve("export.json");
+
+        adapter.export(List.of(note), List.of(), List.of(),
+                outputFile);
+
+        assertTrue(Files.exists(outputFile));
+        String json = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"" + noteId + "\""));
+        assertTrue(json.contains("\"Test Note\""));
+        assertTrue(json.contains("\"Note body\""));
+    }
+
+    @Test
+    @DisplayName("exports notes with links")
+    void exportNotesWithLinks() throws IOException {
+        UUID noteId1 = UUID.randomUUID();
+        UUID noteId2 = UUID.randomUUID();
+        Instant now = Instant.now();
+        Note note1 = new Note(noteId1, "Note A", "", now,
+                now);
+        Note note2 = new Note(noteId2, "Note B", "", now,
+                now);
+        Link link = Link.create(noteId1, noteId2, "web");
+
+        JsonExportAdapter adapter = new JsonExportAdapter();
+        Path outputFile = tempDir.resolve("export.json");
+
+        adapter.export(List.of(note1, note2), List.of(link),
+                List.of(), outputFile);
+
+        String json = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"links\""));
+        assertTrue(json.contains("\"" + noteId1 + "\""));
+        assertTrue(json.contains("\"" + noteId2 + "\""));
+        assertTrue(json.contains("\"web\""));
+    }
+
+    @Test
+    @DisplayName("exports notes with stamps")
+    void exportNotesWithStamps() throws IOException {
+        Instant now = Instant.now();
+        Note note = new Note(UUID.randomUUID(), "N", "", now,
+                now);
+        Stamp stamp = Stamp.create("Color Red",
+                "$Color=red");
+
+        JsonExportAdapter adapter = new JsonExportAdapter();
+        Path outputFile = tempDir.resolve("export.json");
+
+        adapter.export(List.of(note), List.of(),
+                List.of(stamp), outputFile);
+
+        String json = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"stamps\""));
+        assertTrue(json.contains("\"Color Red\""));
+    }
+
+    @Test
+    @DisplayName("exports note with typed attributes")
+    void exportNoteWithTypedAttributes() throws IOException {
+        Instant now = Instant.now();
+        Note note = new Note(UUID.randomUUID(), "N", "", now,
+                now);
+        note.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(
+                        TbxColor.hex("#FF0000")));
+        note.setAttribute(Attributes.CHECKED,
+                new AttributeValue.BooleanValue(true));
+        note.setAttribute(Attributes.OUTLINE_ORDER,
+                new AttributeValue.NumberValue(3.0));
+
+        JsonExportAdapter adapter = new JsonExportAdapter();
+        Path outputFile = tempDir.resolve("export.json");
+
+        adapter.export(List.of(note), List.of(), List.of(),
+                outputFile);
+
+        String json = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"#FF0000\""));
+        assertTrue(json.contains("true"));
+    }
+
+    @Test
+    @DisplayName("produces valid JSON structure with top-level keys")
+    void validJsonStructure() throws IOException {
+        Instant now = Instant.now();
+        Note note = new Note(UUID.randomUUID(), "N", "", now,
+                now);
+
+        JsonExportAdapter adapter = new JsonExportAdapter();
+        Path outputFile = tempDir.resolve("export.json");
+
+        adapter.export(List.of(note), List.of(), List.of(),
+                outputFile);
+
+        String json = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"notes\""));
+        assertTrue(json.contains("\"links\""));
+        assertTrue(json.contains("\"stamps\""));
+        assertTrue(json.startsWith("{"));
+        assertTrue(json.trim().endsWith("}"));
+    }
+}

--- a/src/test/java/com/embervault/adapter/out/persistence/MarkdownExportAdapterTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/MarkdownExportAdapterTest.java
@@ -1,0 +1,134 @@
+package com.embervault.adapter.out.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.Note;
+import com.embervault.domain.TbxColor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link MarkdownExportAdapter}.
+ */
+class MarkdownExportAdapterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("exports single note as .md file with YAML frontmatter")
+    void exportSingleNote() throws IOException {
+        UUID noteId = UUID.randomUUID();
+        Instant now = Instant.parse("2025-06-15T10:30:00Z");
+        Note note = new Note(noteId, "My Note",
+                "Hello **world**", now, now);
+
+        MarkdownExportAdapter adapter =
+                new MarkdownExportAdapter();
+        adapter.export(List.of(note), tempDir);
+
+        Path expectedFile = tempDir.resolve("My Note.md");
+        assertTrue(Files.exists(expectedFile));
+
+        String content = Files.readString(expectedFile,
+                StandardCharsets.UTF_8);
+        assertTrue(content.startsWith("---\n"));
+        assertTrue(content.contains(
+                "id: \"" + noteId + "\""));
+        assertTrue(content.contains("Hello **world**"));
+    }
+
+    @Test
+    @DisplayName("exports multiple notes as separate .md files")
+    void exportMultipleNotes() throws IOException {
+        Instant now = Instant.now();
+        Note note1 = new Note(UUID.randomUUID(), "Alpha", "",
+                now, now);
+        Note note2 = new Note(UUID.randomUUID(), "Beta",
+                "Content", now, now);
+
+        MarkdownExportAdapter adapter =
+                new MarkdownExportAdapter();
+        adapter.export(List.of(note1, note2), tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("Alpha.md")));
+        assertTrue(Files.exists(tempDir.resolve("Beta.md")));
+    }
+
+    @Test
+    @DisplayName("note with color attribute includes it in frontmatter")
+    void exportNoteWithColorAttribute() throws IOException {
+        Instant now = Instant.now();
+        Note note = new Note(UUID.randomUUID(), "Colored", "",
+                now, now);
+        note.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(
+                        TbxColor.hex("#FF0000")));
+
+        MarkdownExportAdapter adapter =
+                new MarkdownExportAdapter();
+        adapter.export(List.of(note), tempDir);
+
+        String content = Files.readString(
+                tempDir.resolve("Colored.md"),
+                StandardCharsets.UTF_8);
+        assertTrue(content.contains(
+                Attributes.COLOR + ": \"#FF0000\""));
+    }
+
+    @Test
+    @DisplayName("sanitizes filename for notes with special characters")
+    void exportNoteWithSpecialCharsInName() throws IOException {
+        Instant now = Instant.now();
+        Note note = new Note(UUID.randomUUID(),
+                "Notes/Ideas: 2025", "body", now, now);
+
+        MarkdownExportAdapter adapter =
+                new MarkdownExportAdapter();
+        adapter.export(List.of(note), tempDir);
+
+        // File should exist with sanitized name
+        long mdCount;
+        try (var files = Files.list(tempDir)) {
+            mdCount = files
+                    .filter(p -> p.toString().endsWith(".md"))
+                    .count();
+        }
+        assertEquals(1, mdCount,
+                "Should produce exactly one .md file");
+    }
+
+    @Test
+    @DisplayName("uses NoteFileSerializer format for consistency")
+    void usesNoteFileSerializerFormat() throws IOException {
+        Instant now = Instant.parse("2025-06-15T10:30:00Z");
+        Note note = new Note(UUID.randomUUID(),
+                "Consistent", "Body text", now, now);
+
+        MarkdownExportAdapter adapter =
+                new MarkdownExportAdapter();
+        adapter.export(List.of(note), tempDir);
+
+        String content = Files.readString(
+                tempDir.resolve("Consistent.md"),
+                StandardCharsets.UTF_8);
+
+        // Should match NoteFileSerializer output format
+        NoteFileSerializer serializer =
+                new NoteFileSerializer();
+        String expected = serializer.serialize(note);
+        assertEquals(expected, content);
+    }
+}

--- a/src/test/java/com/embervault/adapter/out/persistence/MarkdownExportAdapterTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/MarkdownExportAdapterTest.java
@@ -37,7 +37,8 @@ class MarkdownExportAdapterTest {
 
         MarkdownExportAdapter adapter =
                 new MarkdownExportAdapter();
-        adapter.export(List.of(note), tempDir);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Test", tempDir);
 
         Path expectedFile = tempDir.resolve("My Note.md");
         assertTrue(Files.exists(expectedFile));
@@ -61,7 +62,8 @@ class MarkdownExportAdapterTest {
 
         MarkdownExportAdapter adapter =
                 new MarkdownExportAdapter();
-        adapter.export(List.of(note1, note2), tempDir);
+        adapter.export(List.of(note1, note2), List.of(),
+                List.of(), "Test", tempDir);
 
         assertTrue(Files.exists(tempDir.resolve("Alpha.md")));
         assertTrue(Files.exists(tempDir.resolve("Beta.md")));
@@ -79,7 +81,8 @@ class MarkdownExportAdapterTest {
 
         MarkdownExportAdapter adapter =
                 new MarkdownExportAdapter();
-        adapter.export(List.of(note), tempDir);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Test", tempDir);
 
         String content = Files.readString(
                 tempDir.resolve("Colored.md"),
@@ -97,7 +100,8 @@ class MarkdownExportAdapterTest {
 
         MarkdownExportAdapter adapter =
                 new MarkdownExportAdapter();
-        adapter.export(List.of(note), tempDir);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Test", tempDir);
 
         // File should exist with sanitized name
         long mdCount;
@@ -119,7 +123,8 @@ class MarkdownExportAdapterTest {
 
         MarkdownExportAdapter adapter =
                 new MarkdownExportAdapter();
-        adapter.export(List.of(note), tempDir);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Test", tempDir);
 
         String content = Files.readString(
                 tempDir.resolve("Consistent.md"),

--- a/src/test/java/com/embervault/adapter/out/persistence/OpmlExportAdapterTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/OpmlExportAdapterTest.java
@@ -1,0 +1,127 @@
+package com.embervault.adapter.out.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link OpmlExportAdapter}.
+ */
+class OpmlExportAdapterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("exports single note as valid OPML document")
+    void exportSingleNote() throws IOException {
+        Instant now = Instant.parse("2025-06-15T10:30:00Z");
+        Note note = new Note(UUID.randomUUID(), "My Note",
+                "Note body", now, now);
+
+        OpmlExportAdapter adapter = new OpmlExportAdapter();
+        Path outputFile = tempDir.resolve("export.opml");
+
+        adapter.export(List.of(note), "Test Project",
+                outputFile);
+
+        assertTrue(Files.exists(outputFile));
+        String opml = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(opml.contains("<?xml version="));
+        assertTrue(opml.contains("<opml version=\"2.0\">"));
+        assertTrue(opml.contains("<head>"));
+        assertTrue(opml.contains("<title>Test Project</title>"));
+        assertTrue(opml.contains("<body>"));
+        assertTrue(opml.contains("text=\"My Note\""));
+        assertTrue(opml.contains("</opml>"));
+    }
+
+    @Test
+    @DisplayName("exports multiple notes as outline elements")
+    void exportMultipleNotes() throws IOException {
+        Instant now = Instant.now();
+        Note note1 = new Note(UUID.randomUUID(), "Alpha", "",
+                now, now);
+        Note note2 = new Note(UUID.randomUUID(), "Beta",
+                "Content", now, now);
+
+        OpmlExportAdapter adapter = new OpmlExportAdapter();
+        Path outputFile = tempDir.resolve("export.opml");
+
+        adapter.export(List.of(note1, note2), "Project",
+                outputFile);
+
+        String opml = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(opml.contains("text=\"Alpha\""));
+        assertTrue(opml.contains("text=\"Beta\""));
+    }
+
+    @Test
+    @DisplayName("note text is included as _note attribute")
+    void exportNoteTextAsNoteAttribute() throws IOException {
+        Instant now = Instant.now();
+        Note note = new Note(UUID.randomUUID(), "Title",
+                "Some body text", now, now);
+
+        OpmlExportAdapter adapter = new OpmlExportAdapter();
+        Path outputFile = tempDir.resolve("export.opml");
+
+        adapter.export(List.of(note), "Project",
+                outputFile);
+
+        String opml = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(opml.contains(
+                "_note=\"Some body text\""));
+    }
+
+    @Test
+    @DisplayName("escapes XML special characters in note title")
+    void escapesXmlSpecialChars() throws IOException {
+        Instant now = Instant.now();
+        Note note = new Note(UUID.randomUUID(),
+                "Notes & Ideas <2025>", "", now, now);
+
+        OpmlExportAdapter adapter = new OpmlExportAdapter();
+        Path outputFile = tempDir.resolve("export.opml");
+
+        adapter.export(List.of(note), "Project",
+                outputFile);
+
+        String opml = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(opml.contains(
+                "text=\"Notes &amp; Ideas &lt;2025&gt;\""));
+    }
+
+    @Test
+    @DisplayName("note with created date includes it as attribute")
+    void exportNoteWithCreatedDate() throws IOException {
+        Instant now = Instant.parse("2025-06-15T10:30:00Z");
+        Note note = new Note(UUID.randomUUID(), "Dated", "",
+                now, now);
+
+        OpmlExportAdapter adapter = new OpmlExportAdapter();
+        Path outputFile = tempDir.resolve("export.opml");
+
+        adapter.export(List.of(note), "Project",
+                outputFile);
+
+        String opml = Files.readString(outputFile,
+                StandardCharsets.UTF_8);
+        assertTrue(opml.contains("created="));
+    }
+}

--- a/src/test/java/com/embervault/adapter/out/persistence/OpmlExportAdapterTest.java
+++ b/src/test/java/com/embervault/adapter/out/persistence/OpmlExportAdapterTest.java
@@ -33,8 +33,8 @@ class OpmlExportAdapterTest {
         OpmlExportAdapter adapter = new OpmlExportAdapter();
         Path outputFile = tempDir.resolve("export.opml");
 
-        adapter.export(List.of(note), "Test Project",
-                outputFile);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Test Project", outputFile);
 
         assertTrue(Files.exists(outputFile));
         String opml = Files.readString(outputFile,
@@ -60,8 +60,8 @@ class OpmlExportAdapterTest {
         OpmlExportAdapter adapter = new OpmlExportAdapter();
         Path outputFile = tempDir.resolve("export.opml");
 
-        adapter.export(List.of(note1, note2), "Project",
-                outputFile);
+        adapter.export(List.of(note1, note2), List.of(),
+                List.of(), "Project", outputFile);
 
         String opml = Files.readString(outputFile,
                 StandardCharsets.UTF_8);
@@ -79,8 +79,8 @@ class OpmlExportAdapterTest {
         OpmlExportAdapter adapter = new OpmlExportAdapter();
         Path outputFile = tempDir.resolve("export.opml");
 
-        adapter.export(List.of(note), "Project",
-                outputFile);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Project", outputFile);
 
         String opml = Files.readString(outputFile,
                 StandardCharsets.UTF_8);
@@ -98,8 +98,8 @@ class OpmlExportAdapterTest {
         OpmlExportAdapter adapter = new OpmlExportAdapter();
         Path outputFile = tempDir.resolve("export.opml");
 
-        adapter.export(List.of(note), "Project",
-                outputFile);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Project", outputFile);
 
         String opml = Files.readString(outputFile,
                 StandardCharsets.UTF_8);
@@ -117,8 +117,8 @@ class OpmlExportAdapterTest {
         OpmlExportAdapter adapter = new OpmlExportAdapter();
         Path outputFile = tempDir.resolve("export.opml");
 
-        adapter.export(List.of(note), "Project",
-                outputFile);
+        adapter.export(List.of(note), List.of(), List.of(),
+                "Project", outputFile);
 
         String opml = Files.readString(outputFile,
                 StandardCharsets.UTF_8);

--- a/src/test/java/com/embervault/application/ExportServiceImplTest.java
+++ b/src/test/java/com/embervault/application/ExportServiceImplTest.java
@@ -1,0 +1,206 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.embervault.adapter.out.persistence.JsonExportAdapter;
+import com.embervault.adapter.out.persistence.MarkdownExportAdapter;
+import com.embervault.adapter.out.persistence.OpmlExportAdapter;
+import com.embervault.application.port.in.ExportProjectUseCase;
+import com.embervault.application.port.in.GetNoteQuery;
+import com.embervault.application.port.in.LinkService;
+import com.embervault.application.port.in.StampService;
+import com.embervault.application.port.out.ExportPort;
+import com.embervault.domain.ExportFormat;
+import com.embervault.domain.Link;
+import com.embervault.domain.Note;
+import com.embervault.domain.Project;
+import com.embervault.domain.Stamp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link ExportServiceImpl}.
+ */
+class ExportServiceImplTest {
+
+    @TempDir
+    Path tempDir;
+
+    private List<Note> testNotes;
+    private List<Link> testLinks;
+    private List<Stamp> testStamps;
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        project = Project.createEmpty();
+        Instant now = Instant.now();
+        Note noteA = new Note(UUID.randomUUID(), "NoteA",
+                "Body A", now, now);
+        Note noteB = new Note(UUID.randomUUID(), "NoteB",
+                "Body B", now, now);
+        testNotes = List.of(noteA, noteB);
+        testLinks = List.of(
+                Link.create(noteA.getId(), noteB.getId()));
+        testStamps = List.of(
+                Stamp.create("Mark Done", "$Checked=true"));
+    }
+
+    @Test
+    @DisplayName("exports project as JSON")
+    void exportJson() throws IOException {
+        ExportProjectUseCase service = createService();
+        Path output = tempDir.resolve("export.json");
+
+        service.exportProject(ExportFormat.JSON, output);
+
+        assertTrue(Files.exists(output));
+        String json = Files.readString(output,
+                StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"notes\""));
+        assertTrue(json.contains("\"NoteA\""));
+        assertTrue(json.contains("\"links\""));
+        assertTrue(json.contains("\"stamps\""));
+        assertTrue(json.contains("\"Mark Done\""));
+    }
+
+    @Test
+    @DisplayName("exports project as Markdown")
+    void exportMarkdown() throws IOException {
+        ExportProjectUseCase service = createService();
+        Path output = tempDir.resolve("md-export");
+
+        service.exportProject(ExportFormat.MARKDOWN, output);
+
+        assertTrue(Files.exists(
+                output.resolve("NoteA.md")));
+        assertTrue(Files.exists(
+                output.resolve("NoteB.md")));
+    }
+
+    @Test
+    @DisplayName("exports project as OPML")
+    void exportOpml() throws IOException {
+        ExportProjectUseCase service = createService();
+        Path output = tempDir.resolve("export.opml");
+
+        service.exportProject(ExportFormat.OPML, output);
+
+        assertTrue(Files.exists(output));
+        String opml = Files.readString(output,
+                StandardCharsets.UTF_8);
+        assertTrue(opml.contains("<opml"));
+        assertTrue(opml.contains("text=\"NoteA\""));
+        assertTrue(opml.contains("text=\"NoteB\""));
+    }
+
+    private ExportProjectUseCase createService() {
+        GetNoteQuery noteQuery = new GetNoteQuery() {
+            @Override
+            public Optional<Note> getNote(UUID id) {
+                return Optional.empty();
+            }
+
+            @Override
+            public List<Note> getAllNotes() {
+                return testNotes;
+            }
+
+            @Override
+            public List<Note> getChildren(UUID parentId) {
+                return List.of();
+            }
+
+            @Override
+            public boolean hasChildren(UUID noteId) {
+                return false;
+            }
+
+            @Override
+            public Map<UUID, Boolean> hasChildrenBatch(
+                    Collection<UUID> noteIds) {
+                return Map.of();
+            }
+        };
+
+        LinkService linkSvc = new LinkService() {
+            @Override
+            public Link createLink(UUID src, UUID dst) {
+                return null;
+            }
+
+            @Override
+            public Link createLink(UUID src, UUID dst,
+                    String type) {
+                return null;
+            }
+
+            @Override
+            public List<Link> getLinksFrom(UUID noteId) {
+                return testLinks;
+            }
+
+            @Override
+            public List<Link> getLinksTo(UUID noteId) {
+                return List.of();
+            }
+
+            @Override
+            public List<Link> getAllLinksFor(UUID noteId) {
+                return testLinks;
+            }
+
+            @Override
+            public void deleteLink(UUID linkId) { }
+        };
+
+        StampService stampSvc = new StampService() {
+            @Override
+            public Stamp createStamp(String name,
+                    String action) {
+                return null;
+            }
+
+            @Override
+            public void deleteStamp(UUID id) { }
+
+            @Override
+            public List<Stamp> getAllStamps() {
+                return testStamps;
+            }
+
+            @Override
+            public Optional<Stamp> getStamp(UUID id) {
+                return Optional.empty();
+            }
+
+            @Override
+            public void applyStamp(UUID stampId,
+                    UUID noteId) { }
+        };
+
+        Map<ExportFormat, ExportPort> ports = Map.of(
+                ExportFormat.JSON,
+                new JsonExportAdapter(),
+                ExportFormat.MARKDOWN,
+                new MarkdownExportAdapter(),
+                ExportFormat.OPML,
+                new OpmlExportAdapter());
+
+        return new ExportServiceImpl(project, noteQuery,
+                linkSvc, stampSvc, ports);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `JsonExportAdapter` for full-fidelity JSON export preserving all notes, links, stamps, and typed attributes
- Add `MarkdownExportAdapter` for per-note `.md` file export with YAML frontmatter (reuses `NoteFileSerializer`)
- Add `OpmlExportAdapter` for OPML 2.0 outline export with XML escaping
- Add hexagonal architecture wiring: `ExportFormat` enum (domain), `ExportPort` outbound interface, `ExportProjectUseCase` inbound port, and `ExportServiceImpl` application service
- Architecture-compliant: application layer depends on `ExportPort` abstraction, not adapter implementations

## Test plan
- [x] `JsonExportAdapterTest` — 5 tests covering single note, links, stamps, typed attributes, and JSON structure
- [x] `MarkdownExportAdapterTest` — 5 tests covering single/multiple notes, color attributes, filename sanitization, and NoteFileSerializer format consistency
- [x] `OpmlExportAdapterTest` — 5 tests covering OPML structure, multiple notes, `_note` attribute, XML escaping, and created dates
- [x] `ExportServiceImplTest` — 3 tests verifying JSON, Markdown, and OPML export through the service layer
- [x] All existing tests pass
- [x] Checkstyle (0 violations), JaCoCo coverage, and ArchUnit architecture rules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>