### PR TITLE
Bump JUnit Jupiter to 5.14.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
         <!-- Dependency versions -->
         <archunit-junit5.version>1.4.2</archunit-junit5.version>
-        <junit-jupiter.version>5.11.4</junit-jupiter.version>
+        <junit-jupiter.version>5.14.3</junit-jupiter.version>
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.16</logback.version>
         <javafx.version>24</javafx.version>


### PR DESCRIPTION
Closes #293.

## Summary
- Bumps `<junit-jupiter.version>` from 5.11.4 to 5.14.3 in `pom.xml`. The `junit-bom` drives the rest of the Jupiter and Platform artifact versions.
- Prep work for the eventual JUnit 6 migration (#291). Stays on the 5.x line so ArchUnit and TestFX (both still on Platform 1.x) continue to work.

## Verification
- `./mvnw verify` passed locally (1133 tests, 0 failures; checkstyle clean; JaCoCo thresholds met).
- No new deprecation warnings surfaced by the bump.
- `./mvnw verify -Pui-tests` deferred to CI — UI tests require a display.

## Test plan
- [ ] CI full suite (including `-Pui-tests` under xvfb) passes.
- [ ] Manual merge once green — no auto-merge.