### PR TITLE
Update DocumentFactory reference and add cross-links in docs

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # EmberVault Architecture
 
-EmberVault is a Tinderbox-inspired note-taking application built with JavaFX, following hexagonal architecture (ports and adapters) with MVVM for the UI layer.
+EmberVault is a Tinderbox-inspired note-taking application built with JavaFX, following [hexagonal architecture](adr/0009-use-hexagonal-architecture.md) (ports and adapters) with [MVVM](adr/0013-use-mvvm-design-pattern.md) for the UI layer.
 
 ## System Overview
 
@@ -350,4 +350,16 @@ graph TD
     Root --> TopLevel["App (wiring)<br/>ViewPaneContext<br/>ViewPaneDeps<br/>ViewType (enum)"]
 ```
 
-Dependency flow is strictly inward: `adapter` depends on `application` ports, `application` depends on `domain`. ArchUnit tests enforce these boundaries at build time.
+Dependency flow is strictly inward: `adapter` depends on `application` ports, `application` depends on `domain`. [ArchUnit tests](adr/0008-use-archunit-to-enforce-architecture.md) enforce these boundaries at build time.
+
+---
+
+## See Also
+
+- [Developer Guide](DEVELOPER_GUIDE.md) — code-first walkthrough with compilable examples
+- [Contributing](../CONTRIBUTING.md) — TDD workflow and PR checklist
+- Key ADRs:
+  - [ADR-0009](adr/0009-use-hexagonal-architecture.md) — Hexagonal Architecture
+  - [ADR-0013](adr/0013-use-mvvm-design-pattern.md) — MVVM Design Pattern
+  - [ADR-0017](adr/0017-use-result-oriented-apis.md) — Result-Oriented APIs
+  - [ADR-0018](adr/0018-use-type-safe-attribute-map.md) — Type-Safe Attribute Map

--- a/doc/DEVELOPER_GUIDE.md
+++ b/doc/DEVELOPER_GUIDE.md
@@ -6,8 +6,9 @@ the current API. See also [ARCHITECTURE.md](ARCHITECTURE.md) and the
 [ADRs](adr/) for design rationale.
 
 > **Manual wiring** is used throughout so you can see exactly which objects
-> are created and how they connect. A future `DocumentFactory` will
-> automate this.
+> are created and how they connect. For convenience, see
+> [`DocumentFactory.createEmpty()`](../src/main/java/com/embervault/DocumentFactory.java)
+> which automates the standard setup.
 
 ---
 
@@ -312,3 +313,15 @@ linkService.deleteLink(link1.id());
 
 To visualize links, open the Hyperbolic view (Section 7) focused on a
 note that has links.
+
+---
+
+## See Also
+
+- [Architecture](ARCHITECTURE.md) — system overview, domain model, data flow diagrams
+- [ADRs](adr/) — design rationale for all major decisions
+  - [ADR-0009](adr/0009-use-hexagonal-architecture.md) — Hexagonal Architecture
+  - [ADR-0013](adr/0013-use-mvvm-design-pattern.md) — MVVM Design Pattern
+  - [ADR-0017](adr/0017-use-result-oriented-apis.md) — Result-Oriented APIs
+  - [ADR-0018](adr/0018-use-type-safe-attribute-map.md) — Type-Safe Attribute Map
+- [Contributing](../CONTRIBUTING.md) — TDD workflow and PR checklist


### PR DESCRIPTION
## Summary
- Replace stale "future DocumentFactory" note with reference to existing `DocumentFactory.createEmpty()` (#281)
- Add cross-links between ARCHITECTURE.md, DEVELOPER_GUIDE.md, and relevant ADRs (#280)
- Verified existing relative links in DEVELOPER_GUIDE.md are correct — no broken links found (#279)

Closes #279
Closes #280
Closes #281

## Test plan
- [ ] Verify all new links resolve correctly on GitHub
- [ ] Confirm DocumentFactory.createEmpty() reference is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)