### PR TITLE
Add undo/redo command history with EventBus integration

### DIFF
--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -65,6 +65,8 @@ public class App extends Application {
                 setup.paneDeps().noteService(),
                 setup.paneDeps().noteService(),
                 setup.appState(), setup.eventBus());
+        outlineViewModel.setCommandRecorder(
+                sharedServices.commandRecorder());
         outlineViewModel.setBaseNoteId(project.getRootNote().getId());
         var paneHolder = new ViewPaneContext[1];
         Parent outlineView = loadView("OutlineView.fxml", c -> {

--- a/src/main/java/com/embervault/App.java
+++ b/src/main/java/com/embervault/App.java
@@ -13,6 +13,7 @@ import com.embervault.adapter.in.ui.viewmodel.OutlineViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SearchViewModel;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
 import com.embervault.adapter.in.ui.viewmodel.ShortcutRegistry;
+import com.embervault.adapter.in.ui.viewmodel.UndoRedoShortcuts;
 import com.embervault.application.port.in.StampService;
 import com.embervault.domain.Attributes;
 import com.embervault.domain.Project;
@@ -228,6 +229,8 @@ public class App extends Application {
                         LOG.error("Failed to open new window", ex);
                     }
                 });
+        UndoRedoShortcuts.register(registry,
+                sharedServices.undoRedoUseCase());
         registry.register("Shortcut+D", "Delete Note",
                 "Delete the selected note", () -> {
                     UUID noteId =

--- a/src/main/java/com/embervault/OutlineViewFactory.java
+++ b/src/main/java/com/embervault/OutlineViewFactory.java
@@ -21,6 +21,7 @@ final class OutlineViewFactory implements ViewFactory {
                 deps.noteService(), deps.noteService(),
                 deps.noteService(), deps.noteService(),
                 deps.noteService(), deps.appState(), deps.eventBus());
+        vm.setCommandRecorder(deps.commandRecorder());
         vm.setBaseNoteId(baseNoteId);
         return new ViewCreationResult(
                 vm.tabTitleProperty(),

--- a/src/main/java/com/embervault/SharedServices.java
+++ b/src/main/java/com/embervault/SharedServices.java
@@ -3,13 +3,17 @@ package com.embervault;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.adapter.out.persistence.InMemoryStampRepository;
+import com.embervault.application.CommandHistory;
 import com.embervault.application.LinkServiceImpl;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.ProjectServiceImpl;
 import com.embervault.application.StampServiceImpl;
+import com.embervault.application.UndoRedoService;
+import com.embervault.application.port.in.CommandRecorder;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
+import com.embervault.application.port.in.UndoRedoUseCase;
 import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeSchemaRegistry;
 import com.embervault.domain.Project;
@@ -26,6 +30,9 @@ import com.embervault.domain.Project;
  * @param linkService     the link service
  * @param stampService    the stamp service
  * @param schemaRegistry  the attribute schema registry
+ * @param undoRedoUseCase the undo/redo use case
+ * @param commandRecorder the command recorder for registering
+ *                        undoable actions
  */
 public record SharedServices(
         Project project,
@@ -33,7 +40,9 @@ public record SharedServices(
         NoteService noteService,
         LinkService linkService,
         StampService stampService,
-        AttributeSchemaRegistry schemaRegistry
+        AttributeSchemaRegistry schemaRegistry,
+        UndoRedoUseCase undoRedoUseCase,
+        CommandRecorder commandRecorder
 ) {
 
     /**
@@ -53,8 +62,11 @@ public record SharedServices(
         noteRepo.save(project.getRootNote());
         AttributeSchemaRegistry schemaRegistry =
                 new AttributeSchemaRegistry();
+        UndoRedoService undoRedoService =
+                new UndoRedoService(new CommandHistory());
         return new SharedServices(project, noteRepo,
                 noteService, linkService,
-                stampService, schemaRegistry);
+                stampService, schemaRegistry,
+                undoRedoService, undoRedoService);
     }
 }

--- a/src/main/java/com/embervault/ViewPaneContext.java
+++ b/src/main/java/com/embervault/ViewPaneContext.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import com.embervault.adapter.in.ui.viewmodel.AppState;
 import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
+import com.embervault.application.port.in.CommandRecorder;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeSchemaRegistry;
@@ -45,6 +46,7 @@ public final class ViewPaneContext {
     private EventBus eventBus;
     private SelectedNoteViewModel selectedNoteVm;
     private StringProperty rootNoteTitle;
+    private CommandRecorder commandRecorder;
 
     private final ViewFactoryRegistry registry =
             new ViewFactoryRegistry();
@@ -127,6 +129,7 @@ public final class ViewPaneContext {
         this.eventBus = deps.eventBus();
         this.selectedNoteVm = deps.selectedNoteVm();
         this.rootNoteTitle = deps.rootNoteTitle();
+        this.commandRecorder = deps.commandRecorder();
     }
 
     /**
@@ -161,7 +164,8 @@ public final class ViewPaneContext {
 
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
-                appState, eventBus, selectedNoteVm, rootNoteTitle);
+                appState, eventBus, selectedNoteVm, rootNoteTitle,
+                commandRecorder);
         ViewFactory factory = registry.getFactory(newType);
         ViewCreationResult result = factory.create(
                 deps, baseNoteId,

--- a/src/main/java/com/embervault/ViewPaneDeps.java
+++ b/src/main/java/com/embervault/ViewPaneDeps.java
@@ -3,6 +3,7 @@ package com.embervault;
 import com.embervault.adapter.in.ui.viewmodel.AppState;
 import com.embervault.adapter.in.ui.viewmodel.EventBus;
 import com.embervault.adapter.in.ui.viewmodel.SelectedNoteViewModel;
+import com.embervault.application.port.in.CommandRecorder;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.AttributeSchemaRegistry;
@@ -12,13 +13,15 @@ import javafx.beans.property.StringProperty;
  * Shared dependencies needed by {@link ViewPaneContext} to create
  * view models and wire views during a view-type switch.
  *
- * @param noteService    the note service
- * @param linkService    the link service
- * @param schemaRegistry the attribute schema registry
- * @param appState       the shared application state for data-change notification
- * @param eventBus       the shared event bus for fire-and-forget events
- * @param selectedNoteVm the shared selected-note view model
- * @param rootNoteTitle  the root note title property
+ * @param noteService      the note service
+ * @param linkService      the link service
+ * @param schemaRegistry   the attribute schema registry
+ * @param appState         the shared application state for
+ *                         data-change notification
+ * @param eventBus         the shared event bus for fire-and-forget events
+ * @param selectedNoteVm   the shared selected-note view model
+ * @param rootNoteTitle    the root note title property
+ * @param commandRecorder  the command recorder for undo/redo
  */
 public record ViewPaneDeps(
         NoteService noteService,
@@ -27,5 +30,6 @@ public record ViewPaneDeps(
         AppState appState,
         EventBus eventBus,
         SelectedNoteViewModel selectedNoteVm,
-        StringProperty rootNoteTitle) {
+        StringProperty rootNoteTitle,
+        CommandRecorder commandRecorder) {
 }

--- a/src/main/java/com/embervault/WindowBuilder.java
+++ b/src/main/java/com/embervault/WindowBuilder.java
@@ -44,7 +44,8 @@ public final class WindowBuilder {
         ViewPaneDeps paneDeps = new ViewPaneDeps(
                 ctx.noteService(), ctx.linkService(),
                 ctx.schemaRegistry(), appState, eventBus,
-                selectedNoteVm, rootNoteTitle);
+                selectedNoteVm, rootNoteTitle,
+                ctx.commandRecorder());
 
         appState.dataVersionProperty().addListener(
                 (obs, oldVal, newVal) ->

--- a/src/main/java/com/embervault/WindowSetupContext.java
+++ b/src/main/java/com/embervault/WindowSetupContext.java
@@ -2,6 +2,7 @@ package com.embervault;
 
 import java.util.Objects;
 
+import com.embervault.application.port.in.CommandRecorder;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
@@ -53,5 +54,10 @@ public record WindowSetupContext(
     /** Returns the attribute schema registry. */
     public AttributeSchemaRegistry schemaRegistry() {
         return services.schemaRegistry();
+    }
+
+    /** Returns the command recorder for undo/redo. */
+    public CommandRecorder commandRecorder() {
+        return services.commandRecorder();
     }
 }

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModel.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.embervault.application.port.in.CommandRecorder;
 import com.embervault.application.port.in.CreateNoteUseCase;
 import com.embervault.application.port.in.DeleteNoteUseCase;
 import com.embervault.application.port.in.GetNoteQuery;
@@ -47,6 +48,7 @@ public final class OutlineViewModel {
     private final StringProperty rootNoteTitle;
     private final AppState appState;
     private final EventBus eventBus;
+    private CommandRecorder commandRecorder;
 
     /**
      * Constructs an OutlineViewModel that derives its tab title from
@@ -100,6 +102,15 @@ public final class OutlineViewModel {
                 updateTabTitle(newVal);
             }
         });
+    }
+
+    /**
+     * Sets the command recorder for registering undoable actions.
+     *
+     * @param recorder the command recorder (may be null to disable)
+     */
+    public void setCommandRecorder(CommandRecorder recorder) {
+        this.commandRecorder = recorder;
     }
 
     /** Returns the tab title property. */
@@ -173,6 +184,14 @@ public final class OutlineViewModel {
         if (parentId.equals(navigationStack.getCurrentId())) {
             rootItems.add(item);
         }
+        if (commandRecorder != null) {
+            UUID childId = child.getId();
+            commandRecorder.record(
+                    "Create note '" + title + "'",
+                    () -> deleteNoteUseCase.deleteNote(childId),
+                    () -> createNoteUseCase.createChildNote(
+                            parentId, title));
+        }
         eventBus.publish(new NoteCreatedEvent(child.getId()));
         return item;
     }
@@ -240,6 +259,8 @@ public final class OutlineViewModel {
         if (newTitle == null || newTitle.isBlank()) {
             return false;
         }
+        String oldTitle = getNoteQuery.getNote(noteId)
+                .map(Note::getTitle).orElse("");
         renameNoteUseCase.renameNote(noteId, newTitle);
         for (int i = 0; i < rootItems.size(); i++) {
             NoteDisplayItem item = rootItems.get(i);
@@ -252,6 +273,14 @@ public final class OutlineViewModel {
                         item.getBadge()));
                 break;
             }
+        }
+        if (commandRecorder != null) {
+            commandRecorder.record(
+                    "Rename '" + oldTitle + "' to '" + newTitle + "'",
+                    () -> renameNoteUseCase.renameNote(
+                            noteId, oldTitle),
+                    () -> renameNoteUseCase.renameNote(
+                            noteId, newTitle));
         }
         eventBus.publish(new NoteRenamedEvent(noteId, newTitle));
         return true;

--- a/src/main/java/com/embervault/adapter/in/ui/viewmodel/UndoRedoShortcuts.java
+++ b/src/main/java/com/embervault/adapter/in/ui/viewmodel/UndoRedoShortcuts.java
@@ -1,0 +1,30 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import com.embervault.application.port.in.UndoRedoUseCase;
+
+/**
+ * Registers undo/redo keyboard shortcuts in a {@link ShortcutRegistry}.
+ *
+ * <p>Binds Shortcut+Z to undo and Shortcut+Shift+Z to redo. Both
+ * shortcuts are registered as global (fire even during text editing).</p>
+ */
+public final class UndoRedoShortcuts {
+
+    private UndoRedoShortcuts() { }
+
+    /**
+     * Registers undo and redo shortcuts.
+     *
+     * @param registry the shortcut registry to register with
+     * @param undoRedo the undo/redo use case
+     */
+    public static void register(ShortcutRegistry registry,
+            UndoRedoUseCase undoRedo) {
+        registry.register("Shortcut+Z", "Undo",
+                "Undo the last action",
+                undoRedo::undo, true);
+        registry.register("Shortcut+Shift+Z", "Redo",
+                "Redo the last undone action",
+                undoRedo::redo, true);
+    }
+}

--- a/src/main/java/com/embervault/application/CommandHistory.java
+++ b/src/main/java/com/embervault/application/CommandHistory.java
@@ -1,0 +1,74 @@
+package com.embervault.application;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Maintains undo/redo stacks of {@link Reversible} commands.
+ *
+ * <p>Pushing a new command clears the redo stack. Undo pops from the
+ * undo stack and pushes onto the redo stack. Redo does the reverse.</p>
+ */
+public class CommandHistory {
+
+    private final Deque<Reversible> undoStack = new ArrayDeque<>();
+    private final Deque<Reversible> redoStack = new ArrayDeque<>();
+
+    /**
+     * Returns true if there is a command that can be undone.
+     *
+     * @return true if undo is available
+     */
+    public boolean canUndo() {
+        return !undoStack.isEmpty();
+    }
+
+    /**
+     * Returns true if there is a command that can be redone.
+     *
+     * @return true if redo is available
+     */
+    public boolean canRedo() {
+        return !redoStack.isEmpty();
+    }
+
+    /**
+     * Undoes the most recent command.
+     *
+     * @return true if a command was undone, false if the stack was empty
+     */
+    public boolean undo() {
+        if (undoStack.isEmpty()) {
+            return false;
+        }
+        Reversible command = undoStack.pop();
+        command.undo();
+        redoStack.push(command);
+        return true;
+    }
+
+    /**
+     * Redoes the most recently undone command.
+     *
+     * @return true if a command was redone, false if the stack was empty
+     */
+    public boolean redo() {
+        if (redoStack.isEmpty()) {
+            return false;
+        }
+        Reversible command = redoStack.pop();
+        command.redo();
+        undoStack.push(command);
+        return true;
+    }
+
+    /**
+     * Pushes a new command onto the undo stack and clears the redo stack.
+     *
+     * @param command the command to push
+     */
+    public void push(Reversible command) {
+        undoStack.push(command);
+        redoStack.clear();
+    }
+}

--- a/src/main/java/com/embervault/application/CreateNoteCommand.java
+++ b/src/main/java/com/embervault/application/CreateNoteCommand.java
@@ -1,0 +1,44 @@
+package com.embervault.application;
+
+import java.util.Objects;
+
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.Note;
+
+/**
+ * Reversible command for note creation.
+ *
+ * <p>Undo deletes the created note; redo re-saves it with the same
+ * identity and attributes.</p>
+ */
+public final class CreateNoteCommand implements Reversible {
+
+    private final NoteRepository repository;
+    private final Note note;
+
+    /**
+     * Creates a command for a newly created note.
+     *
+     * @param repository the note repository
+     * @param note       the created note (must already be saved)
+     */
+    public CreateNoteCommand(NoteRepository repository, Note note) {
+        this.repository = Objects.requireNonNull(repository);
+        this.note = Objects.requireNonNull(note);
+    }
+
+    @Override
+    public void undo() {
+        repository.delete(note.getId());
+    }
+
+    @Override
+    public void redo() {
+        repository.save(note);
+    }
+
+    @Override
+    public String description() {
+        return "Create note '" + note.getTitle() + "'";
+    }
+}

--- a/src/main/java/com/embervault/application/DeleteNoteCommand.java
+++ b/src/main/java/com/embervault/application/DeleteNoteCommand.java
@@ -1,0 +1,44 @@
+package com.embervault.application;
+
+import java.util.Objects;
+
+import com.embervault.application.port.out.NoteRepository;
+import com.embervault.domain.Note;
+
+/**
+ * Reversible command for note deletion.
+ *
+ * <p>Captures the full note before deletion so that undo can re-save
+ * it with the same identity and attributes.</p>
+ */
+public final class DeleteNoteCommand implements Reversible {
+
+    private final NoteRepository repository;
+    private final Note note;
+
+    /**
+     * Creates a command for a note that is about to be deleted.
+     *
+     * @param repository the note repository
+     * @param note       the note snapshot (before deletion)
+     */
+    public DeleteNoteCommand(NoteRepository repository, Note note) {
+        this.repository = Objects.requireNonNull(repository);
+        this.note = Objects.requireNonNull(note);
+    }
+
+    @Override
+    public void undo() {
+        repository.save(note);
+    }
+
+    @Override
+    public void redo() {
+        repository.delete(note.getId());
+    }
+
+    @Override
+    public String description() {
+        return "Delete note '" + note.getTitle() + "'";
+    }
+}

--- a/src/main/java/com/embervault/application/MoveNoteCommand.java
+++ b/src/main/java/com/embervault/application/MoveNoteCommand.java
@@ -1,0 +1,51 @@
+package com.embervault.application;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.MoveNoteUseCase;
+
+/**
+ * Reversible command for moving a note to a different parent.
+ *
+ * <p>Captures the old and new parent ids so that undo moves the note
+ * back to its original parent.</p>
+ */
+public final class MoveNoteCommand implements Reversible {
+
+    private final MoveNoteUseCase moveUseCase;
+    private final UUID noteId;
+    private final UUID oldParentId;
+    private final UUID newParentId;
+
+    /**
+     * Creates a move command.
+     *
+     * @param moveUseCase the use case for moving notes
+     * @param noteId      the note to move
+     * @param oldParentId the parent before the move
+     * @param newParentId the parent after the move
+     */
+    public MoveNoteCommand(MoveNoteUseCase moveUseCase, UUID noteId,
+            UUID oldParentId, UUID newParentId) {
+        this.moveUseCase = Objects.requireNonNull(moveUseCase);
+        this.noteId = Objects.requireNonNull(noteId);
+        this.oldParentId = Objects.requireNonNull(oldParentId);
+        this.newParentId = Objects.requireNonNull(newParentId);
+    }
+
+    @Override
+    public void undo() {
+        moveUseCase.moveNote(noteId, oldParentId);
+    }
+
+    @Override
+    public void redo() {
+        moveUseCase.moveNote(noteId, newParentId);
+    }
+
+    @Override
+    public String description() {
+        return "Move note";
+    }
+}

--- a/src/main/java/com/embervault/application/RenameCommand.java
+++ b/src/main/java/com/embervault/application/RenameCommand.java
@@ -1,0 +1,51 @@
+package com.embervault.application;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.RenameNoteUseCase;
+
+/**
+ * Reversible command that renames a note.
+ *
+ * <p>Captures the old and new title so that undo restores the original
+ * name and redo re-applies the new name.</p>
+ */
+public final class RenameCommand implements Reversible {
+
+    private final RenameNoteUseCase renameUseCase;
+    private final UUID noteId;
+    private final String oldTitle;
+    private final String newTitle;
+
+    /**
+     * Creates a rename command.
+     *
+     * @param renameUseCase the use case for renaming
+     * @param noteId        the note to rename
+     * @param oldTitle      the title before the rename
+     * @param newTitle      the title after the rename
+     */
+    public RenameCommand(RenameNoteUseCase renameUseCase, UUID noteId,
+            String oldTitle, String newTitle) {
+        this.renameUseCase = Objects.requireNonNull(renameUseCase);
+        this.noteId = Objects.requireNonNull(noteId);
+        this.oldTitle = Objects.requireNonNull(oldTitle);
+        this.newTitle = Objects.requireNonNull(newTitle);
+    }
+
+    @Override
+    public void undo() {
+        renameUseCase.renameNote(noteId, oldTitle);
+    }
+
+    @Override
+    public void redo() {
+        renameUseCase.renameNote(noteId, newTitle);
+    }
+
+    @Override
+    public String description() {
+        return "Rename '" + oldTitle + "' to '" + newTitle + "'";
+    }
+}

--- a/src/main/java/com/embervault/application/Reversible.java
+++ b/src/main/java/com/embervault/application/Reversible.java
@@ -1,0 +1,27 @@
+package com.embervault.application;
+
+/**
+ * A command that can be undone and redone.
+ *
+ * <p>Implementations capture enough state to reverse and re-apply
+ * a single user action.</p>
+ */
+public interface Reversible {
+
+    /**
+     * Undoes this command, restoring the previous state.
+     */
+    void undo();
+
+    /**
+     * Re-applies this command after it has been undone.
+     */
+    void redo();
+
+    /**
+     * Returns a human-readable description of this command.
+     *
+     * @return the description
+     */
+    String description();
+}

--- a/src/main/java/com/embervault/application/UndoRedoService.java
+++ b/src/main/java/com/embervault/application/UndoRedoService.java
@@ -2,14 +2,19 @@ package com.embervault.application;
 
 import java.util.Objects;
 
+import com.embervault.application.port.in.CommandRecorder;
 import com.embervault.application.port.in.UndoRedoUseCase;
 
 /**
- * Application service implementing undo/redo operations.
+ * Application service implementing undo/redo operations and command
+ * recording.
  *
- * <p>Delegates to {@link CommandHistory} for stack management.</p>
+ * <p>Delegates to {@link CommandHistory} for stack management.
+ * ViewModels use the {@link CommandRecorder} interface to register
+ * undoable actions.</p>
  */
-public final class UndoRedoService implements UndoRedoUseCase {
+public final class UndoRedoService
+        implements UndoRedoUseCase, CommandRecorder {
 
     private final CommandHistory history;
 
@@ -40,5 +45,26 @@ public final class UndoRedoService implements UndoRedoUseCase {
     @Override
     public boolean canRedo() {
         return history.canRedo();
+    }
+
+    @Override
+    public void record(String description, Runnable undoAction,
+            Runnable redoAction) {
+        history.push(new Reversible() {
+            @Override
+            public void undo() {
+                undoAction.run();
+            }
+
+            @Override
+            public void redo() {
+                redoAction.run();
+            }
+
+            @Override
+            public String description() {
+                return description;
+            }
+        });
     }
 }

--- a/src/main/java/com/embervault/application/UndoRedoService.java
+++ b/src/main/java/com/embervault/application/UndoRedoService.java
@@ -1,0 +1,44 @@
+package com.embervault.application;
+
+import java.util.Objects;
+
+import com.embervault.application.port.in.UndoRedoUseCase;
+
+/**
+ * Application service implementing undo/redo operations.
+ *
+ * <p>Delegates to {@link CommandHistory} for stack management.</p>
+ */
+public final class UndoRedoService implements UndoRedoUseCase {
+
+    private final CommandHistory history;
+
+    /**
+     * Creates the service.
+     *
+     * @param history the command history
+     */
+    public UndoRedoService(CommandHistory history) {
+        this.history = Objects.requireNonNull(history);
+    }
+
+    @Override
+    public boolean undo() {
+        return history.undo();
+    }
+
+    @Override
+    public boolean redo() {
+        return history.redo();
+    }
+
+    @Override
+    public boolean canUndo() {
+        return history.canUndo();
+    }
+
+    @Override
+    public boolean canRedo() {
+        return history.canRedo();
+    }
+}

--- a/src/main/java/com/embervault/application/UpdateTextCommand.java
+++ b/src/main/java/com/embervault/application/UpdateTextCommand.java
@@ -1,0 +1,51 @@
+package com.embervault.application;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.embervault.application.port.in.UpdateNoteTextUseCase;
+
+/**
+ * Reversible command for updating a note's text content.
+ *
+ * <p>Captures the old and new text so that undo restores the previous
+ * content and redo re-applies the new content.</p>
+ */
+public final class UpdateTextCommand implements Reversible {
+
+    private final UpdateNoteTextUseCase updateTextUseCase;
+    private final UUID noteId;
+    private final String oldText;
+    private final String newText;
+
+    /**
+     * Creates a text update command.
+     *
+     * @param updateTextUseCase the use case for updating text
+     * @param noteId            the note to update
+     * @param oldText           the text before the update
+     * @param newText           the text after the update
+     */
+    public UpdateTextCommand(UpdateNoteTextUseCase updateTextUseCase,
+            UUID noteId, String oldText, String newText) {
+        this.updateTextUseCase = Objects.requireNonNull(updateTextUseCase);
+        this.noteId = Objects.requireNonNull(noteId);
+        this.oldText = Objects.requireNonNull(oldText);
+        this.newText = Objects.requireNonNull(newText);
+    }
+
+    @Override
+    public void undo() {
+        updateTextUseCase.updateNoteText(noteId, oldText);
+    }
+
+    @Override
+    public void redo() {
+        updateTextUseCase.updateNoteText(noteId, newText);
+    }
+
+    @Override
+    public String description() {
+        return "Update note text";
+    }
+}

--- a/src/main/java/com/embervault/application/port/in/CommandRecorder.java
+++ b/src/main/java/com/embervault/application/port/in/CommandRecorder.java
@@ -1,0 +1,21 @@
+package com.embervault.application.port.in;
+
+/**
+ * Inbound port for recording undoable commands.
+ *
+ * <p>ViewModels call {@link #record} after performing an action to
+ * enable undo/redo. Each recorded action captures an undo and redo
+ * function pair.</p>
+ */
+public interface CommandRecorder {
+
+    /**
+     * Records an undoable action.
+     *
+     * @param description human-readable description of the action
+     * @param undoAction  the action to perform on undo
+     * @param redoAction  the action to perform on redo
+     */
+    void record(String description, Runnable undoAction,
+            Runnable redoAction);
+}

--- a/src/main/java/com/embervault/application/port/in/UndoRedoUseCase.java
+++ b/src/main/java/com/embervault/application/port/in/UndoRedoUseCase.java
@@ -1,0 +1,39 @@
+package com.embervault.application.port.in;
+
+/**
+ * Use case for undo/redo operations.
+ *
+ * <p>Provides methods to undo the most recent command, redo the most
+ * recently undone command, and query whether those operations are
+ * available.</p>
+ */
+public interface UndoRedoUseCase {
+
+    /**
+     * Undoes the most recent command.
+     *
+     * @return true if a command was undone, false if nothing to undo
+     */
+    boolean undo();
+
+    /**
+     * Redoes the most recently undone command.
+     *
+     * @return true if a command was redone, false if nothing to redo
+     */
+    boolean redo();
+
+    /**
+     * Returns true if there is a command available to undo.
+     *
+     * @return true if undo is available
+     */
+    boolean canUndo();
+
+    /**
+     * Returns true if there is a command available to redo.
+     *
+     * @return true if redo is available
+     */
+    boolean canRedo();
+}

--- a/src/test/java/com/embervault/SharedServicesTest.java
+++ b/src/test/java/com/embervault/SharedServicesTest.java
@@ -6,10 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import com.embervault.adapter.out.persistence.InMemoryLinkRepository;
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.adapter.out.persistence.InMemoryStampRepository;
+import com.embervault.application.CommandHistory;
 import com.embervault.application.LinkServiceImpl;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.ProjectServiceImpl;
 import com.embervault.application.StampServiceImpl;
+import com.embervault.application.UndoRedoService;
 import com.embervault.application.port.in.LinkService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.application.port.in.StampService;
@@ -35,9 +37,12 @@ class SharedServicesTest {
         AttributeSchemaRegistry registry = new AttributeSchemaRegistry();
         Project project = new ProjectServiceImpl().createEmptyProject();
 
+        UndoRedoService undoRedoService =
+                new UndoRedoService(new CommandHistory());
         SharedServices services = new SharedServices(
                 project, noteRepo, noteService, linkService,
-                stampService, registry);
+                stampService, registry,
+                undoRedoService, undoRedoService);
 
         assertNotNull(services.project());
         assertSame(noteService, services.noteService());

--- a/src/test/java/com/embervault/ViewFactoryCreateTest.java
+++ b/src/test/java/com/embervault/ViewFactoryCreateTest.java
@@ -55,7 +55,7 @@ class ViewFactoryCreateTest {
         deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
                 appState, new EventBus(), selectedNoteVm,
-                rootNoteTitle);
+                rootNoteTitle, null);
         registry = new ViewFactoryRegistry();
     }
 

--- a/src/test/java/com/embervault/ViewPaneContextBranchTest.java
+++ b/src/test/java/com/embervault/ViewPaneContextBranchTest.java
@@ -99,7 +99,7 @@ class ViewPaneContextBranchTest {
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
                 appState, new EventBus(), selectedNoteVm,
-                rootNoteTitle);
+                rootNoteTitle, null);
         paneContext.setDeps(deps);
     }
 

--- a/src/test/java/com/embervault/ViewPaneContextRefreshTest.java
+++ b/src/test/java/com/embervault/ViewPaneContextRefreshTest.java
@@ -92,7 +92,7 @@ class ViewPaneContextRefreshTest {
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
                 appState, new EventBus(), selectedNoteVm,
-                rootNoteTitle);
+                rootNoteTitle, null);
         paneContext.setDeps(deps);
     }
 

--- a/src/test/java/com/embervault/ViewPaneContextTest.java
+++ b/src/test/java/com/embervault/ViewPaneContextTest.java
@@ -88,7 +88,7 @@ class ViewPaneContextTest {
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
                 new AppState(), new EventBus(), selectedNoteVm,
-                rootNoteTitle);
+                rootNoteTitle, null);
         paneContext.setDeps(deps);
     }
 
@@ -171,7 +171,7 @@ class ViewPaneContextTest {
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, linkService, schemaRegistry,
                 new AppState(), new EventBus(), selectedNoteVm,
-                rootNoteTitle);
+                rootNoteTitle, null);
         ctx.setDeps(deps);
 
         ctx.refreshCurrentView();

--- a/src/test/java/com/embervault/ViewPaneDepsEventBusTest.java
+++ b/src/test/java/com/embervault/ViewPaneDepsEventBusTest.java
@@ -35,7 +35,7 @@ class ViewPaneDepsEventBusTest {
         ViewPaneDeps deps = new ViewPaneDeps(
                 noteService, null, new AttributeSchemaRegistry(),
                 appState, eventBus, selectedNoteVm,
-                new SimpleStringProperty("Root"));
+                new SimpleStringProperty("Root"), null);
 
         assertNotNull(deps.eventBus());
         assertSame(eventBus, deps.eventBus());

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelUndoTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelUndoTest.java
@@ -4,13 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.CommandHistory;
 import com.embervault.application.NoteServiceImpl;
 import com.embervault.application.UndoRedoService;
 import com.embervault.application.port.in.NoteService;
 import com.embervault.domain.Note;
-import java.util.UUID;
 import javafx.beans.property.SimpleStringProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelUndoTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/OutlineViewModelUndoTest.java
@@ -1,0 +1,139 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.CommandHistory;
+import com.embervault.application.NoteServiceImpl;
+import com.embervault.application.UndoRedoService;
+import com.embervault.application.port.in.NoteService;
+import com.embervault.domain.Note;
+import java.util.UUID;
+import javafx.beans.property.SimpleStringProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OutlineViewModelUndoTest {
+
+    private OutlineViewModel viewModel;
+    private NoteService noteService;
+    private InMemoryNoteRepository repository;
+    private UndoRedoService undoRedoService;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        noteService = new NoteServiceImpl(repository);
+        EventBus eventBus = new EventBus();
+        AppState appState = new AppState();
+        CommandHistory history = new CommandHistory();
+        undoRedoService = new UndoRedoService(history);
+        viewModel = new OutlineViewModel(
+                new SimpleStringProperty("Root"),
+                noteService, noteService, noteService,
+                noteService, noteService, noteService,
+                appState, eventBus);
+        viewModel.setCommandRecorder(undoRedoService);
+    }
+
+    @Test
+    @DisplayName("rename records an undoable command")
+    void rename_recordsUndoableCommand() {
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
+        Note child = noteService.createChildNote(
+                parent.getId(), "Original");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        viewModel.renameNote(child.getId(), "Renamed");
+
+        assertTrue(undoRedoService.canUndo());
+    }
+
+    @Test
+    @DisplayName("undo rename restores the original title")
+    void undoRename_restoresOriginalTitle() {
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
+        Note child = noteService.createChildNote(
+                parent.getId(), "Original");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        viewModel.renameNote(child.getId(), "Renamed");
+        undoRedoService.undo();
+
+        assertEquals("Original",
+                repository.findById(child.getId())
+                        .orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("redo rename re-applies the new title")
+    void redoRename_reappliesNewTitle() {
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
+        Note child = noteService.createChildNote(
+                parent.getId(), "Original");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        viewModel.renameNote(child.getId(), "Renamed");
+        undoRedoService.undo();
+        undoRedoService.redo();
+
+        assertEquals("Renamed",
+                repository.findById(child.getId())
+                        .orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("create child note records an undoable command")
+    void createChild_recordsUndoableCommand() {
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        viewModel.createChildNote(parent.getId(), "New Child");
+
+        assertTrue(undoRedoService.canUndo());
+    }
+
+    @Test
+    @DisplayName("undo create deletes the created note")
+    void undoCreate_deletesCreatedNote() {
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        NoteDisplayItem item = viewModel.createChildNote(
+                parent.getId(), "New Child");
+        UUID childId = item.getId();
+        assertTrue(repository.findById(childId).isPresent());
+
+        undoRedoService.undo();
+
+        assertFalse(repository.findById(childId).isPresent());
+    }
+
+    @Test
+    @DisplayName("rename without recorder does not throw")
+    void rename_withoutRecorder_doesNotThrow() {
+        viewModel.setCommandRecorder(null);
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
+        Note child = noteService.createChildNote(
+                parent.getId(), "Original");
+        viewModel.setBaseNoteId(parent.getId());
+        viewModel.loadNotes();
+
+        assertTrue(viewModel.renameNote(child.getId(), "Renamed"));
+        assertFalse(undoRedoService.canUndo());
+    }
+}

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/UndoRedoShortcutTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/UndoRedoShortcutTest.java
@@ -1,14 +1,13 @@
 package com.embervault.adapter.in.ui.viewmodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import com.embervault.application.CommandHistory;
 import com.embervault.application.UndoRedoService;
-import com.embervault.application.port.in.UndoRedoUseCase;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/embervault/adapter/in/ui/viewmodel/UndoRedoShortcutTest.java
+++ b/src/test/java/com/embervault/adapter/in/ui/viewmodel/UndoRedoShortcutTest.java
@@ -1,0 +1,83 @@
+package com.embervault.adapter.in.ui.viewmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.application.CommandHistory;
+import com.embervault.application.UndoRedoService;
+import com.embervault.application.port.in.UndoRedoUseCase;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UndoRedoShortcutTest {
+
+    private ShortcutRegistry registry;
+    private UndoRedoService undoRedoService;
+
+    @BeforeEach
+    void setUp() {
+        registry = new ShortcutRegistry();
+        CommandHistory history = new CommandHistory();
+        undoRedoService = new UndoRedoService(history);
+        UndoRedoShortcuts.register(registry, undoRedoService);
+    }
+
+    @Test
+    @DisplayName("registers Shortcut+Z for undo")
+    void registersUndoShortcut() {
+        assertTrue(registry.lookup("Shortcut+Z").isPresent());
+        assertEquals("Undo",
+                registry.lookup("Shortcut+Z").orElseThrow().name());
+    }
+
+    @Test
+    @DisplayName("registers Shortcut+Shift+Z for redo")
+    void registersRedoShortcut() {
+        assertTrue(registry.lookup("Shortcut+Shift+Z").isPresent());
+        assertEquals("Redo",
+                registry.lookup("Shortcut+Shift+Z").orElseThrow()
+                        .name());
+    }
+
+    @Test
+    @DisplayName("undo shortcut triggers undo")
+    void undoShortcut_triggersUndo() {
+        List<String> calls = new ArrayList<>();
+        undoRedoService.record("test",
+                () -> calls.add("undo"),
+                () -> calls.add("redo"));
+
+        registry.lookup("Shortcut+Z").orElseThrow().action().run();
+
+        assertEquals(List.of("undo"), calls);
+    }
+
+    @Test
+    @DisplayName("redo shortcut triggers redo")
+    void redoShortcut_triggersRedo() {
+        List<String> calls = new ArrayList<>();
+        undoRedoService.record("test",
+                () -> calls.add("undo"),
+                () -> calls.add("redo"));
+
+        registry.lookup("Shortcut+Z").orElseThrow().action().run();
+        calls.clear();
+        registry.lookup("Shortcut+Shift+Z").orElseThrow()
+                .action().run();
+
+        assertEquals(List.of("redo"), calls);
+    }
+
+    @Test
+    @DisplayName("undo and redo shortcuts are global")
+    void shortcuts_areGlobal() {
+        assertTrue(registry.lookup("Shortcut+Z").orElseThrow()
+                .global());
+        assertTrue(registry.lookup("Shortcut+Shift+Z").orElseThrow()
+                .global());
+    }
+}

--- a/src/test/java/com/embervault/application/CommandHistoryTest.java
+++ b/src/test/java/com/embervault/application/CommandHistoryTest.java
@@ -1,0 +1,41 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommandHistoryTest {
+
+    private CommandHistory history;
+
+    @BeforeEach
+    void setUp() {
+        history = new CommandHistory();
+    }
+
+    @Test
+    @DisplayName("new CommandHistory has nothing to undo")
+    void newHistory_cannotUndo() {
+        assertFalse(history.canUndo());
+    }
+
+    @Test
+    @DisplayName("new CommandHistory has nothing to redo")
+    void newHistory_cannotRedo() {
+        assertFalse(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("undo on empty history returns false")
+    void undo_emptyHistory_returnsFalse() {
+        assertFalse(history.undo());
+    }
+
+    @Test
+    @DisplayName("redo on empty history returns false")
+    void redo_emptyHistory_returnsFalse() {
+        assertFalse(history.redo());
+    }
+}

--- a/src/test/java/com/embervault/application/CommandHistoryTest.java
+++ b/src/test/java/com/embervault/application/CommandHistoryTest.java
@@ -1,6 +1,11 @@
 package com.embervault.application;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,5 +42,98 @@ class CommandHistoryTest {
     @DisplayName("redo on empty history returns false")
     void redo_emptyHistory_returnsFalse() {
         assertFalse(history.redo());
+    }
+
+    @Test
+    @DisplayName("push makes canUndo true")
+    void push_makesCanUndoTrue() {
+        history.push(stubCommand("test"));
+        assertTrue(history.canUndo());
+    }
+
+    @Test
+    @DisplayName("undo calls command.undo() and moves to redo stack")
+    void undo_callsUndoAndMovesToRedoStack() {
+        List<String> calls = new ArrayList<>();
+        history.push(trackingCommand("cmd", calls));
+
+        assertTrue(history.undo());
+
+        assertEquals(List.of("undo:cmd"), calls);
+        assertFalse(history.canUndo());
+        assertTrue(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("redo calls command.redo() and moves back to undo stack")
+    void redo_callsRedoAndMovesToUndoStack() {
+        List<String> calls = new ArrayList<>();
+        history.push(trackingCommand("cmd", calls));
+        history.undo();
+        calls.clear();
+
+        assertTrue(history.redo());
+
+        assertEquals(List.of("redo:cmd"), calls);
+        assertTrue(history.canUndo());
+        assertFalse(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("push clears redo stack")
+    void push_clearsRedoStack() {
+        history.push(stubCommand("first"));
+        history.undo();
+        assertTrue(history.canRedo());
+
+        history.push(stubCommand("second"));
+        assertFalse(history.canRedo());
+    }
+
+    @Test
+    @DisplayName("undo/redo preserves LIFO order")
+    void undoRedo_preservesLifoOrder() {
+        List<String> calls = new ArrayList<>();
+        history.push(trackingCommand("A", calls));
+        history.push(trackingCommand("B", calls));
+
+        history.undo();
+        history.undo();
+
+        assertEquals(List.of("undo:B", "undo:A"), calls);
+    }
+
+    private Reversible stubCommand(String desc) {
+        return new Reversible() {
+            @Override
+            public void undo() { }
+
+            @Override
+            public void redo() { }
+
+            @Override
+            public String description() {
+                return desc;
+            }
+        };
+    }
+
+    private Reversible trackingCommand(String desc, List<String> calls) {
+        return new Reversible() {
+            @Override
+            public void undo() {
+                calls.add("undo:" + desc);
+            }
+
+            @Override
+            public void redo() {
+                calls.add("redo:" + desc);
+            }
+
+            @Override
+            public String description() {
+                return desc;
+            }
+        };
     }
 }

--- a/src/test/java/com/embervault/application/CreateNoteCommandTest.java
+++ b/src/test/java/com/embervault/application/CreateNoteCommandTest.java
@@ -1,0 +1,57 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CreateNoteCommandTest {
+
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+    }
+
+    @Test
+    @DisplayName("undo deletes the created note")
+    void undo_deletesCreatedNote() {
+        Note note = Note.create("Test", "content");
+        repository.save(note);
+        CreateNoteCommand cmd = new CreateNoteCommand(repository, note);
+
+        cmd.undo();
+
+        assertFalse(repository.findById(note.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("redo re-saves the note")
+    void redo_reSavesNote() {
+        Note note = Note.create("Test", "content");
+        repository.save(note);
+        CreateNoteCommand cmd = new CreateNoteCommand(repository, note);
+        cmd.undo();
+
+        cmd.redo();
+
+        assertTrue(repository.findById(note.getId()).isPresent());
+        assertEquals("Test", repository.findById(note.getId())
+                .orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("description mentions creation")
+    void description_mentionsCreation() {
+        Note note = Note.create("My Note", "content");
+        CreateNoteCommand cmd = new CreateNoteCommand(repository, note);
+
+        assertEquals("Create note 'My Note'", cmd.description());
+    }
+}

--- a/src/test/java/com/embervault/application/DeleteNoteCommandTest.java
+++ b/src/test/java/com/embervault/application/DeleteNoteCommandTest.java
@@ -1,0 +1,60 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DeleteNoteCommandTest {
+
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+    }
+
+    @Test
+    @DisplayName("undo restores the deleted note")
+    void undo_restoresDeletedNote() {
+        Note note = Note.create("Test", "content");
+        repository.save(note);
+        DeleteNoteCommand cmd = new DeleteNoteCommand(repository, note);
+        cmd.redo();
+        assertFalse(repository.findById(note.getId()).isPresent());
+
+        cmd.undo();
+
+        assertTrue(repository.findById(note.getId()).isPresent());
+        assertEquals("Test", repository.findById(note.getId())
+                .orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("redo deletes the note again")
+    void redo_deletesNoteAgain() {
+        Note note = Note.create("Test", "content");
+        repository.save(note);
+        DeleteNoteCommand cmd = new DeleteNoteCommand(repository, note);
+        cmd.redo();
+        cmd.undo();
+
+        cmd.redo();
+
+        assertFalse(repository.findById(note.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("description mentions deletion")
+    void description_mentionsDeletion() {
+        Note note = Note.create("My Note", "content");
+        DeleteNoteCommand cmd = new DeleteNoteCommand(repository, note);
+
+        assertEquals("Delete note 'My Note'", cmd.description());
+    }
+}

--- a/src/test/java/com/embervault/application/MoveNoteCommandTest.java
+++ b/src/test/java/com/embervault/application/MoveNoteCommandTest.java
@@ -2,10 +2,11 @@ package com.embervault.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.UUID;
+
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.port.in.MoveNoteUseCase;
 import com.embervault.domain.Note;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/embervault/application/MoveNoteCommandTest.java
+++ b/src/test/java/com/embervault/application/MoveNoteCommandTest.java
@@ -1,0 +1,69 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.MoveNoteUseCase;
+import com.embervault.domain.Note;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MoveNoteCommandTest {
+
+    private MoveNoteUseCase moveUseCase;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        moveUseCase = service;
+    }
+
+    @Test
+    @DisplayName("undo moves note back to original parent")
+    void undo_movesBackToOriginalParent() {
+        Note parent1 = Note.create("Parent1", "");
+        Note parent2 = Note.create("Parent2", "");
+        Note child = Note.create("Child", "");
+        repository.save(parent1);
+        repository.save(parent2);
+        repository.save(child);
+
+        moveUseCase.moveNote(child.getId(), parent1.getId());
+
+        MoveNoteCommand cmd = new MoveNoteCommand(
+                moveUseCase, child.getId(),
+                parent1.getId(), parent2.getId());
+        cmd.redo();
+
+        assertEquals(parent2.getId().toString(),
+                containerOf(child.getId()));
+
+        cmd.undo();
+
+        assertEquals(parent1.getId().toString(),
+                containerOf(child.getId()));
+    }
+
+    @Test
+    @DisplayName("description mentions move")
+    void description_mentionsMove() {
+        MoveNoteCommand cmd = new MoveNoteCommand(
+                moveUseCase, UUID.randomUUID(),
+                UUID.randomUUID(), UUID.randomUUID());
+
+        assertEquals("Move note", cmd.description());
+    }
+
+    private String containerOf(UUID noteId) {
+        return repository.findById(noteId)
+                .orElseThrow()
+                .getAttribute(com.embervault.domain.Attributes.CONTAINER)
+                .map(v -> ((com.embervault.domain.AttributeValue.StringValue) v)
+                        .value())
+                .orElse("");
+    }
+}

--- a/src/test/java/com/embervault/application/RenameCommandTest.java
+++ b/src/test/java/com/embervault/application/RenameCommandTest.java
@@ -1,0 +1,67 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.CreateNoteUseCase;
+import com.embervault.application.port.in.RenameNoteUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RenameCommandTest {
+
+    private RenameNoteUseCase renameUseCase;
+    private CreateNoteUseCase creator;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        renameUseCase = service;
+        creator = service;
+    }
+
+    @Test
+    @DisplayName("undo restores the previous title")
+    void undo_restoresPreviousTitle() {
+        Note note = creator.createNote("Original", "content");
+        RenameCommand cmd = new RenameCommand(
+                renameUseCase, note.getId(), "Original", "Renamed");
+        cmd.redo();
+
+        assertEquals("Renamed", repository.findById(note.getId())
+                .orElseThrow().getTitle());
+
+        cmd.undo();
+
+        assertEquals("Original", repository.findById(note.getId())
+                .orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("redo re-applies the rename")
+    void redo_reappliesRename() {
+        Note note = creator.createNote("Original", "content");
+        RenameCommand cmd = new RenameCommand(
+                renameUseCase, note.getId(), "Original", "Renamed");
+        cmd.redo();
+        cmd.undo();
+        cmd.redo();
+
+        assertEquals("Renamed", repository.findById(note.getId())
+                .orElseThrow().getTitle());
+    }
+
+    @Test
+    @DisplayName("description mentions rename")
+    void description_mentionsRename() {
+        Note note = creator.createNote("Old", "content");
+        RenameCommand cmd = new RenameCommand(
+                renameUseCase, note.getId(), "Old", "New");
+
+        assertEquals("Rename 'Old' to 'New'", cmd.description());
+    }
+}

--- a/src/test/java/com/embervault/application/SharedServicesUndoRedoTest.java
+++ b/src/test/java/com/embervault/application/SharedServicesUndoRedoTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.embervault.SharedServices;
-import com.embervault.application.port.in.CommandRecorder;
-import com.embervault.application.port.in.UndoRedoUseCase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/embervault/application/SharedServicesUndoRedoTest.java
+++ b/src/test/java/com/embervault/application/SharedServicesUndoRedoTest.java
@@ -1,0 +1,36 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.SharedServices;
+import com.embervault.application.port.in.CommandRecorder;
+import com.embervault.application.port.in.UndoRedoUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SharedServicesUndoRedoTest {
+
+    @Test
+    @DisplayName("SharedServices provides UndoRedoUseCase")
+    void sharedServices_providesUndoRedoUseCase() {
+        SharedServices services = SharedServices.create();
+        assertNotNull(services.undoRedoUseCase());
+    }
+
+    @Test
+    @DisplayName("SharedServices provides CommandRecorder")
+    void sharedServices_providesCommandRecorder() {
+        SharedServices services = SharedServices.create();
+        assertNotNull(services.commandRecorder());
+    }
+
+    @Test
+    @DisplayName("undo/redo and recorder share the same history")
+    void undoRedoAndRecorder_shareSameHistory() {
+        SharedServices services = SharedServices.create();
+        services.commandRecorder().record("test",
+                () -> { }, () -> { });
+        assertTrue(services.undoRedoUseCase().canUndo());
+    }
+}

--- a/src/test/java/com/embervault/application/UndoRedoServiceTest.java
+++ b/src/test/java/com/embervault/application/UndoRedoServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.embervault.application.port.in.CommandRecorder;
 import com.embervault.application.port.in.UndoRedoUseCase;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,19 +14,54 @@ import org.junit.jupiter.api.Test;
 
 class UndoRedoServiceTest {
 
+    private UndoRedoService service;
     private UndoRedoUseCase undoRedo;
     private CommandHistory history;
 
     @BeforeEach
     void setUp() {
         history = new CommandHistory();
-        undoRedo = new UndoRedoService(history);
+        service = new UndoRedoService(history);
+        undoRedo = service;
     }
 
     @Test
     @DisplayName("implements UndoRedoUseCase")
     void implementsUseCase() {
         assertTrue(undoRedo instanceof UndoRedoUseCase);
+    }
+
+    @Test
+    @DisplayName("implements CommandRecorder")
+    void implementsCommandRecorder() {
+        assertTrue(service instanceof CommandRecorder);
+    }
+
+    @Test
+    @DisplayName("record creates an undoable command")
+    void record_createsUndoableCommand() {
+        List<String> calls = new ArrayList<>();
+        service.record("test action",
+                () -> calls.add("undo"),
+                () -> calls.add("redo"));
+
+        assertTrue(undoRedo.canUndo());
+        undoRedo.undo();
+        assertEquals(List.of("undo"), calls);
+    }
+
+    @Test
+    @DisplayName("recorded command can be redone")
+    void record_canBeRedone() {
+        List<String> calls = new ArrayList<>();
+        service.record("test action",
+                () -> calls.add("undo"),
+                () -> calls.add("redo"));
+
+        undoRedo.undo();
+        calls.clear();
+        undoRedo.redo();
+        assertEquals(List.of("redo"), calls);
     }
 
     @Test

--- a/src/test/java/com/embervault/application/UndoRedoServiceTest.java
+++ b/src/test/java/com/embervault/application/UndoRedoServiceTest.java
@@ -4,10 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.embervault.application.port.in.CommandRecorder;
-import com.embervault.application.port.in.UndoRedoUseCase;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.embervault.application.port.in.CommandRecorder;
+import com.embervault.application.port.in.UndoRedoUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/embervault/application/UndoRedoServiceTest.java
+++ b/src/test/java/com/embervault/application/UndoRedoServiceTest.java
@@ -1,0 +1,104 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.embervault.application.port.in.UndoRedoUseCase;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UndoRedoServiceTest {
+
+    private UndoRedoUseCase undoRedo;
+    private CommandHistory history;
+
+    @BeforeEach
+    void setUp() {
+        history = new CommandHistory();
+        undoRedo = new UndoRedoService(history);
+    }
+
+    @Test
+    @DisplayName("implements UndoRedoUseCase")
+    void implementsUseCase() {
+        assertTrue(undoRedo instanceof UndoRedoUseCase);
+    }
+
+    @Test
+    @DisplayName("delegates canUndo to CommandHistory")
+    void canUndo_delegatesToHistory() {
+        assertFalse(undoRedo.canUndo());
+        history.push(stubCommand());
+        assertTrue(undoRedo.canUndo());
+    }
+
+    @Test
+    @DisplayName("delegates canRedo to CommandHistory")
+    void canRedo_delegatesToHistory() {
+        assertFalse(undoRedo.canRedo());
+        history.push(stubCommand());
+        history.undo();
+        assertTrue(undoRedo.canRedo());
+    }
+
+    @Test
+    @DisplayName("undo delegates to CommandHistory")
+    void undo_delegatesToHistory() {
+        List<String> calls = new ArrayList<>();
+        history.push(trackingCommand(calls));
+
+        assertTrue(undoRedo.undo());
+        assertEquals(List.of("undo"), calls);
+    }
+
+    @Test
+    @DisplayName("redo delegates to CommandHistory")
+    void redo_delegatesToHistory() {
+        List<String> calls = new ArrayList<>();
+        history.push(trackingCommand(calls));
+        undoRedo.undo();
+        calls.clear();
+
+        assertTrue(undoRedo.redo());
+        assertEquals(List.of("redo"), calls);
+    }
+
+    @Test
+    @DisplayName("undo on empty returns false")
+    void undo_empty_returnsFalse() {
+        assertFalse(undoRedo.undo());
+    }
+
+    @Test
+    @DisplayName("redo on empty returns false")
+    void redo_empty_returnsFalse() {
+        assertFalse(undoRedo.redo());
+    }
+
+    private Reversible stubCommand() {
+        return trackingCommand(new ArrayList<>());
+    }
+
+    private Reversible trackingCommand(List<String> calls) {
+        return new Reversible() {
+            @Override
+            public void undo() {
+                calls.add("undo");
+            }
+
+            @Override
+            public void redo() {
+                calls.add("redo");
+            }
+
+            @Override
+            public String description() {
+                return "test";
+            }
+        };
+    }
+}

--- a/src/test/java/com/embervault/application/UpdateTextCommandTest.java
+++ b/src/test/java/com/embervault/application/UpdateTextCommandTest.java
@@ -1,0 +1,68 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.UpdateNoteTextUseCase;
+import com.embervault.domain.Note;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UpdateTextCommandTest {
+
+    private UpdateNoteTextUseCase updateTextUseCase;
+    private InMemoryNoteRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        updateTextUseCase = service;
+    }
+
+    @Test
+    @DisplayName("undo restores previous text")
+    void undo_restoresPreviousText() {
+        Note note = Note.create("Title", "old text");
+        repository.save(note);
+
+        UpdateTextCommand cmd = new UpdateTextCommand(
+                updateTextUseCase, note.getId(), "old text", "new text");
+        cmd.redo();
+
+        assertEquals("new text", repository.findById(note.getId())
+                .orElseThrow().getText());
+
+        cmd.undo();
+
+        assertEquals("old text", repository.findById(note.getId())
+                .orElseThrow().getText());
+    }
+
+    @Test
+    @DisplayName("redo re-applies the text change")
+    void redo_reappliesTextChange() {
+        Note note = Note.create("Title", "old text");
+        repository.save(note);
+
+        UpdateTextCommand cmd = new UpdateTextCommand(
+                updateTextUseCase, note.getId(), "old text", "new text");
+        cmd.redo();
+        cmd.undo();
+        cmd.redo();
+
+        assertEquals("new text", repository.findById(note.getId())
+                .orElseThrow().getText());
+    }
+
+    @Test
+    @DisplayName("description mentions text update")
+    void description_mentionsTextUpdate() {
+        UpdateTextCommand cmd = new UpdateTextCommand(
+                updateTextUseCase, java.util.UUID.randomUUID(),
+                "old", "new");
+
+        assertEquals("Update note text", cmd.description());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Reversible` interface, `CommandHistory` service, and concrete command classes (`RenameCommand`, `CreateNoteCommand`, `DeleteNoteCommand`, `MoveNoteCommand`, `UpdateTextCommand`) for undoable operations
- Add `UndoRedoUseCase` inbound port and `UndoRedoService` implementation with `CommandRecorder` port for ViewModels to register undoable actions
- Register `Ctrl+Z` / `Ctrl+Shift+Z` global keyboard shortcuts via `UndoRedoShortcuts`
- Integrate `CommandRecorder` into `OutlineViewModel` for rename and create operations as proof of concept
- Thread `CommandRecorder` through `SharedServices`, `ViewPaneDeps`, and view factories

Closes #262

## Architecture

- `Reversible` and `CommandHistory` live in the application layer
- `UndoRedoUseCase` and `CommandRecorder` are inbound ports
- `UndoRedoShortcuts` is in the viewmodel adapter layer
- No application-layer dependency on adapters (clean hexagonal architecture)

## Test plan

- [x] `CommandHistoryTest` — empty state, push/undo/redo stack behavior, LIFO ordering
- [x] `RenameCommandTest` — undo restores old title, redo re-applies
- [x] `CreateNoteCommandTest` — undo deletes, redo re-saves
- [x] `DeleteNoteCommandTest` — undo restores, redo deletes
- [x] `MoveNoteCommandTest` — undo moves back to original parent
- [x] `UpdateTextCommandTest` — undo restores old text, redo re-applies
- [x] `UndoRedoServiceTest` — delegation, CommandRecorder integration
- [x] `UndoRedoShortcutTest` — Ctrl+Z/Ctrl+Shift+Z registration and triggering
- [x] `SharedServicesUndoRedoTest` — wiring verification
- [x] `OutlineViewModelUndoTest` — rename and create undo integration
- [x] All existing tests pass, checkstyle clean, JaCoCo coverage met
- [x] `mvn verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)