### PR TITLE
Bump archunit-junit5 to 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
 
         <!-- Dependency versions -->
-        <archunit-junit5.version>1.4.1</archunit-junit5.version>
+        <archunit-junit5.version>1.4.2</archunit-junit5.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.16</logback.version>


### PR DESCRIPTION
Closes #292.

## Summary
- Bumps `<archunit-junit5.version>` from 1.4.1 to 1.4.2 in `pom.xml`.
- Prep work for the eventual JUnit 6 migration (#291). Stays on the 5.x-compatible ArchUnit module.
- No source code changes.

## Verification
- `./mvnw verify` passed locally (1133 tests, 0 failures; checkstyle clean; JaCoCo thresholds met).
- `./mvnw verify -Pui-tests` deferred to CI — UI tests require a display.

## Test plan
- [ ] CI full suite (including `-Pui-tests` under xvfb) passes.
- [ ] Manual merge once green — no auto-merge.