### PR TITLE
Replace back button with clickable breadcrumb navigation (#266)

### DIFF
--- a/src/main/java/com/embervault/adapter/in/ui/view/BreadcrumbBar.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/BreadcrumbBar.java
@@ -1,0 +1,74 @@
+package com.embervault.adapter.in.ui.view;
+
+import java.util.function.IntConsumer;
+
+import com.embervault.adapter.in.ui.viewmodel.BreadcrumbEntry;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.scene.Cursor;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+
+/**
+ * A horizontal breadcrumb bar showing the drill-down path as clickable labels
+ * separated by "&#x203a;" separators. The last (current) entry is displayed as
+ * plain text; earlier entries are clickable and invoke the supplied callback.
+ */
+public final class BreadcrumbBar extends HBox {
+
+    private static final String SEPARATOR = " \u203A ";
+    private static final String LINK_STYLE =
+            "-fx-text-fill: #4A90D9; -fx-underline: true; -fx-cursor: hand;";
+    private static final String CURRENT_STYLE =
+            "-fx-text-fill: #333333; -fx-font-weight: bold;";
+
+    private final ObservableList<BreadcrumbEntry> breadcrumbs;
+    private final IntConsumer onNavigate;
+
+    /**
+     * Creates a breadcrumb bar bound to the given breadcrumb list.
+     *
+     * @param breadcrumbs the observable breadcrumb entries
+     * @param onNavigate  callback receiving the breadcrumb index when clicked
+     */
+    public BreadcrumbBar(ObservableList<BreadcrumbEntry> breadcrumbs,
+            IntConsumer onNavigate) {
+        this.breadcrumbs = breadcrumbs;
+        this.onNavigate = onNavigate;
+        setSpacing(0);
+        rebuild();
+        breadcrumbs.addListener(
+                (ListChangeListener<BreadcrumbEntry>) change -> rebuild());
+    }
+
+    private void rebuild() {
+        getChildren().clear();
+        if (breadcrumbs.isEmpty()) {
+            setVisible(false);
+            setManaged(false);
+            return;
+        }
+        setVisible(true);
+        setManaged(true);
+        for (int i = 0; i < breadcrumbs.size(); i++) {
+            if (i > 0) {
+                Label separator = new Label(SEPARATOR);
+                separator.setStyle("-fx-text-fill: #999999;");
+                getChildren().add(separator);
+            }
+            BreadcrumbEntry entry = breadcrumbs.get(i);
+            Label label = new Label(entry.displayName());
+            if (i < breadcrumbs.size() - 1) {
+                // Clickable ancestor
+                label.setStyle(LINK_STYLE);
+                label.setCursor(Cursor.HAND);
+                final int index = i;
+                label.setOnMouseClicked(e -> onNavigate.accept(index));
+            } else {
+                // Current location — not clickable
+                label.setStyle(CURRENT_STYLE);
+            }
+            getChildren().add(label);
+        }
+    }
+}

--- a/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/HyperbolicViewController.java
@@ -12,7 +12,6 @@ import com.embervault.adapter.in.ui.viewmodel.PositionedNode;
 import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
@@ -43,7 +42,7 @@ public class HyperbolicViewController {
     @FXML private Pane hyperbolicCanvas;
 
     private HyperbolicViewModel viewModel;
-    private Button backButton;
+    private BreadcrumbBar breadcrumbBar;
     private Consumer<String> onViewSwitch;
     private double dragStartX;
     private double dragStartY;
@@ -68,14 +67,12 @@ public class HyperbolicViewController {
     public void initViewModel(HyperbolicViewModel viewModel) {
         this.viewModel = viewModel;
 
-        // Back navigation button
-        backButton = new Button("\u2190 Back");
-        backButton.setVisible(false);
-        backButton.setOnAction(e -> viewModel.navigateBack());
-        backButton.setLayoutX(BACK_BUTTON_PADDING);
-        backButton.setLayoutY(BACK_BUTTON_PADDING);
-        viewModel.canNavigateBackProperty().addListener(
-                (obs, oldVal, newVal) -> backButton.setVisible(newVal));
+        // Breadcrumb navigation bar
+        breadcrumbBar = new BreadcrumbBar(
+                viewModel.getBreadcrumbs(),
+                viewModel::navigateToBreadcrumb);
+        breadcrumbBar.setLayoutX(BACK_BUTTON_PADDING);
+        breadcrumbBar.setLayoutY(BACK_BUTTON_PADDING);
 
         // Update viewport radius when canvas resizes
         hyperbolicCanvas.widthProperty().addListener((obs, oldVal, newVal) -> {
@@ -238,7 +235,7 @@ public class HyperbolicViewController {
         }
 
         // Keep back button on top
-        hyperbolicCanvas.getChildren().add(backButton);
+        hyperbolicCanvas.getChildren().add(breadcrumbBar);
     }
 
     private ContextMenu createNodeContextMenu(UUID noteId) {

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -181,7 +181,7 @@ public class MapViewController {
         zoomToolbar.setPadding(new Insets(4));
         zoomToolbar.setStyle("-fx-background-color: rgba(245,245,245,0.9);");
         zoomToolbar.setLayoutX(BACK_BUTTON_PADDING);
-        zoomToolbar.setLayoutY(BACK_BUTTON_PADDING);
+        zoomToolbar.setLayoutY(BACK_BUTTON_PADDING + 24);
         zoomToolbar.setMouseTransparent(false);
         zoomToolbar.setId("zoomToolbar");
 

--- a/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/MapViewController.java
@@ -51,7 +51,7 @@ public class MapViewController {
     @FXML private Pane mapCanvas;
 
     private MapViewModel viewModel;
-    private Button backButton;
+    private BreadcrumbBar breadcrumbBar;
     private HBox zoomToolbar;
     private final Map<UUID, StackPane> nodeMap = new HashMap<>();
     private Scale zoomScale;
@@ -72,13 +72,11 @@ public class MapViewController {
         this.viewModel = viewModel;
         setupZoom();
 
-        backButton = new Button("\u2190 Back");
-        backButton.setVisible(false);
-        backButton.setOnAction(e -> viewModel.navigateBack());
-        backButton.setLayoutX(BACK_BUTTON_PADDING);
-        backButton.setLayoutY(BACK_BUTTON_PADDING);
-        viewModel.canNavigateBackProperty().addListener(
-                (obs, oldVal, newVal) -> backButton.setVisible(newVal));
+        breadcrumbBar = new BreadcrumbBar(
+                viewModel.getBreadcrumbs(),
+                viewModel::navigateToBreadcrumb);
+        breadcrumbBar.setLayoutX(BACK_BUTTON_PADDING);
+        breadcrumbBar.setLayoutY(BACK_BUTTON_PADDING);
 
         viewModel.loadNotes();
         renderAllNotes();
@@ -202,7 +200,7 @@ public class MapViewController {
                 nodeMap.put(item.getId(), n);
                 mapCanvas.getChildren().add(n);
             }
-            mapCanvas.getChildren().addAll(backButton, zoomToolbar);
+            mapCanvas.getChildren().addAll(breadcrumbBar, zoomToolbar);
         } finally {
             interactionState.endRender();
         }
@@ -250,7 +248,7 @@ public class MapViewController {
                     }
                 }
                 if (change.wasAdded()) {
-                    int backIdx = mapCanvas.getChildren().indexOf(backButton);
+                    int backIdx = mapCanvas.getChildren().indexOf(breadcrumbBar);
                     if (backIdx < 0) {
                         backIdx = mapCanvas.getChildren().size();
                     }

--- a/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/OutlineViewController.java
@@ -10,7 +10,6 @@ import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
 import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
@@ -37,7 +36,7 @@ public class OutlineViewController {
     @FXML private VBox outlineRoot;
 
     private OutlineViewModel viewModel;
-    private Button backButton;
+    private BreadcrumbBar breadcrumbBar;
     private Consumer<String> onViewSwitch;
     private UUID pendingEditNoteId;
 
@@ -50,13 +49,11 @@ public class OutlineViewController {
     public void initViewModel(OutlineViewModel viewModel) {
         this.viewModel = viewModel;
 
-        // Back navigation button
-        backButton = new Button("\u2190 Back");
-        backButton.setVisible(false);
-        backButton.setOnAction(e -> viewModel.navigateBack());
-        viewModel.canNavigateBackProperty().addListener(
-                (obs, oldVal, newVal) -> backButton.setVisible(newVal));
-        outlineRoot.getChildren().add(0, backButton);
+        // Breadcrumb navigation bar
+        breadcrumbBar = new BreadcrumbBar(
+                viewModel.getBreadcrumbs(),
+                viewModel::navigateToBreadcrumb);
+        outlineRoot.getChildren().add(0, breadcrumbBar);
 
         outlineTreeView.setEditable(false);
         outlineTreeView.setCellFactory(tv -> new OutlineNoteTreeCell());

--- a/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
+++ b/src/main/java/com/embervault/adapter/in/ui/view/TreemapViewController.java
@@ -14,7 +14,6 @@ import com.embervault.adapter.in.ui.viewmodel.ViewColorConfig;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
-import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.input.KeyCode;
@@ -43,7 +42,7 @@ public class TreemapViewController {
     @FXML private Pane treemapCanvas;
 
     private TreemapViewModel viewModel;
-    private Button backButton;
+    private BreadcrumbBar breadcrumbBar;
     private ViewColorConfig currentColors;
     private Consumer<String> onViewSwitch;
 
@@ -65,13 +64,11 @@ public class TreemapViewController {
     public void initViewModel(TreemapViewModel treemapViewModel) {
         this.viewModel = treemapViewModel;
 
-        backButton = new Button("\u2190 Back");
-        backButton.setVisible(false);
-        backButton.setOnAction(e -> viewModel.navigateBack());
-        backButton.setLayoutX(BACK_BUTTON_PADDING);
-        backButton.setLayoutY(BACK_BUTTON_PADDING);
-        viewModel.canNavigateBackProperty().addListener(
-                (obs, oldVal, newVal) -> backButton.setVisible(newVal));
+        breadcrumbBar = new BreadcrumbBar(
+                viewModel.getBreadcrumbs(),
+                viewModel::navigateToBreadcrumb);
+        breadcrumbBar.setLayoutX(BACK_BUTTON_PADDING);
+        breadcrumbBar.setLayoutY(BACK_BUTTON_PADDING);
 
         viewModel.loadNotes();
         renderAllNotes();
@@ -135,7 +132,7 @@ public class TreemapViewController {
         double width = treemapCanvas.getWidth();
         double height = treemapCanvas.getHeight();
         if (width <= 0 || height <= 0) {
-            treemapCanvas.getChildren().add(backButton);
+            treemapCanvas.getChildren().add(breadcrumbBar);
             return;
         }
 
@@ -150,7 +147,7 @@ public class TreemapViewController {
                 treemapCanvas.getChildren().add(noteNode);
             }
         }
-        treemapCanvas.getChildren().add(backButton);
+        treemapCanvas.getChildren().add(breadcrumbBar);
     }
 
     private StackPane createNoteNode(NoteDisplayItem item, TreemapRect tr) {

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/BreadcrumbEntry.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/BreadcrumbEntry.java
@@ -1,0 +1,12 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import java.util.UUID;
+
+/**
+ * Represents one entry in a breadcrumb trail.
+ *
+ * @param noteId      the id of the note this entry represents
+ * @param displayName the human-readable label to show in the breadcrumb
+ */
+public record BreadcrumbEntry(UUID noteId, String displayName) {
+}

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModel.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import com.embervault.application.port.in.GetNoteQuery;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.domain.Link;
+import com.embervault.domain.Note;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
@@ -144,8 +145,16 @@ public final class HyperbolicViewModel {
     public void drillDown(UUID noteId) {
         UUID current = focusNoteId.get();
         if (current != null) {
-            navigationStack.setCurrentId(current);
-            navigationStack.push(noteId);
+            String newName = getNoteQuery.getNote(noteId)
+                    .map(Note::getTitle).orElse("Unknown");
+            if (navigationStack.getBreadcrumbs().isEmpty()) {
+                String currentName = getNoteQuery.getNote(current)
+                        .map(Note::getTitle).orElse("Unknown");
+                navigationStack.setCurrentId(current, currentName);
+            } else {
+                navigationStack.setCurrentId(current);
+            }
+            navigationStack.push(noteId, newName);
         }
         setFocusNote(noteId);
     }
@@ -215,6 +224,29 @@ public final class HyperbolicViewModel {
     /** Returns the canNavigateBack property. */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
         return navigationStack.canNavigateBackProperty();
+    }
+
+    /**
+     * Returns the observable breadcrumb trail for the current drill-down path.
+     *
+     * @return the unmodifiable observable list of breadcrumb entries
+     */
+    public ObservableList<BreadcrumbEntry> getBreadcrumbs() {
+        return navigationStack.getBreadcrumbs();
+    }
+
+    /**
+     * Navigates to the breadcrumb at the given index, setting the focus note
+     * to that ancestor.
+     *
+     * @param index the zero-based breadcrumb index to navigate to
+     */
+    public void navigateToBreadcrumb(int index) {
+        navigationStack.navigateTo(index);
+        UUID targetId = navigationStack.getCurrentId();
+        if (targetId != null) {
+            setFocusNote(targetId);
+        }
     }
 
     /**

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/MapViewModel.java
@@ -124,7 +124,9 @@ public final class MapViewModel {
      * @param noteId the base note id
      */
     public void setBaseNoteId(UUID noteId) {
-        navigationStack.setCurrentId(noteId);
+        String name = getNoteQuery.getNote(noteId)
+                .map(Note::getTitle).orElse("Unknown");
+        navigationStack.setCurrentId(noteId, name);
     }
 
     /** Returns the base note id. */
@@ -232,6 +234,32 @@ public final class MapViewModel {
         return navigationStack.canNavigateBackProperty();
     }
 
+    /**
+     * Returns the observable breadcrumb trail for the current drill-down path.
+     *
+     * @return the unmodifiable observable list of breadcrumb entries
+     */
+    public ObservableList<BreadcrumbEntry> getBreadcrumbs() {
+        return navigationStack.getBreadcrumbs();
+    }
+
+    /**
+     * Navigates to the breadcrumb at the given index, reloading notes
+     * and updating the tab title.
+     *
+     * @param index the zero-based breadcrumb index to navigate to
+     */
+    public void navigateToBreadcrumb(int index) {
+        navigationStack.navigateTo(index);
+        if (navigationStack.isAtRoot()) {
+            updateTabTitle(rootNoteTitle.get());
+        } else {
+            getNoteQuery.getNote(navigationStack.getCurrentId())
+                    .ifPresent(note -> updateTabTitle(note.getTitle()));
+        }
+        loadNotes();
+    }
+
     /** Returns the zoom level property. */
     public DoubleProperty zoomLevelProperty() {
         return zoomLevel;
@@ -330,9 +358,10 @@ public final class MapViewModel {
      * @param noteId the note id to drill into
      */
     public void drillDown(UUID noteId) {
-        navigationStack.push(noteId);
-        getNoteQuery.getNote(noteId).ifPresent(note ->
-                updateTabTitle(note.getTitle()));
+        String name = getNoteQuery.getNote(noteId)
+                .map(Note::getTitle).orElse("Unknown");
+        navigationStack.push(noteId, name);
+        updateTabTitle(name);
         loadNotes();
         eventBus.publish(new NoteMovedEvent(noteId));
     }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NavigationStack.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NavigationStack.java
@@ -126,6 +126,38 @@ public final class NavigationStack {
     }
 
     /**
+     * Navigates to a specific ancestor in the breadcrumb trail by index.
+     *
+     * <p>Index 0 is the root, and the last index is the current note.
+     * Navigating to the current index is a no-op. Navigating to an earlier
+     * index truncates the history and breadcrumb trail accordingly.</p>
+     *
+     * @param index the zero-based index in the breadcrumb trail
+     * @throws IndexOutOfBoundsException if index is out of range
+     */
+    public void navigateTo(int index) {
+        if (index < 0 || index >= breadcrumbPath.size()) {
+            throw new IndexOutOfBoundsException(
+                    "Index " + index + " out of range for breadcrumb size "
+                    + breadcrumbPath.size());
+        }
+        if (index == breadcrumbPath.size() - 1) {
+            return; // already at this position
+        }
+        // Truncate to keep entries 0..index
+        int toRemove = breadcrumbPath.size() - 1 - index;
+        for (int i = 0; i < toRemove; i++) {
+            breadcrumbPath.removeLast();
+            if (!history.isEmpty()) {
+                history.pop();
+            }
+        }
+        currentId = breadcrumbPath.get(index).noteId();
+        canNavigateBack.set(!history.isEmpty());
+        rebuildBreadcrumbs();
+    }
+
+    /**
      * Returns an observable list of breadcrumb entries representing the
      * full drill-down path from root to the current note.
      *

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/NavigationStack.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/NavigationStack.java
@@ -1,12 +1,16 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 import java.util.UUID;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 /**
  * Reusable navigation history stack for ViewModels that support drill-down navigation.
@@ -21,6 +25,10 @@ public final class NavigationStack {
     private final Deque<UUID> history = new ArrayDeque<>();
     private final BooleanProperty canNavigateBack =
             new SimpleBooleanProperty(false);
+    private final ObservableList<BreadcrumbEntry> breadcrumbs =
+            FXCollections.observableArrayList();
+    private final List<BreadcrumbEntry> breadcrumbPath =
+            new ArrayList<>();
     private UUID currentId;
 
     /**
@@ -44,6 +52,19 @@ public final class NavigationStack {
     }
 
     /**
+     * Sets the current id with a display name, updating the breadcrumb trail.
+     *
+     * @param id          the current id
+     * @param displayName the human-readable label for the breadcrumb
+     */
+    public void setCurrentId(UUID id, String displayName) {
+        this.currentId = id;
+        breadcrumbPath.clear();
+        breadcrumbPath.add(new BreadcrumbEntry(id, displayName));
+        rebuildBreadcrumbs();
+    }
+
+    /**
      * Pushes the current id onto the history stack and sets a new current id.
      *
      * @param newId the new current id to navigate to
@@ -52,6 +73,19 @@ public final class NavigationStack {
         history.push(currentId);
         currentId = newId;
         canNavigateBack.set(true);
+    }
+
+    /**
+     * Pushes the current id onto the history stack and sets a new current id
+     * with a display name, updating the breadcrumb trail.
+     *
+     * @param newId       the new current id to navigate to
+     * @param displayName the human-readable label for the breadcrumb
+     */
+    public void push(UUID newId, String displayName) {
+        push(newId);
+        breadcrumbPath.add(new BreadcrumbEntry(newId, displayName));
+        rebuildBreadcrumbs();
     }
 
     /**
@@ -66,6 +100,10 @@ public final class NavigationStack {
         UUID previous = history.pop();
         currentId = previous;
         canNavigateBack.set(!history.isEmpty());
+        if (!breadcrumbPath.isEmpty()) {
+            breadcrumbPath.removeLast();
+            rebuildBreadcrumbs();
+        }
         return previous;
     }
 
@@ -85,5 +123,19 @@ public final class NavigationStack {
      */
     public ReadOnlyBooleanProperty canNavigateBackProperty() {
         return canNavigateBack;
+    }
+
+    /**
+     * Returns an observable list of breadcrumb entries representing the
+     * full drill-down path from root to the current note.
+     *
+     * @return the unmodifiable observable breadcrumb list
+     */
+    public ObservableList<BreadcrumbEntry> getBreadcrumbs() {
+        return FXCollections.unmodifiableObservableList(breadcrumbs);
+    }
+
+    private void rebuildBreadcrumbs() {
+        breadcrumbs.setAll(breadcrumbPath);
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -123,7 +123,9 @@ public final class OutlineViewModel {
      * @param noteId the base note id
      */
     public void setBaseNoteId(UUID noteId) {
-        navigationStack.setCurrentId(noteId);
+        String name = getNoteQuery.getNote(noteId)
+                .map(Note::getTitle).orElse("Unknown");
+        navigationStack.setCurrentId(noteId, name);
     }
 
     /** Returns the base note id. */
@@ -261,14 +263,41 @@ public final class OutlineViewModel {
     }
 
     /**
+     * Returns the observable breadcrumb trail for the current drill-down path.
+     *
+     * @return the unmodifiable observable list of breadcrumb entries
+     */
+    public ObservableList<BreadcrumbEntry> getBreadcrumbs() {
+        return navigationStack.getBreadcrumbs();
+    }
+
+    /**
+     * Navigates to the breadcrumb at the given index, reloading notes
+     * and updating the tab title.
+     *
+     * @param index the zero-based breadcrumb index to navigate to
+     */
+    public void navigateToBreadcrumb(int index) {
+        navigationStack.navigateTo(index);
+        if (navigationStack.isAtRoot()) {
+            updateTabTitle(rootNoteTitle.get());
+        } else {
+            getNoteQuery.getNote(navigationStack.getCurrentId())
+                    .ifPresent(note -> updateTabTitle(note.getTitle()));
+        }
+        loadNotes();
+    }
+
+    /**
      * Drills down into a child note, making it the new base note.
      *
      * @param noteId the note id to drill into
      */
     public void drillDown(UUID noteId) {
-        navigationStack.push(noteId);
-        getNoteQuery.getNote(noteId).ifPresent(note ->
-                updateTabTitle(note.getTitle()));
+        String name = getNoteQuery.getNote(noteId)
+                .map(Note::getTitle).orElse("Unknown");
+        navigationStack.push(noteId, name);
+        updateTabTitle(name);
         loadNotes();
         eventBus.publish(new NoteMovedEvent(noteId));
     }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModel.java
@@ -94,7 +94,9 @@ public final class TreemapViewModel {
      * @param noteId the base note id
      */
     public void setBaseNoteId(UUID noteId) {
-        navigationStack.setCurrentId(noteId);
+        String name = getNoteQuery.getNote(noteId)
+                .map(Note::getTitle).orElse("Unknown");
+        navigationStack.setCurrentId(noteId, name);
     }
 
     /** Returns the base note id. */
@@ -151,14 +153,41 @@ public final class TreemapViewModel {
     }
 
     /**
+     * Returns the observable breadcrumb trail for the current drill-down path.
+     *
+     * @return the unmodifiable observable list of breadcrumb entries
+     */
+    public ObservableList<BreadcrumbEntry> getBreadcrumbs() {
+        return navigationStack.getBreadcrumbs();
+    }
+
+    /**
+     * Navigates to the breadcrumb at the given index, reloading notes
+     * and updating the tab title.
+     *
+     * @param index the zero-based breadcrumb index to navigate to
+     */
+    public void navigateToBreadcrumb(int index) {
+        navigationStack.navigateTo(index);
+        if (navigationStack.isAtRoot()) {
+            updateTabTitle(rootNoteTitle.get());
+        } else {
+            getNoteQuery.getNote(navigationStack.getCurrentId())
+                    .ifPresent(note -> updateTabTitle(note.getTitle()));
+        }
+        loadNotes();
+    }
+
+    /**
      * Drills down into a child note, making it the new base note.
      *
      * @param noteId the note id to drill into
      */
     public void drillDown(UUID noteId) {
-        navigationStack.push(noteId);
-        getNoteQuery.getNote(noteId).ifPresent(note ->
-                updateTabTitle(note.getTitle()));
+        String name = getNoteQuery.getNote(noteId)
+                .map(Note::getTitle).orElse("Unknown");
+        navigationStack.push(noteId, name);
+        updateTabTitle(name);
         loadNotes();
         eventBus.publish(new NoteMovedEvent(noteId));
     }

--- a/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerBranchTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerBranchTest.java
@@ -275,41 +275,48 @@ class OutlineViewControllerBranchTest {
                 "Root with no children should be empty");
     }
 
-    // --- Back button visibility ---
+    // --- Breadcrumb bar visibility ---
 
     @Test
-    @DisplayName("back button becomes visible after drill-down")
-    void backButton_visibleAfterDrillDown(FxRobot robot) {
-        NoteDisplayItem child =
-                viewModel.createChildNote(parentId, "Container");
-        noteService.createChildNote(child.getId(), "Nested");
-
-        // Back button is at index 0 of outlineRoot
-        var backButton = outlineRoot.getChildren().get(0);
-        assertFalse(backButton.isVisible(),
-                "Back button should be hidden at root");
-
-        robot.interact(
-                () -> viewModel.drillDown(child.getId()));
-        assertTrue(backButton.isVisible(),
-                "Back button should be visible after drill-down");
+    @DisplayName("breadcrumb bar is a BreadcrumbBar at index 0")
+    void breadcrumbBar_isPresentAtIndexZero(FxRobot robot) {
+        assertTrue(
+                outlineRoot.getChildren().get(0)
+                        instanceof BreadcrumbBar,
+                "First child should be BreadcrumbBar");
     }
 
     @Test
-    @DisplayName("back button hides after navigating back")
-    void backButton_hidesAfterNavigateBack(FxRobot robot) {
+    @DisplayName("breadcrumb bar grows after drill-down")
+    void breadcrumbBar_growsAfterDrillDown(FxRobot robot) {
+        NoteDisplayItem child =
+                viewModel.createChildNote(parentId, "Container");
+        noteService.createChildNote(child.getId(), "Nested");
+
+        BreadcrumbBar bar = (BreadcrumbBar)
+                outlineRoot.getChildren().get(0);
+        int sizeBefore = viewModel.getBreadcrumbs().size();
+
+        robot.interact(
+                () -> viewModel.drillDown(child.getId()));
+        assertTrue(viewModel.getBreadcrumbs().size() > sizeBefore,
+                "Breadcrumbs should grow after drill-down");
+    }
+
+    @Test
+    @DisplayName("breadcrumb bar shrinks after navigating back")
+    void breadcrumbBar_shrinksAfterNavigateBack(FxRobot robot) {
         NoteDisplayItem child =
                 viewModel.createChildNote(parentId, "Container");
         noteService.createChildNote(child.getId(), "Nested");
 
         robot.interact(
                 () -> viewModel.drillDown(child.getId()));
-        var backButton = outlineRoot.getChildren().get(0);
-        assertTrue(backButton.isVisible());
+        int sizeAfterDrill = viewModel.getBreadcrumbs().size();
 
         robot.interact(() -> viewModel.navigateBack());
-        assertFalse(backButton.isVisible(),
-                "Back button should hide after navigating back");
+        assertTrue(viewModel.getBreadcrumbs().size() < sizeAfterDrill,
+                "Breadcrumbs should shrink after navigating back");
     }
 
     // --- buildTreeItem with hasChildren ---

--- a/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/view/OutlineViewControllerTest.java
@@ -155,11 +155,14 @@ class OutlineViewControllerTest {
     }
 
     @Test
-    @DisplayName("back button is inserted into outlineRoot")
-    void backButton_insertedIntoRoot() {
-        // The back button is added at index 0
+    @DisplayName("breadcrumb bar is inserted into outlineRoot")
+    void breadcrumbBar_insertedIntoRoot() {
+        // The breadcrumb bar is added at index 0
         assertTrue(outlineRoot.getChildren().size() >= 1,
-                "outlineRoot should contain back button");
+                "outlineRoot should contain breadcrumb bar");
+        assertTrue(outlineRoot.getChildren().get(0)
+                instanceof BreadcrumbBar,
+                "First child should be BreadcrumbBar");
     }
 
     @Test

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/HyperbolicViewModelTest.java
@@ -262,6 +262,41 @@ class HyperbolicViewModelTest {
         assertFalse(viewModel.canNavigateBackProperty().get());
     }
 
+    // --- Breadcrumb navigation tests ---
+
+    @Test
+    @DisplayName("getBreadcrumbs grows after drillDown")
+    void getBreadcrumbs_shouldGrowAfterDrillDown() {
+        Note n1 = noteService.createNote("N1", "");
+        Note n2 = noteService.createNote("N2", "");
+        linkService.createLink(n1.getId(), n2.getId());
+        viewModel.setFocusNote(n1.getId());
+
+        viewModel.drillDown(n2.getId());
+
+        assertEquals(2, viewModel.getBreadcrumbs().size());
+        assertEquals("N1", viewModel.getBreadcrumbs().get(0).displayName());
+        assertEquals("N2", viewModel.getBreadcrumbs().get(1).displayName());
+    }
+
+    @Test
+    @DisplayName("navigateToBreadcrumb jumps to ancestor")
+    void navigateToBreadcrumb_shouldJumpToAncestor() {
+        Note n1 = noteService.createNote("N1", "");
+        Note n2 = noteService.createNote("N2", "");
+        Note n3 = noteService.createNote("N3", "");
+        linkService.createLink(n1.getId(), n2.getId());
+        linkService.createLink(n2.getId(), n3.getId());
+        viewModel.setFocusNote(n1.getId());
+        viewModel.drillDown(n2.getId());
+        viewModel.drillDown(n3.getId());
+
+        viewModel.navigateToBreadcrumb(0);
+
+        assertEquals(n1.getId(), viewModel.getFocusNoteId());
+        assertEquals(1, viewModel.getBreadcrumbs().size());
+    }
+
     @Test
     @DisplayName("AppState always notified on createLink")
     void appState_shouldAlwaysBeNotified() {

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/MapViewModelTest.java
@@ -398,6 +398,49 @@ class MapViewModelTest {
         assertFalse(viewModel.canNavigateBackProperty().get());
     }
 
+    // --- Breadcrumb navigation tests ---
+
+    @Test
+    @DisplayName("getBreadcrumbs returns root entry after setBaseNoteId")
+    void getBreadcrumbs_shouldReturnRootAfterSetBaseNoteId() {
+        Note root = noteService.createNote("Root", "");
+        viewModel.setBaseNoteId(root.getId());
+
+        assertEquals(1, viewModel.getBreadcrumbs().size());
+        assertEquals("Root", viewModel.getBreadcrumbs().get(0).displayName());
+    }
+
+    @Test
+    @DisplayName("getBreadcrumbs grows after drillDown")
+    void getBreadcrumbs_shouldGrowAfterDrillDown() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        assertEquals(2, viewModel.getBreadcrumbs().size());
+        assertEquals("Root", viewModel.getBreadcrumbs().get(0).displayName());
+        assertEquals("Child", viewModel.getBreadcrumbs().get(1).displayName());
+    }
+
+    @Test
+    @DisplayName("navigateToBreadcrumb jumps to ancestor and reloads")
+    void navigateToBreadcrumb_shouldJumpToAncestorAndReload() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        viewModel.navigateToBreadcrumb(0);
+
+        assertEquals(root.getId(), viewModel.getBaseNoteId());
+        assertEquals(1, viewModel.getBreadcrumbs().size());
+    }
+
     @Test
     @DisplayName("toDisplayItem() resolves badge from $Badge attribute")
     void toDisplayItem_shouldResolveBadgeFromAttribute() {

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/NavigationStackTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/NavigationStackTest.java
@@ -165,6 +165,53 @@ class NavigationStackTest {
     }
 
     @Test
+    @DisplayName("getBreadcrumbs returns empty list when no current id is set")
+    void getBreadcrumbs_shouldBeEmptyWhenNoCurrentId() {
+        assertTrue(stack.getBreadcrumbs().isEmpty());
+    }
+
+    @Test
+    @DisplayName("getBreadcrumbs returns single entry for root note")
+    void getBreadcrumbs_shouldReturnSingleEntryForRoot() {
+        UUID root = UUID.randomUUID();
+        stack.setCurrentId(root, "Root");
+
+        assertEquals(1, stack.getBreadcrumbs().size());
+        assertEquals(root, stack.getBreadcrumbs().get(0).noteId());
+        assertEquals("Root", stack.getBreadcrumbs().get(0).displayName());
+    }
+
+    @Test
+    @DisplayName("getBreadcrumbs returns full path after drill-down")
+    void getBreadcrumbs_shouldReturnFullPathAfterDrillDown() {
+        UUID root = UUID.randomUUID();
+        UUID child = UUID.randomUUID();
+        UUID grandchild = UUID.randomUUID();
+        stack.setCurrentId(root, "Root");
+        stack.push(child, "Child");
+        stack.push(grandchild, "Grandchild");
+
+        assertEquals(3, stack.getBreadcrumbs().size());
+        assertEquals("Root", stack.getBreadcrumbs().get(0).displayName());
+        assertEquals("Child", stack.getBreadcrumbs().get(1).displayName());
+        assertEquals("Grandchild", stack.getBreadcrumbs().get(2).displayName());
+    }
+
+    @Test
+    @DisplayName("getBreadcrumbs shrinks after pop")
+    void getBreadcrumbs_shouldShrinkAfterPop() {
+        UUID root = UUID.randomUUID();
+        UUID child = UUID.randomUUID();
+        stack.setCurrentId(root, "Root");
+        stack.push(child, "Child");
+
+        stack.pop();
+
+        assertEquals(1, stack.getBreadcrumbs().size());
+        assertEquals("Root", stack.getBreadcrumbs().get(0).displayName());
+    }
+
+    @Test
     @DisplayName("canNavigateBack property is observable and updates on pop")
     void canNavigateBackProperty_shouldUpdateOnPop() {
         UUID first = UUID.randomUUID();

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/NavigationStackTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/NavigationStackTest.java
@@ -212,6 +212,57 @@ class NavigationStackTest {
     }
 
     @Test
+    @DisplayName("navigateTo jumps to ancestor by index")
+    void navigateTo_shouldJumpToAncestorByIndex() {
+        UUID root = UUID.randomUUID();
+        UUID child = UUID.randomUUID();
+        UUID grandchild = UUID.randomUUID();
+        stack.setCurrentId(root, "Root");
+        stack.push(child, "Child");
+        stack.push(grandchild, "Grandchild");
+
+        stack.navigateTo(0);
+
+        assertEquals(root, stack.getCurrentId());
+        assertEquals(1, stack.getBreadcrumbs().size());
+        assertEquals("Root", stack.getBreadcrumbs().get(0).displayName());
+        assertFalse(stack.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("navigateTo middle ancestor keeps correct path")
+    void navigateTo_shouldKeepCorrectPathForMiddleAncestor() {
+        UUID root = UUID.randomUUID();
+        UUID child = UUID.randomUUID();
+        UUID grandchild = UUID.randomUUID();
+        stack.setCurrentId(root, "Root");
+        stack.push(child, "Child");
+        stack.push(grandchild, "Grandchild");
+
+        stack.navigateTo(1);
+
+        assertEquals(child, stack.getCurrentId());
+        assertEquals(2, stack.getBreadcrumbs().size());
+        assertEquals("Root", stack.getBreadcrumbs().get(0).displayName());
+        assertEquals("Child", stack.getBreadcrumbs().get(1).displayName());
+        assertTrue(stack.canNavigateBackProperty().get());
+    }
+
+    @Test
+    @DisplayName("navigateTo current index is a no-op")
+    void navigateTo_shouldBeNoOpForCurrentIndex() {
+        UUID root = UUID.randomUUID();
+        UUID child = UUID.randomUUID();
+        stack.setCurrentId(root, "Root");
+        stack.push(child, "Child");
+
+        stack.navigateTo(1);
+
+        assertEquals(child, stack.getCurrentId());
+        assertEquals(2, stack.getBreadcrumbs().size());
+    }
+
+    @Test
     @DisplayName("canNavigateBack property is observable and updates on pop")
     void canNavigateBackProperty_shouldUpdateOnPop() {
         UUID first = UUID.randomUUID();

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelTest.java
@@ -401,6 +401,69 @@ class OutlineViewModelTest {
         assertEquals("Outline: New Root Title", viewModel.tabTitleProperty().get());
     }
 
+    // --- Breadcrumb navigation tests ---
+
+    @Test
+    @DisplayName("getBreadcrumbs returns single root entry after setBaseNoteId")
+    void getBreadcrumbs_shouldReturnRootAfterSetBaseNoteId() {
+        Note root = noteService.createNote("Root", "");
+        viewModel.setBaseNoteId(root.getId());
+
+        ObservableList<BreadcrumbEntry> crumbs = viewModel.getBreadcrumbs();
+        assertEquals(1, crumbs.size());
+        assertEquals(root.getId(), crumbs.get(0).noteId());
+        assertEquals("Root", crumbs.get(0).displayName());
+    }
+
+    @Test
+    @DisplayName("getBreadcrumbs grows after drillDown")
+    void getBreadcrumbs_shouldGrowAfterDrillDown() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        ObservableList<BreadcrumbEntry> crumbs = viewModel.getBreadcrumbs();
+        assertEquals(2, crumbs.size());
+        assertEquals("Root", crumbs.get(0).displayName());
+        assertEquals("Child", crumbs.get(1).displayName());
+    }
+
+    @Test
+    @DisplayName("navigateToBreadcrumb jumps to ancestor and reloads")
+    void navigateToBreadcrumb_shouldJumpToAncestorAndReload() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        viewModel.navigateToBreadcrumb(0);
+
+        assertEquals(root.getId(), viewModel.getBaseNoteId());
+        assertEquals(1, viewModel.getBreadcrumbs().size());
+        assertEquals(1, viewModel.getRootItems().size());
+        assertEquals("Child", viewModel.getRootItems().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("navigateToBreadcrumb updates tab title")
+    void navigateToBreadcrumb_shouldUpdateTabTitle() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        viewModel.navigateToBreadcrumb(0);
+
+        assertEquals("Outline: My Note", viewModel.tabTitleProperty().get());
+    }
+
     // --- createSiblingNote tests ---
 
     @Test

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModelTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/TreemapViewModelTest.java
@@ -432,6 +432,49 @@ class TreemapViewModelTest {
         assertTrue(appState.getDataVersion() > versionBefore);
     }
 
+    // --- Breadcrumb navigation tests ---
+
+    @Test
+    @DisplayName("getBreadcrumbs returns root entry after setBaseNoteId")
+    void getBreadcrumbs_shouldReturnRootAfterSetBaseNoteId() {
+        Note root = noteService.createNote("Root", "");
+        viewModel.setBaseNoteId(root.getId());
+
+        assertEquals(1, viewModel.getBreadcrumbs().size());
+        assertEquals("Root", viewModel.getBreadcrumbs().get(0).displayName());
+    }
+
+    @Test
+    @DisplayName("getBreadcrumbs grows after drillDown")
+    void getBreadcrumbs_shouldGrowAfterDrillDown() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+
+        viewModel.drillDown(child.getId());
+
+        assertEquals(2, viewModel.getBreadcrumbs().size());
+        assertEquals("Root", viewModel.getBreadcrumbs().get(0).displayName());
+        assertEquals("Child", viewModel.getBreadcrumbs().get(1).displayName());
+    }
+
+    @Test
+    @DisplayName("navigateToBreadcrumb jumps to ancestor and reloads")
+    void navigateToBreadcrumb_shouldJumpToAncestorAndReload() {
+        Note root = noteService.createNote("Root", "");
+        Note child = noteService.createChildNote(root.getId(), "Child");
+        noteService.createChildNote(child.getId(), "Grandchild");
+        viewModel.setBaseNoteId(root.getId());
+        viewModel.loadNotes();
+        viewModel.drillDown(child.getId());
+
+        viewModel.navigateToBreadcrumb(0);
+
+        assertEquals(root.getId(), viewModel.getBaseNoteId());
+        assertEquals(1, viewModel.getBreadcrumbs().size());
+    }
+
     @Test
     @DisplayName("toDisplayItem() resolves badge from $Badge attribute")
     void toDisplayItem_shouldResolveBadge() {


### PR DESCRIPTION
## Summary
- Add `BreadcrumbEntry` record and extend `NavigationStack` with observable breadcrumb trail (`getBreadcrumbs()`) and `navigateTo(index)` for direct ancestor navigation
- Add `BreadcrumbBar` HBox component that renders clickable ancestor labels separated by "›" with the current location shown as bold non-clickable text
- Replace the "← Back" button with `BreadcrumbBar` in all four view controllers (Outline, Map, Treemap, Hyperbolic)
- Add `getBreadcrumbs()` and `navigateToBreadcrumb(index)` to all ViewModels that support drill-down (Outline, Map, Treemap, Hyperbolic)

## Test plan
- [x] NavigationStack breadcrumb path tests: empty, single root, multi-level drill-down, pop shrinks, navigateTo jumps correctly
- [x] OutlineViewModel breadcrumb tests: root entry after setBaseNoteId, grows after drillDown, navigateToBreadcrumb reloads and updates tab title
- [x] MapViewModel breadcrumb tests: root entry, drill-down growth, navigateToBreadcrumb
- [x] TreemapViewModel breadcrumb tests: root entry, drill-down growth, navigateToBreadcrumb
- [x] HyperbolicViewModel breadcrumb tests: drill-down growth, navigateToBreadcrumb jumps to ancestor
- [x] UI tests updated to verify BreadcrumbBar presence instead of back button
- [x] Full `mvn verify` passes (all logic tests, checkstyle, JaCoCo, ArchUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>