### PR TITLE
Enhance search with attribute filters and operators (#263)

### DIFF
--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -28,6 +28,7 @@ import com.embervault.application.port.out.NoteRepository;
 import com.embervault.domain.AttributeMap;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
+import com.embervault.domain.SearchFilter;
 import com.embervault.domain.UuidGenerator;
 
 /**
@@ -472,6 +473,68 @@ public final class NoteServiceImpl implements NoteService {
         results.addAll(titleMatches);
         results.addAll(textOnlyMatches);
         return results;
+    }
+
+    @Override
+    public List<Note> searchWithFilters(List<SearchFilter> filters) {
+        List<Note> allNotes = repository.findAll();
+        if (filters.isEmpty()) {
+            return allNotes;
+        }
+        return allNotes.stream()
+                .filter(note -> filters.stream()
+                        .allMatch(f -> matchesFilter(note, f)))
+                .toList();
+    }
+
+    private boolean matchesFilter(Note note, SearchFilter filter) {
+        return switch (filter) {
+            case SearchFilter.SubstringFilter sf -> {
+                String lower = sf.text().toLowerCase(Locale.ROOT);
+                yield note.getTitle().toLowerCase(Locale.ROOT)
+                        .contains(lower)
+                    || note.getContent().toLowerCase(Locale.ROOT)
+                        .contains(lower);
+            }
+            case SearchFilter.AttributeFilter af -> {
+                String key = af.attributeKey();
+                String attrName = "$"
+                    + key.substring(0, 1).toUpperCase(Locale.ROOT)
+                    + key.substring(1);
+                yield note.getAttribute(attrName)
+                    .map(v -> matchesAttributeValue(v, af.value()))
+                    .orElse(false);
+            }
+            case SearchFilter.RelationFilter rf -> {
+                if ("children".equals(rf.relation())) {
+                    yield hasChildren(note.getId());
+                }
+                yield false;
+            }
+        };
+    }
+
+    private boolean matchesAttributeValue(
+            AttributeValue value, String expected) {
+        return switch (value) {
+            case AttributeValue.StringValue sv ->
+                sv.value().equalsIgnoreCase(expected);
+            case AttributeValue.BooleanValue bv ->
+                String.valueOf(bv.value()).equalsIgnoreCase(expected);
+            case AttributeValue.ColorValue cv ->
+                cv.value().toHex().equalsIgnoreCase(expected)
+                    || cv.value().getName()
+                        .map(n -> n.equalsIgnoreCase(expected))
+                        .orElse(false);
+            case AttributeValue.NumberValue nv -> {
+                try {
+                    yield nv.value() == Double.parseDouble(expected);
+                } catch (NumberFormatException e) {
+                    yield false;
+                }
+            }
+            default -> value.toString().contains(expected);
+        };
     }
 
     /**

--- a/src/main/java/com/embervault/application/NoteServiceImpl.java
+++ b/src/main/java/com/embervault/application/NoteServiceImpl.java
@@ -29,6 +29,7 @@ import com.embervault.domain.AttributeMap;
 import com.embervault.domain.AttributeValue;
 import com.embervault.domain.Note;
 import com.embervault.domain.SearchFilter;
+import com.embervault.domain.SearchFilterMatcher;
 import com.embervault.domain.UuidGenerator;
 
 /**
@@ -449,10 +450,8 @@ public final class NoteServiceImpl implements NoteService {
         }
         String lowerQuery = query.toLowerCase(Locale.ROOT);
         List<Note> allNotes = repository.findAll();
-
         List<Note> titleMatches = new ArrayList<>();
         List<Note> textOnlyMatches = new ArrayList<>();
-
         for (Note note : allNotes) {
             boolean titleMatch = note.getTitle()
                     .toLowerCase(Locale.ROOT)
@@ -477,64 +476,8 @@ public final class NoteServiceImpl implements NoteService {
 
     @Override
     public List<Note> searchWithFilters(List<SearchFilter> filters) {
-        List<Note> allNotes = repository.findAll();
-        if (filters.isEmpty()) {
-            return allNotes;
-        }
-        return allNotes.stream()
-                .filter(note -> filters.stream()
-                        .allMatch(f -> matchesFilter(note, f)))
-                .toList();
-    }
-
-    private boolean matchesFilter(Note note, SearchFilter filter) {
-        return switch (filter) {
-            case SearchFilter.SubstringFilter sf -> {
-                String lower = sf.text().toLowerCase(Locale.ROOT);
-                yield note.getTitle().toLowerCase(Locale.ROOT)
-                        .contains(lower)
-                    || note.getContent().toLowerCase(Locale.ROOT)
-                        .contains(lower);
-            }
-            case SearchFilter.AttributeFilter af -> {
-                String key = af.attributeKey();
-                String attrName = "$"
-                    + key.substring(0, 1).toUpperCase(Locale.ROOT)
-                    + key.substring(1);
-                yield note.getAttribute(attrName)
-                    .map(v -> matchesAttributeValue(v, af.value()))
-                    .orElse(false);
-            }
-            case SearchFilter.RelationFilter rf -> {
-                if ("children".equals(rf.relation())) {
-                    yield hasChildren(note.getId());
-                }
-                yield false;
-            }
-        };
-    }
-
-    private boolean matchesAttributeValue(
-            AttributeValue value, String expected) {
-        return switch (value) {
-            case AttributeValue.StringValue sv ->
-                sv.value().equalsIgnoreCase(expected);
-            case AttributeValue.BooleanValue bv ->
-                String.valueOf(bv.value()).equalsIgnoreCase(expected);
-            case AttributeValue.ColorValue cv ->
-                cv.value().toHex().equalsIgnoreCase(expected)
-                    || cv.value().getName()
-                        .map(n -> n.equalsIgnoreCase(expected))
-                        .orElse(false);
-            case AttributeValue.NumberValue nv -> {
-                try {
-                    yield nv.value() == Double.parseDouble(expected);
-                } catch (NumberFormatException e) {
-                    yield false;
-                }
-            }
-            default -> value.toString().contains(expected);
-        };
+        return new SearchFilterMatcher(note -> hasChildren(note.getId()))
+                .match(repository.findAll(), filters);
     }
 
     /**

--- a/src/main/java/com/embervault/application/port/in/SearchNotesQuery.java
+++ b/src/main/java/com/embervault/application/port/in/SearchNotesQuery.java
@@ -3,6 +3,7 @@ package com.embervault.application.port.in;
 import java.util.List;
 
 import com.embervault.domain.Note;
+import com.embervault.domain.SearchFilter;
 
 /**
  * Query interface for searching notes by text content.
@@ -20,4 +21,15 @@ public interface SearchNotesQuery {
      * @return matching notes ordered by relevance (title matches first)
      */
     List<Note> searchNotes(String query);
+
+    /**
+     * Searches notes using structured filters.
+     *
+     * <p>All filters must match for a note to be included (AND semantics).
+     * An empty filter list returns all notes.</p>
+     *
+     * @param filters the parsed search filters
+     * @return notes matching all filters
+     */
+    List<Note> searchWithFilters(List<SearchFilter> filters);
 }

--- a/src/main/java/com/embervault/domain/SearchFilter.java
+++ b/src/main/java/com/embervault/domain/SearchFilter.java
@@ -1,0 +1,54 @@
+package com.embervault.domain;
+
+import java.util.List;
+
+/**
+ * Represents a parsed search filter for querying notes.
+ *
+ * <p>Supports substring matching on name/text and attribute-specific
+ * filters like {@code color:red} or {@code has:children}.</p>
+ */
+public sealed interface SearchFilter
+    permits SearchFilter.SubstringFilter,
+    SearchFilter.AttributeFilter,
+    SearchFilter.RelationFilter {
+
+  /**
+   * Parses a query string into a list of search filters.
+   *
+   * <p>Plain text tokens become substring filters. Tokens in
+   * {@code key:value} format become attribute or relation filters.</p>
+   *
+   * @param query the raw search query
+   * @return list of parsed filters, empty if query is blank/null
+   */
+  static List<SearchFilter> parse(String query) {
+    if (query == null || query.isBlank()) {
+      return List.of();
+    }
+    return List.of(new SubstringFilter(query.strip()));
+  }
+
+  /**
+   * A substring match against note name and text.
+   *
+   * @param text the substring to search for
+   */
+  record SubstringFilter(String text) implements SearchFilter {}
+
+  /**
+   * A filter matching a specific attribute value.
+   *
+   * @param attributeKey the attribute key (e.g., "color", "badge")
+   * @param value the expected value
+   */
+  record AttributeFilter(String attributeKey,
+      String value) implements SearchFilter {}
+
+  /**
+   * A relational filter (e.g., has:children, has:links).
+   *
+   * @param relation the relation type
+   */
+  record RelationFilter(String relation) implements SearchFilter {}
+}

--- a/src/main/java/com/embervault/domain/SearchFilter.java
+++ b/src/main/java/com/embervault/domain/SearchFilter.java
@@ -26,7 +26,23 @@ public sealed interface SearchFilter
     if (query == null || query.isBlank()) {
       return List.of();
     }
-    return List.of(new SubstringFilter(query.strip()));
+    String[] tokens = query.strip().split("\\s+");
+    List<SearchFilter> filters = new java.util.ArrayList<>();
+    for (String token : tokens) {
+      int colon = token.indexOf(':');
+      if (colon > 0 && colon < token.length() - 1) {
+        String key = token.substring(0, colon);
+        String value = token.substring(colon + 1);
+        if ("has".equals(key)) {
+          filters.add(new RelationFilter(value));
+        } else {
+          filters.add(new AttributeFilter(key, value));
+        }
+      } else {
+        filters.add(new SubstringFilter(token));
+      }
+    }
+    return List.copyOf(filters);
   }
 
   /**

--- a/src/main/java/com/embervault/domain/SearchFilter.java
+++ b/src/main/java/com/embervault/domain/SearchFilter.java
@@ -1,5 +1,6 @@
 package com.embervault.domain;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -9,62 +10,62 @@ import java.util.List;
  * filters like {@code color:red} or {@code has:children}.</p>
  */
 public sealed interface SearchFilter
-    permits SearchFilter.SubstringFilter,
-    SearchFilter.AttributeFilter,
-    SearchFilter.RelationFilter {
+        permits SearchFilter.SubstringFilter,
+        SearchFilter.AttributeFilter,
+        SearchFilter.RelationFilter {
 
-  /**
-   * Parses a query string into a list of search filters.
-   *
-   * <p>Plain text tokens become substring filters. Tokens in
-   * {@code key:value} format become attribute or relation filters.</p>
-   *
-   * @param query the raw search query
-   * @return list of parsed filters, empty if query is blank/null
-   */
-  static List<SearchFilter> parse(String query) {
-    if (query == null || query.isBlank()) {
-      return List.of();
-    }
-    String[] tokens = query.strip().split("\\s+");
-    List<SearchFilter> filters = new java.util.ArrayList<>();
-    for (String token : tokens) {
-      int colon = token.indexOf(':');
-      if (colon > 0 && colon < token.length() - 1) {
-        String key = token.substring(0, colon);
-        String value = token.substring(colon + 1);
-        if ("has".equals(key)) {
-          filters.add(new RelationFilter(value));
-        } else {
-          filters.add(new AttributeFilter(key, value));
+    /**
+     * Parses a query string into a list of search filters.
+     *
+     * <p>Plain text tokens become substring filters. Tokens in
+     * {@code key:value} format become attribute or relation filters.</p>
+     *
+     * @param query the raw search query
+     * @return list of parsed filters, empty if query is blank/null
+     */
+    static List<SearchFilter> parse(String query) {
+        if (query == null || query.isBlank()) {
+            return List.of();
         }
-      } else {
-        filters.add(new SubstringFilter(token));
-      }
+        String[] tokens = query.strip().split("\\s+");
+        List<SearchFilter> filters = new ArrayList<>();
+        for (String token : tokens) {
+            int colon = token.indexOf(':');
+            if (colon > 0 && colon < token.length() - 1) {
+                String key = token.substring(0, colon);
+                String value = token.substring(colon + 1);
+                if ("has".equals(key)) {
+                    filters.add(new RelationFilter(value));
+                } else {
+                    filters.add(new AttributeFilter(key, value));
+                }
+            } else {
+                filters.add(new SubstringFilter(token));
+            }
+        }
+        return List.copyOf(filters);
     }
-    return List.copyOf(filters);
-  }
 
-  /**
-   * A substring match against note name and text.
-   *
-   * @param text the substring to search for
-   */
-  record SubstringFilter(String text) implements SearchFilter {}
+    /**
+     * A substring match against note name and text.
+     *
+     * @param text the substring to search for
+     */
+    record SubstringFilter(String text) implements SearchFilter {}
 
-  /**
-   * A filter matching a specific attribute value.
-   *
-   * @param attributeKey the attribute key (e.g., "color", "badge")
-   * @param value the expected value
-   */
-  record AttributeFilter(String attributeKey,
-      String value) implements SearchFilter {}
+    /**
+     * A filter matching a specific attribute value.
+     *
+     * @param attributeKey the attribute key (e.g., "color", "badge")
+     * @param value the expected value
+     */
+    record AttributeFilter(String attributeKey,
+            String value) implements SearchFilter {}
 
-  /**
-   * A relational filter (e.g., has:children, has:links).
-   *
-   * @param relation the relation type
-   */
-  record RelationFilter(String relation) implements SearchFilter {}
+    /**
+     * A relational filter (e.g., has:children, has:links).
+     *
+     * @param relation the relation type
+     */
+    record RelationFilter(String relation) implements SearchFilter {}
 }

--- a/src/main/java/com/embervault/domain/SearchFilterMatcher.java
+++ b/src/main/java/com/embervault/domain/SearchFilterMatcher.java
@@ -1,0 +1,110 @@
+package com.embervault.domain;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Predicate;
+
+/**
+ * Matches notes against parsed search filters.
+ *
+ * <p>Evaluates {@link SearchFilter} instances against a {@link Note},
+ * supporting substring, attribute, and relation filters.</p>
+ */
+public final class SearchFilterMatcher {
+
+    private final Predicate<Note> hasChildrenCheck;
+
+    /**
+     * Creates a matcher with the given children-check predicate.
+     *
+     * @param hasChildrenCheck returns true if a note has children
+     */
+    public SearchFilterMatcher(Predicate<Note> hasChildrenCheck) {
+        this.hasChildrenCheck = hasChildrenCheck;
+    }
+
+    /**
+     * Returns notes from the list that match all filters (AND semantics).
+     *
+     * @param notes the candidate notes
+     * @param filters the filters to apply
+     * @return notes matching all filters
+     */
+    public List<Note> match(List<Note> notes,
+            List<SearchFilter> filters) {
+        if (filters.isEmpty()) {
+            return notes;
+        }
+        return notes.stream()
+                .filter(note -> filters.stream()
+                        .allMatch(f -> matches(note, f)))
+                .toList();
+    }
+
+    /**
+     * Tests whether a single note matches a single filter.
+     */
+    public boolean matches(Note note, SearchFilter filter) {
+        return switch (filter) {
+            case SearchFilter.SubstringFilter sf ->
+                matchesSubstring(note, sf);
+            case SearchFilter.AttributeFilter af ->
+                matchesAttribute(note, af);
+            case SearchFilter.RelationFilter rf ->
+                matchesRelation(note, rf);
+        };
+    }
+
+    private boolean matchesSubstring(Note note,
+            SearchFilter.SubstringFilter sf) {
+        String lower = sf.text().toLowerCase(Locale.ROOT);
+        return note.getTitle().toLowerCase(Locale.ROOT).contains(lower)
+                || note.getContent().toLowerCase(Locale.ROOT)
+                        .contains(lower);
+    }
+
+    private boolean matchesAttribute(Note note,
+            SearchFilter.AttributeFilter af) {
+        String key = af.attributeKey();
+        String attrName = "$"
+                + key.substring(0, 1).toUpperCase(Locale.ROOT)
+                + key.substring(1);
+        return note.getAttribute(attrName)
+                .map(v -> matchesValue(v, af.value()))
+                .orElse(false);
+    }
+
+    private boolean matchesRelation(Note note,
+            SearchFilter.RelationFilter rf) {
+        if ("children".equals(rf.relation())) {
+            return hasChildrenCheck.test(note);
+        }
+        return false;
+    }
+
+    private boolean matchesValue(AttributeValue value, String expected) {
+        return switch (value) {
+            case AttributeValue.StringValue sv ->
+                sv.value().equalsIgnoreCase(expected);
+            case AttributeValue.BooleanValue bv ->
+                String.valueOf(bv.value()).equalsIgnoreCase(expected);
+            case AttributeValue.ColorValue cv ->
+                cv.value().toHex().equalsIgnoreCase(expected)
+                        || cv.value().getName()
+                                .map(n -> n.equalsIgnoreCase(expected))
+                                .orElse(false);
+            case AttributeValue.NumberValue nv -> {
+                try {
+                    yield nv.value() == Double.parseDouble(expected);
+                } catch (NumberFormatException e) {
+                    yield false;
+                }
+            }
+            default -> value.toString().contains(expected);
+        };
+    }
+
+    private SearchFilterMatcher() {
+        this.hasChildrenCheck = note -> false;
+    }
+}

--- a/src/test/java/com/embervault/application/FilteredSearchTest.java
+++ b/src/test/java/com/embervault/application/FilteredSearchTest.java
@@ -1,0 +1,140 @@
+package com.embervault.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
+import com.embervault.application.port.in.SearchNotesQuery;
+import com.embervault.domain.Attributes;
+import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Note;
+import com.embervault.domain.SearchFilter;
+import com.embervault.domain.TbxColor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FilteredSearchTest {
+
+  private SearchNotesQuery searchQuery;
+  private InMemoryNoteRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new InMemoryNoteRepository();
+    NoteServiceImpl service = new NoteServiceImpl(repository);
+    searchQuery = service;
+  }
+
+  @Test
+  @DisplayName("searchWithFilters returns notes matching color attribute")
+  void searchWithFilters_shouldMatchColorAttribute() {
+    Note red = Note.create("Red Note", "");
+    red.setAttribute(Attributes.COLOR,
+        new AttributeValue.ColorValue(TbxColor.named("red")));
+    repository.save(red);
+
+    Note blue = Note.create("Blue Note", "");
+    blue.setAttribute(Attributes.COLOR,
+        new AttributeValue.ColorValue(TbxColor.named("blue")));
+    repository.save(blue);
+
+    List<SearchFilter> filters = SearchFilter.parse("color:red");
+    List<Note> results = searchQuery.searchWithFilters(filters);
+
+    assertEquals(1, results.size());
+    assertEquals("Red Note", results.getFirst().getTitle());
+  }
+
+  @Test
+  @DisplayName("searchWithFilters with empty filters returns all notes")
+  void searchWithFilters_emptyFilters_shouldReturnAll() {
+    Note note = Note.create("Test", "content");
+    repository.save(note);
+
+    List<Note> results = searchQuery.searchWithFilters(List.of());
+
+    assertEquals(1, results.size());
+  }
+
+  @Test
+  @DisplayName("searchWithFilters with substring filter matches title")
+  void searchWithFilters_substringFilter_shouldMatchTitle() {
+    Note match = Note.create("Meeting notes", "");
+    repository.save(match);
+    Note noMatch = Note.create("Shopping list", "");
+    repository.save(noMatch);
+
+    List<SearchFilter> filters = SearchFilter.parse("meeting");
+    List<Note> results = searchQuery.searchWithFilters(filters);
+
+    assertEquals(1, results.size());
+    assertEquals("Meeting notes", results.getFirst().getTitle());
+  }
+
+  @Test
+  @DisplayName("searchWithFilters compound filter requires all to match")
+  void searchWithFilters_compoundFilter_shouldRequireAll() {
+    Note match = Note.create("Task", "");
+    match.setAttribute(Attributes.COLOR,
+        new AttributeValue.ColorValue(TbxColor.named("red")));
+    match.setAttribute(Attributes.BADGE,
+        new AttributeValue.StringValue("star"));
+    repository.save(match);
+
+    Note partial = Note.create("Other", "");
+    partial.setAttribute(Attributes.COLOR,
+        new AttributeValue.ColorValue(TbxColor.named("red")));
+    repository.save(partial);
+
+    List<SearchFilter> filters =
+        SearchFilter.parse("color:red badge:star");
+    List<Note> results = searchQuery.searchWithFilters(filters);
+
+    assertEquals(1, results.size());
+    assertEquals("Task", results.getFirst().getTitle());
+  }
+
+  @Test
+  @DisplayName("searchWithFilters checked:true matches boolean attr")
+  void searchWithFilters_checkedFilter_shouldMatchBoolean() {
+    Note checked = Note.create("Done", "");
+    checked.setAttribute(Attributes.CHECKED,
+        new AttributeValue.BooleanValue(true));
+    repository.save(checked);
+
+    Note unchecked = Note.create("Pending", "");
+    unchecked.setAttribute(Attributes.CHECKED,
+        new AttributeValue.BooleanValue(false));
+    repository.save(unchecked);
+
+    List<SearchFilter> filters = SearchFilter.parse("checked:true");
+    List<Note> results = searchQuery.searchWithFilters(filters);
+
+    assertEquals(1, results.size());
+    assertEquals("Done", results.getFirst().getTitle());
+  }
+
+  @Test
+  @DisplayName("searchWithFilters has:children matches parent notes")
+  void searchWithFilters_hasChildren_shouldMatchParents() {
+    Note parent = Note.create("Parent", "");
+    repository.save(parent);
+
+    Note child = Note.create("Child", "");
+    child.setAttribute(Attributes.CONTAINER,
+        new AttributeValue.StringValue(parent.getId().toString()));
+    repository.save(child);
+
+    Note lonely = Note.create("Lonely", "");
+    repository.save(lonely);
+
+    List<SearchFilter> filters = SearchFilter.parse("has:children");
+    List<Note> results = searchQuery.searchWithFilters(filters);
+
+    assertEquals(1, results.size());
+    assertEquals("Parent", results.getFirst().getTitle());
+  }
+}

--- a/src/test/java/com/embervault/application/FilteredSearchTest.java
+++ b/src/test/java/com/embervault/application/FilteredSearchTest.java
@@ -1,14 +1,13 @@
 package com.embervault.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import com.embervault.adapter.out.persistence.InMemoryNoteRepository;
 import com.embervault.application.port.in.SearchNotesQuery;
-import com.embervault.domain.Attributes;
 import com.embervault.domain.AttributeValue;
+import com.embervault.domain.Attributes;
 import com.embervault.domain.Note;
 import com.embervault.domain.SearchFilter;
 import com.embervault.domain.TbxColor;
@@ -18,123 +17,124 @@ import org.junit.jupiter.api.Test;
 
 class FilteredSearchTest {
 
-  private SearchNotesQuery searchQuery;
-  private InMemoryNoteRepository repository;
+    private SearchNotesQuery searchQuery;
+    private InMemoryNoteRepository repository;
 
-  @BeforeEach
-  void setUp() {
-    repository = new InMemoryNoteRepository();
-    NoteServiceImpl service = new NoteServiceImpl(repository);
-    searchQuery = service;
-  }
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryNoteRepository();
+        NoteServiceImpl service = new NoteServiceImpl(repository);
+        searchQuery = service;
+    }
 
-  @Test
-  @DisplayName("searchWithFilters returns notes matching color attribute")
-  void searchWithFilters_shouldMatchColorAttribute() {
-    Note red = Note.create("Red Note", "");
-    red.setAttribute(Attributes.COLOR,
-        new AttributeValue.ColorValue(TbxColor.named("red")));
-    repository.save(red);
+    @Test
+    @DisplayName("searchWithFilters returns notes matching color attribute")
+    void searchWithFilters_shouldMatchColorAttribute() {
+        Note red = Note.create("Red Note", "");
+        red.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+        repository.save(red);
 
-    Note blue = Note.create("Blue Note", "");
-    blue.setAttribute(Attributes.COLOR,
-        new AttributeValue.ColorValue(TbxColor.named("blue")));
-    repository.save(blue);
+        Note blue = Note.create("Blue Note", "");
+        blue.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("blue")));
+        repository.save(blue);
 
-    List<SearchFilter> filters = SearchFilter.parse("color:red");
-    List<Note> results = searchQuery.searchWithFilters(filters);
+        List<SearchFilter> filters = SearchFilter.parse("color:red");
+        List<Note> results = searchQuery.searchWithFilters(filters);
 
-    assertEquals(1, results.size());
-    assertEquals("Red Note", results.getFirst().getTitle());
-  }
+        assertEquals(1, results.size());
+        assertEquals("Red Note", results.getFirst().getTitle());
+    }
 
-  @Test
-  @DisplayName("searchWithFilters with empty filters returns all notes")
-  void searchWithFilters_emptyFilters_shouldReturnAll() {
-    Note note = Note.create("Test", "content");
-    repository.save(note);
+    @Test
+    @DisplayName("searchWithFilters with empty filters returns all notes")
+    void searchWithFilters_emptyFilters_shouldReturnAll() {
+        Note note = Note.create("Test", "content");
+        repository.save(note);
 
-    List<Note> results = searchQuery.searchWithFilters(List.of());
+        List<Note> results = searchQuery.searchWithFilters(List.of());
 
-    assertEquals(1, results.size());
-  }
+        assertEquals(1, results.size());
+    }
 
-  @Test
-  @DisplayName("searchWithFilters with substring filter matches title")
-  void searchWithFilters_substringFilter_shouldMatchTitle() {
-    Note match = Note.create("Meeting notes", "");
-    repository.save(match);
-    Note noMatch = Note.create("Shopping list", "");
-    repository.save(noMatch);
+    @Test
+    @DisplayName("searchWithFilters with substring filter matches title")
+    void searchWithFilters_substringFilter_shouldMatchTitle() {
+        Note match = Note.create("Meeting notes", "");
+        repository.save(match);
+        Note noMatch = Note.create("Shopping list", "");
+        repository.save(noMatch);
 
-    List<SearchFilter> filters = SearchFilter.parse("meeting");
-    List<Note> results = searchQuery.searchWithFilters(filters);
+        List<SearchFilter> filters = SearchFilter.parse("meeting");
+        List<Note> results = searchQuery.searchWithFilters(filters);
 
-    assertEquals(1, results.size());
-    assertEquals("Meeting notes", results.getFirst().getTitle());
-  }
+        assertEquals(1, results.size());
+        assertEquals("Meeting notes", results.getFirst().getTitle());
+    }
 
-  @Test
-  @DisplayName("searchWithFilters compound filter requires all to match")
-  void searchWithFilters_compoundFilter_shouldRequireAll() {
-    Note match = Note.create("Task", "");
-    match.setAttribute(Attributes.COLOR,
-        new AttributeValue.ColorValue(TbxColor.named("red")));
-    match.setAttribute(Attributes.BADGE,
-        new AttributeValue.StringValue("star"));
-    repository.save(match);
+    @Test
+    @DisplayName("searchWithFilters compound filter requires all to match")
+    void searchWithFilters_compoundFilter_shouldRequireAll() {
+        Note match = Note.create("Task", "");
+        match.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+        match.setAttribute(Attributes.BADGE,
+                new AttributeValue.StringValue("star"));
+        repository.save(match);
 
-    Note partial = Note.create("Other", "");
-    partial.setAttribute(Attributes.COLOR,
-        new AttributeValue.ColorValue(TbxColor.named("red")));
-    repository.save(partial);
+        Note partial = Note.create("Other", "");
+        partial.setAttribute(Attributes.COLOR,
+                new AttributeValue.ColorValue(TbxColor.named("red")));
+        repository.save(partial);
 
-    List<SearchFilter> filters =
-        SearchFilter.parse("color:red badge:star");
-    List<Note> results = searchQuery.searchWithFilters(filters);
+        List<SearchFilter> filters =
+                SearchFilter.parse("color:red badge:star");
+        List<Note> results = searchQuery.searchWithFilters(filters);
 
-    assertEquals(1, results.size());
-    assertEquals("Task", results.getFirst().getTitle());
-  }
+        assertEquals(1, results.size());
+        assertEquals("Task", results.getFirst().getTitle());
+    }
 
-  @Test
-  @DisplayName("searchWithFilters checked:true matches boolean attr")
-  void searchWithFilters_checkedFilter_shouldMatchBoolean() {
-    Note checked = Note.create("Done", "");
-    checked.setAttribute(Attributes.CHECKED,
-        new AttributeValue.BooleanValue(true));
-    repository.save(checked);
+    @Test
+    @DisplayName("searchWithFilters checked:true matches boolean attr")
+    void searchWithFilters_checkedFilter_shouldMatchBoolean() {
+        Note checked = Note.create("Done", "");
+        checked.setAttribute(Attributes.CHECKED,
+                new AttributeValue.BooleanValue(true));
+        repository.save(checked);
 
-    Note unchecked = Note.create("Pending", "");
-    unchecked.setAttribute(Attributes.CHECKED,
-        new AttributeValue.BooleanValue(false));
-    repository.save(unchecked);
+        Note unchecked = Note.create("Pending", "");
+        unchecked.setAttribute(Attributes.CHECKED,
+                new AttributeValue.BooleanValue(false));
+        repository.save(unchecked);
 
-    List<SearchFilter> filters = SearchFilter.parse("checked:true");
-    List<Note> results = searchQuery.searchWithFilters(filters);
+        List<SearchFilter> filters = SearchFilter.parse("checked:true");
+        List<Note> results = searchQuery.searchWithFilters(filters);
 
-    assertEquals(1, results.size());
-    assertEquals("Done", results.getFirst().getTitle());
-  }
+        assertEquals(1, results.size());
+        assertEquals("Done", results.getFirst().getTitle());
+    }
 
-  @Test
-  @DisplayName("searchWithFilters has:children matches parent notes")
-  void searchWithFilters_hasChildren_shouldMatchParents() {
-    Note parent = Note.create("Parent", "");
-    repository.save(parent);
+    @Test
+    @DisplayName("searchWithFilters has:children matches parent notes")
+    void searchWithFilters_hasChildren_shouldMatchParents() {
+        Note parent = Note.create("Parent", "");
+        repository.save(parent);
 
-    Note child = Note.create("Child", "");
-    child.setAttribute(Attributes.CONTAINER,
-        new AttributeValue.StringValue(parent.getId().toString()));
-    repository.save(child);
+        Note child = Note.create("Child", "");
+        child.setAttribute(Attributes.CONTAINER,
+                new AttributeValue.StringValue(
+                        parent.getId().toString()));
+        repository.save(child);
 
-    Note lonely = Note.create("Lonely", "");
-    repository.save(lonely);
+        Note lonely = Note.create("Lonely", "");
+        repository.save(lonely);
 
-    List<SearchFilter> filters = SearchFilter.parse("has:children");
-    List<Note> results = searchQuery.searchWithFilters(filters);
+        List<SearchFilter> filters = SearchFilter.parse("has:children");
+        List<Note> results = searchQuery.searchWithFilters(filters);
 
-    assertEquals(1, results.size());
-    assertEquals("Parent", results.getFirst().getTitle());
-  }
+        assertEquals(1, results.size());
+        assertEquals("Parent", results.getFirst().getTitle());
+    }
 }

--- a/src/test/java/com/embervault/domain/SearchFilterTest.java
+++ b/src/test/java/com/embervault/domain/SearchFilterTest.java
@@ -21,6 +21,54 @@ class SearchFilterTest {
   }
 
   @Test
+  void keyValueQueryParsesToAttributeFilter() {
+    List<SearchFilter> filters = SearchFilter.parse("color:red");
+
+    assertEquals(1, filters.size());
+    SearchFilter filter = filters.getFirst();
+    assertTrue(filter instanceof SearchFilter.AttributeFilter);
+    SearchFilter.AttributeFilter af =
+        (SearchFilter.AttributeFilter) filter;
+    assertEquals("color", af.attributeKey());
+    assertEquals("red", af.value());
+  }
+
+  @Test
+  void compoundQueryParsesMultipleFilters() {
+    List<SearchFilter> filters =
+        SearchFilter.parse("badge:star checked:true");
+
+    assertEquals(2, filters.size());
+    assertTrue(filters.get(0) instanceof SearchFilter.AttributeFilter);
+    assertTrue(filters.get(1) instanceof SearchFilter.AttributeFilter);
+    assertEquals("badge",
+        ((SearchFilter.AttributeFilter) filters.get(0)).attributeKey());
+    assertEquals("checked",
+        ((SearchFilter.AttributeFilter) filters.get(1)).attributeKey());
+  }
+
+  @Test
+  void mixedQueryParsesSubstringAndAttributeFilters() {
+    List<SearchFilter> filters =
+        SearchFilter.parse("meeting color:red");
+
+    assertEquals(2, filters.size());
+    assertTrue(filters.get(0) instanceof SearchFilter.SubstringFilter);
+    assertTrue(filters.get(1) instanceof SearchFilter.AttributeFilter);
+  }
+
+  @Test
+  void hasRelationParsesToRelationFilter() {
+    List<SearchFilter> filters = SearchFilter.parse("has:children");
+
+    assertEquals(1, filters.size());
+    assertTrue(filters.getFirst()
+        instanceof SearchFilter.RelationFilter);
+    assertEquals("children",
+        ((SearchFilter.RelationFilter) filters.getFirst()).relation());
+  }
+
+  @Test
   void emptyQueryParsesToEmptyList() {
     assertTrue(SearchFilter.parse("").isEmpty());
     assertTrue(SearchFilter.parse("  ").isEmpty());

--- a/src/test/java/com/embervault/domain/SearchFilterTest.java
+++ b/src/test/java/com/embervault/domain/SearchFilterTest.java
@@ -9,69 +9,76 @@ import org.junit.jupiter.api.Test;
 
 class SearchFilterTest {
 
-  @Test
-  void plainTextQueryParsesToSubstringFilter() {
-    List<SearchFilter> filters = SearchFilter.parse("meeting");
+    @Test
+    void plainTextQueryParsesToSubstringFilter() {
+        List<SearchFilter> filters = SearchFilter.parse("meeting");
 
-    assertEquals(1, filters.size());
-    SearchFilter filter = filters.getFirst();
-    assertTrue(filter instanceof SearchFilter.SubstringFilter);
-    assertEquals("meeting",
-        ((SearchFilter.SubstringFilter) filter).text());
-  }
+        assertEquals(1, filters.size());
+        SearchFilter filter = filters.getFirst();
+        assertTrue(filter instanceof SearchFilter.SubstringFilter);
+        assertEquals("meeting",
+                ((SearchFilter.SubstringFilter) filter).text());
+    }
 
-  @Test
-  void keyValueQueryParsesToAttributeFilter() {
-    List<SearchFilter> filters = SearchFilter.parse("color:red");
+    @Test
+    void keyValueQueryParsesToAttributeFilter() {
+        List<SearchFilter> filters = SearchFilter.parse("color:red");
 
-    assertEquals(1, filters.size());
-    SearchFilter filter = filters.getFirst();
-    assertTrue(filter instanceof SearchFilter.AttributeFilter);
-    SearchFilter.AttributeFilter af =
-        (SearchFilter.AttributeFilter) filter;
-    assertEquals("color", af.attributeKey());
-    assertEquals("red", af.value());
-  }
+        assertEquals(1, filters.size());
+        SearchFilter filter = filters.getFirst();
+        assertTrue(filter instanceof SearchFilter.AttributeFilter);
+        SearchFilter.AttributeFilter af =
+                (SearchFilter.AttributeFilter) filter;
+        assertEquals("color", af.attributeKey());
+        assertEquals("red", af.value());
+    }
 
-  @Test
-  void compoundQueryParsesMultipleFilters() {
-    List<SearchFilter> filters =
-        SearchFilter.parse("badge:star checked:true");
+    @Test
+    void compoundQueryParsesMultipleFilters() {
+        List<SearchFilter> filters =
+                SearchFilter.parse("badge:star checked:true");
 
-    assertEquals(2, filters.size());
-    assertTrue(filters.get(0) instanceof SearchFilter.AttributeFilter);
-    assertTrue(filters.get(1) instanceof SearchFilter.AttributeFilter);
-    assertEquals("badge",
-        ((SearchFilter.AttributeFilter) filters.get(0)).attributeKey());
-    assertEquals("checked",
-        ((SearchFilter.AttributeFilter) filters.get(1)).attributeKey());
-  }
+        assertEquals(2, filters.size());
+        assertTrue(filters.get(0)
+                instanceof SearchFilter.AttributeFilter);
+        assertTrue(filters.get(1)
+                instanceof SearchFilter.AttributeFilter);
+        assertEquals("badge",
+                ((SearchFilter.AttributeFilter) filters.get(0))
+                        .attributeKey());
+        assertEquals("checked",
+                ((SearchFilter.AttributeFilter) filters.get(1))
+                        .attributeKey());
+    }
 
-  @Test
-  void mixedQueryParsesSubstringAndAttributeFilters() {
-    List<SearchFilter> filters =
-        SearchFilter.parse("meeting color:red");
+    @Test
+    void mixedQueryParsesSubstringAndAttributeFilters() {
+        List<SearchFilter> filters =
+                SearchFilter.parse("meeting color:red");
 
-    assertEquals(2, filters.size());
-    assertTrue(filters.get(0) instanceof SearchFilter.SubstringFilter);
-    assertTrue(filters.get(1) instanceof SearchFilter.AttributeFilter);
-  }
+        assertEquals(2, filters.size());
+        assertTrue(filters.get(0)
+                instanceof SearchFilter.SubstringFilter);
+        assertTrue(filters.get(1)
+                instanceof SearchFilter.AttributeFilter);
+    }
 
-  @Test
-  void hasRelationParsesToRelationFilter() {
-    List<SearchFilter> filters = SearchFilter.parse("has:children");
+    @Test
+    void hasRelationParsesToRelationFilter() {
+        List<SearchFilter> filters = SearchFilter.parse("has:children");
 
-    assertEquals(1, filters.size());
-    assertTrue(filters.getFirst()
-        instanceof SearchFilter.RelationFilter);
-    assertEquals("children",
-        ((SearchFilter.RelationFilter) filters.getFirst()).relation());
-  }
+        assertEquals(1, filters.size());
+        assertTrue(filters.getFirst()
+                instanceof SearchFilter.RelationFilter);
+        assertEquals("children",
+                ((SearchFilter.RelationFilter) filters.getFirst())
+                        .relation());
+    }
 
-  @Test
-  void emptyQueryParsesToEmptyList() {
-    assertTrue(SearchFilter.parse("").isEmpty());
-    assertTrue(SearchFilter.parse("  ").isEmpty());
-    assertTrue(SearchFilter.parse(null).isEmpty());
-  }
+    @Test
+    void emptyQueryParsesToEmptyList() {
+        assertTrue(SearchFilter.parse("").isEmpty());
+        assertTrue(SearchFilter.parse("  ").isEmpty());
+        assertTrue(SearchFilter.parse(null).isEmpty());
+    }
 }

--- a/src/test/java/com/embervault/domain/SearchFilterTest.java
+++ b/src/test/java/com/embervault/domain/SearchFilterTest.java
@@ -1,0 +1,29 @@
+package com.embervault.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SearchFilterTest {
+
+  @Test
+  void plainTextQueryParsesToSubstringFilter() {
+    List<SearchFilter> filters = SearchFilter.parse("meeting");
+
+    assertEquals(1, filters.size());
+    SearchFilter filter = filters.getFirst();
+    assertTrue(filter instanceof SearchFilter.SubstringFilter);
+    assertEquals("meeting",
+        ((SearchFilter.SubstringFilter) filter).text());
+  }
+
+  @Test
+  void emptyQueryParsesToEmptyList() {
+    assertTrue(SearchFilter.parse("").isEmpty());
+    assertTrue(SearchFilter.parse("  ").isEmpty());
+    assertTrue(SearchFilter.parse(null).isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SearchFilter` sealed interface with `SubstringFilter`, `AttributeFilter`, and `RelationFilter` variants
- Add `SearchFilterMatcher` domain service for evaluating filters against notes
- Add `searchWithFilters(List<SearchFilter>)` to `SearchNotesQuery` port and implement in `NoteServiceImpl`
- Support query syntax: `color:red`, `badge:star`, `checked:true`, `has:children`, and compound queries
- All filters use AND semantics — notes must match every filter

### Supported query types
- Plain text: `meeting` — substring match on $Name/$Text
- Attribute: `color:red` — matches $Color attribute by name or hex
- Boolean: `checked:true` — matches boolean attributes
- Relation: `has:children` — matches notes that have child notes
- Compound: `color:red badge:star` — all filters must match

Closes #263

## Test plan
- [x] SearchFilterTest: parsing plain text, key:value, has:relation, compound, empty
- [x] FilteredSearchTest: color attribute, substring, compound, boolean, has:children
- [x] Full `mvn verify` passes (tests, checkstyle, JaCoCo, ArchUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)